### PR TITLE
Final Commit

### DIFF
--- a/httpclient/src/test/java/org/baeldung/httpclient/HttpClientMultipartTest.java
+++ b/httpclient/src/test/java/org/baeldung/httpclient/HttpClientMultipartTest.java
@@ -170,7 +170,6 @@ public class HttpClientMultipartTest {
         while ((body = rd.readLine()) != null) {
             content += body + "\n";
         }
-        rd.close();
         return content.trim();
     }
 


### PR DESCRIPTION
Removed irrelevant printing of response headers. Addet a utility method to get he Content Type of the Post, since this is the relevant issue. Testing the Content Type in the Response content is not correct, since it is this server's way to echo what is sent in the post. So testing the Content Type Header of the Post is what is needed, and I added the corresponding  assert test.
