### PR TITLE
#BAEL-100 tests and update spring boot to 1.5.1.RELEASE

### DIFF
--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -199,9 +199,9 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <!--<systemPropertyVariables>-->
-                            <!--<test.mime>json</test.mime>-->
-                            <!--</systemPropertyVariables>-->
+                            <systemPropertyVariables>
+                            <test.mime>json</test.mime>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.baeldung</groupId>
     <artifactId>spring-boot</artifactId>
@@ -12,8 +12,8 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.4.2.RELEASE</version>
-        <relativePath /> <!-- lookup parent from repository -->
+        <version>1.5.1.RELEASE</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <dependencies>
@@ -24,6 +24,26 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-osgi-locator</artifactId>
+            <version>1.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.geronimo.components</groupId>
+            <artifactId>geronimo-jaspi</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -86,6 +106,20 @@
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
             <version>${jquery.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomee</groupId>
+            <artifactId>arquillian-tomee-embedded</artifactId>
+            <version>${arquillian-tomee-embedded.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomee</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>${tomee-javaee-api.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -165,9 +199,9 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <systemPropertyVariables>
-                                <test.mime>json</test.mime>
-                            </systemPropertyVariables>
+                            <!--<systemPropertyVariables>-->
+                            <!--<test.mime>json</test.mime>-->
+                            <!--</systemPropertyVariables>-->
                         </configuration>
                     </plugin>
                 </plugins>
@@ -186,6 +220,8 @@
         <jquery.version>3.1.1</jquery.version>
         <bootstrap.version>3.3.7-1</bootstrap.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
+        <arquillian-tomee-embedded.version>7.0.2</arquillian-tomee-embedded.version>
+        <tomee-javaee-api.version>7.0-1</tomee-javaee-api.version>
     </properties>
 
 </project>

--- a/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/JavaEEApp.java
+++ b/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/JavaEEApp.java
@@ -1,0 +1,28 @@
+package com.baeldung.annotation.servletcomponentscan;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+import javax.servlet.ServletContext;
+
+@ApplicationScoped
+public class JavaEEApp {
+
+    private ServletContext context;
+
+    /**
+     * act as a servletContext provider
+     */
+    private void setContext(@Observes @Initialized(ApplicationScoped.class) final ServletContext context) {
+        if (this.context != null) {
+            throw new IllegalStateException("app context started twice");
+        }
+
+        this.context = context;
+    }
+
+    public ServletContext getContext() {
+        return context;
+    }
+
+}

--- a/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/SpringBootAnnotatedApp.java
+++ b/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/SpringBootAnnotatedApp.java
@@ -1,0 +1,25 @@
+package com.baeldung.annotation.servletcomponentscan;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
+
+/**
+ * using the following annotations are equivalent:
+ * <ul><li>
+ * <code>@ServletComponentScan</code>
+ * </li><li>
+ * <code>@ServletComponentScan(basePackages = "com.baeldung.annotation.servletcomponentscan.javaee")</code>
+ * </li><li>
+ * <code>@ServletComponentScan(basePackageClasses = {AttrListener.class, HelloFilter.class, HelloServlet.class, EchoServlet.class})</code>
+ * </li></ul>
+ */
+@SpringBootApplication
+@ServletComponentScan("com.baeldung.annotation.servletcomponentscan.javaee")
+public class SpringBootAnnotatedApp {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SpringBootAnnotatedApp.class, args);
+    }
+
+}

--- a/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/SpringBootPlainApp.java
+++ b/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/SpringBootPlainApp.java
@@ -1,0 +1,13 @@
+package com.baeldung.annotation.servletcomponentscan;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = "com.baeldung.annotation.servletcomponentscan.javaee")
+public class SpringBootPlainApp {
+
+    public static void main(String[] args) {
+    }
+
+}

--- a/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/javaee/AttrListener.java
+++ b/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/javaee/AttrListener.java
@@ -1,0 +1,23 @@
+package com.baeldung.annotation.servletcomponentscan.javaee;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+@WebListener
+public class AttrListener implements ServletContextListener {
+
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent) {
+        servletContextEvent
+          .getServletContext()
+          .setAttribute("servlet-context-attr", "test");
+        System.out.println("context init");
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent) {
+        System.out.println("context destroy");
+    }
+
+}

--- a/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/javaee/EchoServlet.java
+++ b/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/javaee/EchoServlet.java
@@ -1,0 +1,30 @@
+package com.baeldung.annotation.servletcomponentscan.javaee;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.CopyOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+@WebServlet(name = "echo servlet", urlPatterns = "/echo")
+public class EchoServlet extends HttpServlet {
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) {
+        try {
+            Path path = File
+              .createTempFile("echo", "tmp")
+              .toPath();
+            Files.copy(request.getInputStream(), path, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(path, response.getOutputStream());
+            Files.delete(path);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/javaee/HelloFilter.java
+++ b/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/javaee/HelloFilter.java
@@ -1,0 +1,32 @@
+package com.baeldung.annotation.servletcomponentscan.javaee;
+
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.annotation.WebInitParam;
+import java.io.IOException;
+
+@WebFilter(urlPatterns = "/hello", description = "a filter for hello servlet", initParams = { @WebInitParam(name = "msg", value = "filtering ") }, filterName = "hello filter", servletNames = { "echo servlet" })
+public class HelloFilter implements Filter {
+
+    private FilterConfig filterConfig;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        System.out.println("filter init");
+        this.filterConfig = filterConfig;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        servletResponse
+          .getOutputStream()
+          .print(filterConfig.getInitParameter("msg"));
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    @Override
+    public void destroy() {
+        System.out.println("filter destroy");
+    }
+
+}

--- a/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/javaee/HelloServlet.java
+++ b/spring-boot/src/main/java/com/baeldung/annotation/servletcomponentscan/javaee/HelloServlet.java
@@ -1,0 +1,33 @@
+package com.baeldung.annotation.servletcomponentscan.javaee;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebInitParam;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet(urlPatterns = "/hello", initParams = { @WebInitParam(name = "msg", value = "hello")})
+public class HelloServlet extends HttpServlet {
+
+    private ServletConfig servletConfig;
+
+    @Override
+    public void init(ServletConfig servletConfig){
+        this.servletConfig = servletConfig;
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) {
+        try {
+            response
+              .getOutputStream()
+              .write(servletConfig.getInitParameter("msg").getBytes());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/spring-boot/src/main/java/com/baeldung/webjar/TestController.java
+++ b/spring-boot/src/main/java/com/baeldung/webjar/TestController.java
@@ -1,4 +1,4 @@
-package com.baeldung;
+package com.baeldung.webjar;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;

--- a/spring-boot/src/main/java/com/baeldung/webjar/WebjarsdemoApplication.java
+++ b/spring-boot/src/main/java/com/baeldung/webjar/WebjarsdemoApplication.java
@@ -1,7 +1,8 @@
-package com.baeldung;
+package com.baeldung.webjar;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 public class WebjarsdemoApplication {

--- a/spring-boot/src/main/java/org/baeldung/common/error/SpringHelloServletRegistrationBean.java
+++ b/spring-boot/src/main/java/org/baeldung/common/error/SpringHelloServletRegistrationBean.java
@@ -1,8 +1,8 @@
 package org.baeldung.common.error;
 
-import javax.servlet.Servlet;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
 
-import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import javax.servlet.Servlet;
 
 public class SpringHelloServletRegistrationBean extends ServletRegistrationBean {
 

--- a/spring-boot/src/main/java/org/baeldung/common/properties/MyServletContainerCustomizationBean.java
+++ b/spring-boot/src/main/java/org/baeldung/common/properties/MyServletContainerCustomizationBean.java
@@ -2,7 +2,7 @@ package org.baeldung.common.properties;
 
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
-import org.springframework.boot.context.embedded.ErrorPage;
+import org.springframework.boot.web.servlet.ErrorPage;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 

--- a/spring-boot/src/test/java/com/baeldung/annotation/servletcomponentscan/JavaEEAppTest.java
+++ b/spring-boot/src/test/java/com/baeldung/annotation/servletcomponentscan/JavaEEAppTest.java
@@ -1,0 +1,88 @@
+package com.baeldung.annotation.servletcomponentscan;
+
+import com.baeldung.annotation.servletcomponentscan.javaee.AttrListener;
+import com.baeldung.annotation.servletcomponentscan.javaee.EchoServlet;
+import com.baeldung.annotation.servletcomponentscan.javaee.HelloFilter;
+import com.baeldung.annotation.servletcomponentscan.javaee.HelloServlet;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.servlet.FilterRegistration;
+import javax.servlet.ServletContext;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+import static org.junit.Assert.*;
+
+@RunWith(Arquillian.class)
+public class JavaEEAppTest {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap
+          .create(WebArchive.class)
+          .addClass(JavaEEApp.class)
+          .addClasses(AttrListener.class, HelloFilter.class, HelloServlet.class, EchoServlet.class);
+    }
+
+    @Inject private ServletContext servletContext;
+
+    @Test
+    public void givenServletContextListener_whenAccessSpecialAttrs_thenFound() throws MalformedURLException {
+        assertNotNull(servletContext);
+        assertNotNull(servletContext.getAttribute("servlet-context-attr"));
+        assertEquals("test", servletContext.getAttribute("servlet-context-attr"));
+    }
+
+    @Test
+    public void givenServletContext_whenCheckHelloFilterMappings_thenCorrect() throws MalformedURLException {
+        assertNotNull(servletContext);
+        FilterRegistration filterRegistration = servletContext.getFilterRegistration("hello filter");
+
+        assertNotNull(filterRegistration);
+        assertTrue(filterRegistration
+          .getServletNameMappings()
+          .contains("echo servlet"));
+    }
+
+    @ArquillianResource private URL base;
+
+    @Test
+    @RunAsClient
+    public void givenFilterAndServlet_whenGetHello_thenRespondFilteringHello() throws MalformedURLException {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(URI.create(new URL(base, "hello").toExternalForm()));
+        Response response = target
+          .request()
+          .get();
+
+        assertEquals("filtering hello", response.readEntity(String.class));
+    }
+
+    @Test
+    @RunAsClient
+    public void givenFilterAndServlet_whenPostEcho_thenEchoFiltered() throws MalformedURLException {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(URI.create(new URL(base, "echo").toExternalForm()));
+        Response response = target
+          .request()
+          .post(Entity.entity("echo", MediaType.TEXT_PLAIN_TYPE));
+
+        assertEquals("filtering echo", response.readEntity(String.class));
+    }
+
+}

--- a/spring-boot/src/test/java/com/baeldung/annotation/servletcomponentscan/SpringBootWithServletComponentTest.java
+++ b/spring-boot/src/test/java/com/baeldung/annotation/servletcomponentscan/SpringBootWithServletComponentTest.java
@@ -1,0 +1,65 @@
+package com.baeldung.annotation.servletcomponentscan;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.servlet.FilterRegistration;
+import javax.servlet.ServletContext;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SpringBootAnnotatedApp.class)
+@AutoConfigureMockMvc
+@TestPropertySource(properties = { "security.basic.enabled=false", "server.tomcat.additional-tld-skip-patterns=tomee-*.jar,tomcat-*.jar,openejb-*.jar,cxf-*.jar,activemq-*.jar" })
+public class SpringBootWithServletComponentTest {
+
+    @Autowired private ServletContext servletContext;
+
+    @Test
+    public void givenServletContext_whenAccessAttrs_thenFoundAttrsPutInServletListner() {
+        assertNotNull(servletContext);
+        assertNotNull(servletContext.getAttribute("servlet-context-attr"));
+        assertEquals("test", servletContext.getAttribute("servlet-context-attr"));
+    }
+
+    @Test
+    public void givenServletContext_whenCheckHelloFilterMappings_thenCorrect() {
+        assertNotNull(servletContext);
+        FilterRegistration filterRegistration = servletContext.getFilterRegistration("hello filter");
+
+        assertNotNull(filterRegistration);
+        assertTrue(filterRegistration
+          .getServletNameMappings()
+          .contains("echo servlet"));
+    }
+
+    @Autowired private TestRestTemplate restTemplate;
+
+    @Test
+    public void givenServletFilter_whenGetHello_thenRequestFiltered() {
+        ResponseEntity<String> responseEntity = this.restTemplate.getForEntity("/hello", String.class);
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals("filtering hello", responseEntity.getBody());
+    }
+
+    @Test
+    public void givenFilterAndServlet_whenPostEcho_thenEchoFiltered() {
+        ResponseEntity<String> responseEntity = this.restTemplate.postForEntity("/echo", "echo", String.class);
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals("filtering echo", responseEntity.getBody());
+    }
+
+
+
+}
+
+

--- a/spring-boot/src/test/java/com/baeldung/annotation/servletcomponentscan/SpringBootWithoutServletComponentTest.java
+++ b/spring-boot/src/test/java/com/baeldung/annotation/servletcomponentscan/SpringBootWithoutServletComponentTest.java
@@ -1,0 +1,50 @@
+package com.baeldung.annotation.servletcomponentscan;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.servlet.FilterRegistration;
+import javax.servlet.ServletContext;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SpringBootPlainApp.class)
+@AutoConfigureMockMvc
+@TestPropertySource(properties = { "security.basic.enabled=false", "server.tomcat.additional-tld-skip-patterns=tomee-*.jar,tomcat-*.jar,openejb-*.jar,cxf-*.jar,activemq-*.jar" })
+public class SpringBootWithoutServletComponentTest {
+
+    @Autowired private ServletContext servletContext;
+
+    @Autowired private TestRestTemplate restTemplate;
+
+    @Test
+    public void givenServletContext_whenAccessAttrs_thenNotFound() {
+        assertNull(servletContext.getAttribute("servlet-context-attr"));
+    }
+
+    @Test
+    public void givenServletFilter_whenGetHello_thenEndpointNotFound() {
+        ResponseEntity<String> responseEntity = this.restTemplate.getForEntity("/hello", String.class);
+        assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
+    }
+
+    @Test
+    public void givenServletContext_whenCheckFilterMappings_thenEmpty() {
+        assertNotNull(servletContext);
+        FilterRegistration filterRegistration = servletContext.getFilterRegistration("hello filter");
+
+        assertNull(filterRegistration);
+    }
+
+}
+
+

--- a/spring-boot/src/test/java/com/baeldung/intro/AppLiveTest.java
+++ b/spring-boot/src/test/java/com/baeldung/intro/AppLiveTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -17,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@TestPropertySource(properties = { "security.basic.enabled=false" })
 public class AppLiveTest {
 
     @Autowired

--- a/spring-boot/src/test/java/com/baeldung/webjar/WebjarsdemoApplicationIntegrationTest.java
+++ b/spring-boot/src/test/java/com/baeldung/webjar/WebjarsdemoApplicationIntegrationTest.java
@@ -1,13 +1,13 @@
-package com.baeldung;
+package com.baeldung.webjar;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = WebjarsdemoApplication.class)
+@SpringBootTest(classes = WebjarsdemoApplication.class)
 @WebAppConfiguration
 public class WebjarsdemoApplicationIntegrationTest {
 

--- a/spring-boot/src/test/java/org/baeldung/SpringBootApplicationIntegrationTest.java
+++ b/spring-boot/src/test/java/org/baeldung/SpringBootApplicationIntegrationTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -22,7 +22,7 @@ import org.springframework.web.context.WebApplicationContext;
 import java.nio.charset.Charset;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = Application.class)
+@SpringBootTest(classes = Application.class)
 @WebAppConfiguration
 public class SpringBootApplicationIntegrationTest {
     @Autowired

--- a/spring-boot/src/test/java/org/baeldung/SpringBootJPAIntegrationTest.java
+++ b/spring-boot/src/test/java/org/baeldung/SpringBootJPAIntegrationTest.java
@@ -5,14 +5,14 @@ import org.baeldung.repository.GenericEntityRepository;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = Application.class)
+@SpringBootTest(classes = Application.class)
 public class SpringBootJPAIntegrationTest {
     @Autowired
     private GenericEntityRepository genericEntityRepository;

--- a/spring-boot/src/test/java/org/baeldung/SpringBootMailIntegrationTest.java
+++ b/spring-boot/src/test/java/org/baeldung/SpringBootMailIntegrationTest.java
@@ -5,7 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = Application.class)
+@SpringBootTest(classes = Application.class)
 public class SpringBootMailIntegrationTest {
     @Autowired
     private JavaMailSender javaMailSender;


### PR DESCRIPTION
1. add tests for #BAEL-100
2. update spring-boot version to 1.5.1.RELEASE (previously 1.4.2.RELEASE)

Major changes in the existing code:

- moved WebjarsdemoApplication and TestController to webjars package for a more clear package structure
- due to spring-boot version changes, the following import changes are made:

    - according to [spring-boot-6524](https://github.com/spring-projects/spring-boot/issues/6524)

    ```diff
    - import org.springframework.boot.context.embedded.ServletRegistrationBean;
    + import org.springframework.boot.web.servlet.ServletRegistrationBean;
    ```
    - according to [spring-boot-6764](https://github.com/spring-projects/spring-boot/issues/6764)
    ```diff
    - import org.springframework.boot.context.embedded.ErrorPage;
    + import org.springframework.boot.web.servlet.ErrorPage;
    ```
    - according to [spring-boot api doc of 1.4.2.RELEASE: SpringApplicationConfiguration](http://docs.spring.io/spring-boot/docs/1.4.2.RELEASE/api/org/springframework/boot/test/SpringApplicationConfiguration.html)
    ```diff
    - import org.springframework.boot.test.SpringApplicationConfiguration;
    + import org.springframework.boot.test.context.SpringBootTest;
    ```
    - since we included spring-boot-security in maven dependencies, the servlets are automatically protected and needs authentication, which breaks the AppLiveTest, so the following change is made to fix this:
    ```diff
    +@TestPropertySource(properties = { "security.basic.enabled=false" })
    ```