### PR TITLE
Add unit test for File path article - BAEL-827

### DIFF
--- a/core-java/src/test/java/org/baeldung/java/io/JavaFilePathUnitTest.java
+++ b/core-java/src/test/java/org/baeldung/java/io/JavaFilePathUnitTest.java
@@ -1,0 +1,97 @@
+package org.baeldung.java.io;
+
+import static org.junit.Assert.*;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+public class JavaFilePathUnitTest {
+
+    private static String userDir;
+
+    @BeforeClass
+    public static void createFilesAndFolders() throws IOException {
+        userDir = System.getProperty("user.dir");
+
+        new File(userDir + "/baeldung/foo").mkdirs();
+        new File(userDir + "/baeldung/bar/baz").mkdirs();
+        new File(userDir + "/baeldung/foo/foo-one.txt").createNewFile();
+        new File(userDir + "/baeldung/foo/foo-two.txt").createNewFile();
+        new File(userDir + "/baeldung/bar/bar-one.txt").createNewFile();
+        new File(userDir + "/baeldung/bar/bar-two.txt").createNewFile();
+        new File(userDir + "/baeldung/bar/baz/baz-one.txt").createNewFile();
+        new File(userDir + "/baeldung/bar/baz/baz-two.txt").createNewFile();
+
+    }
+
+    @Test
+    public void whenPathResolved_thenSuccess() {
+        File file = new File("baeldung/foo/foo-one.txt");
+        String expectedPath = isWindows() ? "baeldung\\foo\\foo-one.txt" : "baeldung/foo/foo-one.txt";
+        String actualPath = file.getPath();
+        assertEquals(expectedPath, actualPath);
+    }
+
+    @Test
+    public void whenAbsolutePathResolved_thenSuccess() {
+        File file = new File("baeldung/foo/foo-one.txt");
+        String expectedPath = isWindows() ? userDir + "\\baeldung\\foo\\foo-one.txt" : userDir + "/baeldung/foo/foo-one.txt";
+        String actualPath = file.getAbsolutePath();
+        assertEquals(expectedPath, actualPath);
+    }
+
+    @Test
+    public void whenAbsolutePathWithShorthandResolved_thenSuccess() {
+        File file = new File("baeldung/bar/baz/../bar-one.txt");
+        String expectedPath = isWindows() ? userDir + "\\baeldung\\bar\\baz\\..\\bar-one.txt" : userDir + "/baeldung/bar/baz/../bar-one.txt";
+        String actualPath = file.getAbsolutePath();
+        assertEquals(expectedPath, actualPath);
+    }
+
+    @Test
+    public void whenCanonicalPathWithShorthandResolved_thenSuccess() throws IOException {
+        File file = new File("baeldung/bar/baz/../bar-one.txt");
+        String expectedPath = isWindows() ? userDir + "\\baeldung\\bar\\bar-one.txt" : userDir + "/baeldung/bar/bar-one.txt";
+        String actualPath = file.getCanonicalPath();
+        assertEquals(expectedPath, actualPath);
+    }
+
+    @Test
+    public void whenCanonicalPathWithDotShorthandResolved_thenSuccess() throws IOException {
+        File file = new File("baeldung/bar/baz/./baz-one.txt");
+        String expectedPath = isWindows() ? userDir + "\\baeldung\\bar\\baz\\baz-one.txt" : userDir + "/baeldung/bar/baz/baz-one.txt";
+        String actualPath = file.getCanonicalPath();
+        assertEquals(expectedPath, actualPath);
+    }
+
+    @Test(expected = IOException.class)
+    public void whenIOException_thenSuccess() throws IOException {
+        new File("*").getCanonicalPath();
+    }
+
+    @AfterClass
+    public static void deleteFilesAndFolders() {
+        File baeldungDir = new File(userDir + "/baeldung");
+        deleteRecursively(baeldungDir);
+    }
+
+    private static void deleteRecursively(File dir) {
+        for (File f : dir.listFiles()) {
+            if (f.isDirectory()) {
+                deleteRecursively(f);
+            }
+            f.delete();
+        }
+        dir.delete();
+    }
+
+    private static boolean isWindows() {
+        String osName = System.getProperty("os.name");
+        return osName.contains("Windows");
+    }
+
+}

--- a/core-java/src/test/java/org/baeldung/java/io/JavaFilePathUnitTest.java
+++ b/core-java/src/test/java/org/baeldung/java/io/JavaFilePathUnitTest.java
@@ -70,7 +70,7 @@ public class JavaFilePathUnitTest {
     }
 
     @Test(expected = IOException.class)
-    public void givenWindowsOs_whenIOException_thenSuccess() throws IOException {
+    public void givenWindowsOs_whenCanonicalPathWithWildcard_thenIOException() throws IOException {
         Assume.assumeTrue(isWindows());
         new File("*").getCanonicalPath();
     }

--- a/core-java/src/test/java/org/baeldung/java/io/JavaFilePathUnitTest.java
+++ b/core-java/src/test/java/org/baeldung/java/io/JavaFilePathUnitTest.java
@@ -3,6 +3,7 @@ package org.baeldung.java.io;
 import static org.junit.Assert.*;
 
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -69,7 +70,8 @@ public class JavaFilePathUnitTest {
     }
 
     @Test(expected = IOException.class)
-    public void whenIOException_thenSuccess() throws IOException {
+    public void givenWindowsOs_whenIOException_thenSuccess() throws IOException {
+        Assume.assumeTrue(isWindows());
         new File("*").getCanonicalPath();
     }
 


### PR DESCRIPTION
Add a unit test class to demonstrate the results of the three different methods to get filesystem path.