### PR TITLE
Spring scheduling beyond scheduled

### DIFF
--- a/spring-all/src/main/java/org/baeldung/taskscheduler/ThreadPoolTaskSchedulerConfig.java
+++ b/spring-all/src/main/java/org/baeldung/taskscheduler/ThreadPoolTaskSchedulerConfig.java
@@ -1,0 +1,41 @@
+package org.baeldung.taskscheduler;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.scheduling.support.PeriodicTrigger;
+
+@Configuration
+@ComponentScan(basePackages = "org.baeldung.taskscheduler", basePackageClasses = { ThreadPoolTaskSchedulerExamples.class })
+public class ThreadPoolTaskSchedulerConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler threadPoolTaskScheduler() {
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+        threadPoolTaskScheduler.setPoolSize(5);
+        threadPoolTaskScheduler.setThreadNamePrefix("ThreadPoolTaskScheduler");
+        return threadPoolTaskScheduler;
+    }
+
+    @Bean
+    public CronTrigger cronTrigger() {
+        return new CronTrigger("10 * * * * ?");
+    }
+
+    @Bean
+    public PeriodicTrigger periodicTrigger() {
+        return new PeriodicTrigger(2000, TimeUnit.MICROSECONDS);
+    }
+
+    @Bean
+    public PeriodicTrigger periodicFixedDelayTrigger() {
+        PeriodicTrigger periodicTrigger = new PeriodicTrigger(2000, TimeUnit.MICROSECONDS);
+        periodicTrigger.setFixedRate(true);
+        periodicTrigger.setInitialDelay(1000);
+        return periodicTrigger;
+    }
+}

--- a/spring-all/src/main/java/org/baeldung/taskscheduler/ThreadPoolTaskSchedulerExamples.java
+++ b/spring-all/src/main/java/org/baeldung/taskscheduler/ThreadPoolTaskSchedulerExamples.java
@@ -1,0 +1,47 @@
+package org.baeldung.taskscheduler;
+
+import java.util.Date;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.scheduling.support.PeriodicTrigger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ThreadPoolTaskSchedulerExamples {
+    @Autowired
+    private ThreadPoolTaskScheduler taskScheduler;
+    
+    @Autowired
+    private CronTrigger cronTrigger;
+    
+    @Autowired
+    private PeriodicTrigger periodicTrigger;
+    
+    @PostConstruct
+    public void scheduleRunnableWithCronTrigger(){
+        taskScheduler.schedule(new RunnableTask("Current Date"), new Date());
+        taskScheduler.scheduleWithFixedDelay(new RunnableTask("Fixed 1 second Delay"), 1000);
+        taskScheduler.scheduleWithFixedDelay(new RunnableTask("Current Date Fixed 1 second Delay"),new Date() , 1000);
+        taskScheduler.scheduleAtFixedRate(new RunnableTask("Fixed Rate of 2 seconds"),new Date(), 2000);
+        taskScheduler.scheduleAtFixedRate(new RunnableTask("Fixed Rate of 2 seconds"), 2000);
+        taskScheduler.schedule(new RunnableTask("Cron Trigger"), cronTrigger);
+        taskScheduler.schedule(new RunnableTask("Periodic Trigger"), periodicTrigger);
+    }
+    
+    class RunnableTask implements Runnable{
+
+        private String message;
+        
+        public RunnableTask(String message){
+            this.message = message;
+        }
+        @Override
+        public void run() {
+            System.out.println("Runnable Task with "+message+" on thread "+Thread.currentThread().getName());
+        }
+    }
+}

--- a/spring-all/src/test/java/org/baeldung/taskscheduler/ThreadPoolTaskSchedulerTest.java
+++ b/spring-all/src/test/java/org/baeldung/taskscheduler/ThreadPoolTaskSchedulerTest.java
@@ -1,0 +1,16 @@
+package org.baeldung.taskscheduler;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { ThreadPoolTaskSchedulerConfig.class }, loader = AnnotationConfigContextLoader.class)
+public class ThreadPoolTaskSchedulerTest {
+    @Test
+    public void testThreadPoolTaskSchedulerAnnotation() throws InterruptedException {
+        Thread.sleep(2550);
+    }
+}


### PR DESCRIPTION
Introduction to spring scheduling using annotations.
One configuration class only annotation based for all needed beans.
One component ThreadPoolTaskSchedulerExamples to try and schedule all ThreadPoolTaskScheduler provided scheduling.
One Test class for running the component for some time