### PR TITLE
refactor: Use 'of' instead of Stream 'builder'

### DIFF
--- a/mockito2/src/test/java/com/baeldung/mockito/java8/CustomAnswerWithLambdaUnitTest.java
+++ b/mockito2/src/test/java/com/baeldung/mockito/java8/CustomAnswerWithLambdaUnitTest.java
@@ -39,7 +39,7 @@ public class CustomAnswerWithLambdaUnitTest {
         MockitoAnnotations.initMocks(this);
 
         when(jobService.listJobs(any(Person.class))).then((i) -> {
-            return ((Person) i.getArgument(0)).getName().equals("Peter") ? Stream.<JobPosition> builder().add(new JobPosition("Teacher")).build() : Stream.empty();
+            return ((Person) i.getArgument(0)).getName().equals("Peter") ? Stream.of(new JobPosition("Teacher")) : Stream.empty();
         });
     }
 }


### PR DESCRIPTION
Simplify the construction of a Stream by using the 'of()' method instead
of a 'builder'

Resolves: BAEL-632