### PR TITLE
Create example with Spring stereotype annotations

### DIFF
--- a/spring-mvc-java/pom.xml
+++ b/spring-mvc-java/pom.xml
@@ -38,6 +38,38 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- AOP -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <version>${org.springframework.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+            <version>${aspectj.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+            <version>${aspectj.version}</version>
+        </dependency>
+
+        <!-- logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${org.slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${org.slf4j.version}</version>
+        </dependency>
+
         <!-- test scoped -->
 
         <dependency>
@@ -64,6 +96,13 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${org.springframework.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -175,6 +214,8 @@
         <maven-resources-plugin.version>2.7</maven-resources-plugin.version>
         <cargo-maven2-plugin.version>1.4.15</cargo-maven2-plugin.version>
 
+        <!-- AspectJ -->
+        <aspectj.version>1.8.7</aspectj.version>
     </properties>
 
 </project>

--- a/spring-mvc-java/src/main/java/org/baeldung/aop/PerformanceAspect.java
+++ b/spring-mvc-java/src/main/java/org/baeldung/aop/PerformanceAspect.java
@@ -1,0 +1,31 @@
+package org.baeldung.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+@Aspect
+@Component
+public class PerformanceAspect {
+
+    private static Logger logger = Logger.getLogger(PerformanceAspect.class.getName());
+
+    @Pointcut("within(@org.springframework.stereotype.Repository *)")
+    public void repositoryClassMethods() {};
+
+    @Around("repositoryClassMethods()")
+    public Object measureMethodExecutionTime(ProceedingJoinPoint pjp) throws Throwable {
+        long start = System.nanoTime();
+        Object retval = pjp.proceed();
+        long end = System.nanoTime();
+        String methodName = pjp.getSignature().getName();
+        logger.info("Execution of " + methodName + " took " + TimeUnit.NANOSECONDS.toMillis(end - start) + " ms");
+        return retval;
+    }
+
+}

--- a/spring-mvc-java/src/main/java/org/baeldung/dao/FooDao.java
+++ b/spring-mvc-java/src/main/java/org/baeldung/dao/FooDao.java
@@ -1,0 +1,10 @@
+package org.baeldung.dao;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class FooDao {
+    public String findById(Long id) {
+        return "Bazz";
+    }
+}

--- a/spring-mvc-java/src/test/java/org/baeldung/aop/AopPerformanceTest.java
+++ b/spring-mvc-java/src/test/java/org/baeldung/aop/AopPerformanceTest.java
@@ -1,0 +1,69 @@
+package org.baeldung.aop;
+
+import org.baeldung.config.TestConfig;
+import org.baeldung.dao.FooDao;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {TestConfig.class}, loader = AnnotationConfigContextLoader.class)
+public class AopPerformanceTest {
+
+    @Before
+    public void setUp() {
+        logEventHandler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                messages.add(record.getMessage());
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() throws SecurityException {
+            }
+        };
+
+        messages = new ArrayList<>();
+    }
+
+    @Autowired
+    private FooDao dao;
+
+    private Handler logEventHandler;
+
+    private List<String> messages;
+
+    @Test
+    public void givenPerformanceAspect_whenCallDaoMethod_thenPerformanceMeasurementAdviceIsCalled() {
+        Logger logger = Logger.getLogger(PerformanceAspect.class.getName());
+        logger.addHandler(logEventHandler);
+
+        final String entity = dao.findById(1L);
+        assertThat(entity, notNullValue());
+        assertThat(messages, hasSize(1));
+
+        String logMessage = messages.get(0);
+        Pattern pattern = Pattern.compile("Execution of findById took \\d+ ms");
+        assertTrue(pattern.matcher(logMessage).matches());
+    }
+}

--- a/spring-mvc-java/src/test/java/org/baeldung/config/TestConfig.java
+++ b/spring-mvc-java/src/test/java/org/baeldung/config/TestConfig.java
@@ -1,0 +1,11 @@
+package org.baeldung.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Configuration
+@ComponentScan(basePackages = {"org.baeldung.dao", "org.baeldung.aop"})
+@EnableAspectJAutoProxy
+public class TestConfig {
+}

--- a/spring-mvc-java/src/test/resources/log4j.properties
+++ b/spring-mvc-java/src/test/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=WARN, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
- Use component scanning for loading bean definitions
- Use Spring stereotypes to define poincuts