### PR TITLE
fixed failing tests

### DIFF
--- a/sockets/src/test/java/com/baeldung/socket/EchoMultiTest.java
+++ b/sockets/src/test/java/com/baeldung/socket/EchoMultiTest.java
@@ -14,46 +14,44 @@ public class EchoMultiTest {
 		Executors.newSingleThreadExecutor().submit(() -> new EchoMultiServer().start(5555));
 	}
 
-	EchoClient client = new EchoClient();
 
-	@Before
-	public void init() {
+	@Test
+	public void givenClient1_whenServerResponds_thenCorrect() {
+		EchoClient client = new EchoClient();
 		client.startConnection("127.0.0.1", 5555);
-	}
-
-	@After
-	public void finish(){
+		String msg1 = client.sendMessage("hello");
+		String msg2 = client.sendMessage("world");
+		String terminate = client.sendMessage(".");
+		assertEquals(msg1, "hello");
+		assertEquals(msg2, "world");
+		assertEquals(terminate, "bye");
 		client.stopConnection();
 	}
 
 	@Test
-	public void givenClient1_whenServerResponds_thenCorrect() {
-		String msg1 = client.sendMessage("hello");
-		String msg2 = client.sendMessage("world");
-		String terminate = client.sendMessage(".");
-		assertEquals(msg1, "hello");
-		assertEquals(msg2, "world");
-		assertEquals(terminate, "bye");
-	}
-
-	@Test
 	public void givenClient2_whenServerResponds_thenCorrect() {
+		EchoClient client = new EchoClient();
+		client.startConnection("127.0.0.1", 5555);
 		String msg1 = client.sendMessage("hello");
 		String msg2 = client.sendMessage("world");
 		String terminate = client.sendMessage(".");
 		assertEquals(msg1, "hello");
 		assertEquals(msg2, "world");
 		assertEquals(terminate, "bye");
+		client.stopConnection();
 	}
 
 	@Test
 	public void givenClient3_whenServerResponds_thenCorrect() {
+		EchoClient client = new EchoClient();
+		client.startConnection("127.0.0.1", 5555);
 		String msg1 = client.sendMessage("hello");
 		String msg2 = client.sendMessage("world");
 		String terminate = client.sendMessage(".");
 		assertEquals(msg1, "hello");
 		assertEquals(msg2, "world");
 		assertEquals(terminate, "bye");
+		client.stopConnection();
 	}
 
 }

--- a/sockets/src/test/java/com/baeldung/socket/EchoTest.java
+++ b/sockets/src/test/java/com/baeldung/socket/EchoTest.java
@@ -4,19 +4,23 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import java.util.concurrent.Executors;
 
 import static org.junit.Assert.assertEquals;
 
 public class EchoTest {
-	EchoClient client = null;
+	{
+		Executors.newSingleThreadExecutor().submit(() -> new EchoServer().start(4444));
+	}
+
+	EchoClient client = new EchoClient();
 
 	@Before
-	public void setup() {
-		client = new EchoClient();
+	public void init() {
 		client.startConnection("127.0.0.1", 4444);
 	}
 
-	@Test @Ignore
+	@Test
 	public void givenClient_whenServerEchosMessage_thenCorrect() {
 
 		String resp1 = client.sendMessage("hello");

--- a/sockets/src/test/java/com/baeldung/socket/GreetServerTest.java
+++ b/sockets/src/test/java/com/baeldung/socket/GreetServerTest.java
@@ -19,11 +19,12 @@ public class GreetServerTest {
     @Before
     public void init() {
         client = new GreetClient();
+		client.startConnection("127.0.0.1", 6666);
+
     }
 
     @Test
     public void givenGreetingClient_whenServerRespondsWhenStarted_thenCorrect() {
-        client.startConnection("127.0.0.1", 6666);
         String response = client.sendMessage("hello server");
         assertEquals("hello client", response);
     }


### PR DESCRIPTION
Hey Eugen,
I think all the tests are now passing with ExecutorService, thanks for the pointers.
However, I am getting a binding exception in EchoMultiTest because am creating different clients, 1 in each test.
When I run with only one of the three tests i.e. the rest commented out, there is of course no exception.
I am not very well versed with ExecutorService, why do you think connecting to the server from different clients throws a binding exception, I was thinking that should happen when am trying to start different servers on the same port.