### PR TITLE
added karate for rest-api & json / xml testing

### DIFF
--- a/karate/README.md
+++ b/karate/README.md
@@ -1,0 +1,8 @@
+# Karate
+Project Home Page: [https://github.com/intuit/karate](https://github.com/intuit/karate)
+
+Comparison with REST-assured: [http://tinyurl.com/karatera](http://tinyurl.com/karatera)
+
+Into By Joe Colantonio: [Karate - a REST test tool](https://www.joecolantonio.com/2017/03/23/rest-test-tool-karate-api-testing/)
+
+Slide Deck: [Karate for Complex Web-Service API Testing](https://www.slideshare.net/intuit_india/karate-for-complex-webservice-api-testing-by-peter-thomas)

--- a/karate/pom.xml
+++ b/karate/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.baeldung</groupId>
+    <artifactId>karate</artifactId>
+    <version>1.0</version>
+    <name>karate</name>            
+
+    <dependencies>
+		<dependency>
+			<groupId>com.intuit.karate</groupId>
+			<artifactId>karate-apache</artifactId>
+			<version>${karate.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.intuit.karate</groupId>
+			<artifactId>karate-junit4</artifactId>
+			<version>${karate.version}</version>
+			<scope>test</scope>
+		</dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>        
+    </dependencies>
+    
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/java</directory>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>                       
+        </plugins>        
+    </build>
+    
+    <properties>        
+        <karate.version>0.4.1.1</karate.version>
+        <wiremock.version>2.4.1</wiremock.version>
+    </properties>    
+
+</project>

--- a/karate/src/test/java/employees.xml
+++ b/karate/src/test/java/employees.xml
@@ -1,0 +1,7 @@
+<employees>
+	<employee category="skilled">
+		<first-name>Jane</first-name>
+		<last-name>Daisy</last-name>
+		<sex>f</sex>
+	</employee>
+</employees>

--- a/karate/src/test/java/event_0.json
+++ b/karate/src/test/java/event_0.json
@@ -1,0 +1,43 @@
+{
+	"id": "390",
+		"odd":	{
+			"price": "1.20",
+			"status": 2,
+			"ck": 12.2,
+			"name": "2"
+		},
+	"data": {
+		"countryId": 35,
+		"countryName": "Norway",
+		"leagueName": "Norway 3",
+		"status": 0,
+		"sportName": "Soccer",
+		"time": "2016-06-12T12:00:00Z"
+	},
+		"odds": [{
+			"price": "1.30",
+			"status": 0,
+			"ck": 12.2,
+			"name": "1"
+		},
+		{
+			"price":"5.25",
+			"status": 1,
+			"ck": 13.1,
+			"name": "X"
+		},
+		{
+			"price": "2.70",
+			"status": 0,
+			"ck": 12.2,
+			"name": "0"
+		},
+		{
+			"price": "1.20",
+			"status": 2,
+			"ck": 13.1,
+			"name": "2"
+		}
+		
+		]
+}

--- a/karate/src/test/java/karate-config.js
+++ b/karate/src/test/java/karate-config.js
@@ -1,0 +1,3 @@
+function() {
+  return { wiremockPort: karate.properties['wiremock.port'] };
+}

--- a/karate/src/test/java/karate/Integration2Test.java
+++ b/karate/src/test/java/karate/Integration2Test.java
@@ -1,0 +1,38 @@
+package karate;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.intuit.karate.junit4.Karate;
+import cucumber.api.CucumberOptions;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+@RunWith(Karate.class)
+@CucumberOptions(features = "classpath:karate/integration2-test.feature")
+public class Integration2Test {
+    
+    @ClassRule
+    public static WireMockClassRule WIREMOCK_RULE = new WireMockClassRule(wireMockConfig().dynamicPort());
+
+    @Rule
+    public WireMockClassRule instanceRule = WIREMOCK_RULE;
+    
+	private static final String URL = "/odds";
+	private static final String RESPONSE = Util.read("odds.json");
+
+    @BeforeClass
+    public static void before() {
+        System.setProperty("wiremock.port", WIREMOCK_RULE.port() + "");
+		stubFor(get(urlEqualTo(URL)).willReturn(
+				aResponse().withStatus(200)
+						.withHeader("Content-Type", "application/json")
+						.withBody(RESPONSE)));        
+    }
+    
+}

--- a/karate/src/test/java/karate/IntegrationTest.java
+++ b/karate/src/test/java/karate/IntegrationTest.java
@@ -1,0 +1,38 @@
+package karate;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.intuit.karate.junit4.Karate;
+import cucumber.api.CucumberOptions;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+@RunWith(Karate.class)
+@CucumberOptions(features = "classpath:karate/integration-test.feature")
+public class IntegrationTest {
+    
+    @ClassRule
+    public static WireMockClassRule WIREMOCK_RULE = new WireMockClassRule(wireMockConfig().dynamicPort());
+
+    @Rule
+    public WireMockClassRule instanceRule = WIREMOCK_RULE;
+    
+	private static final String URL = "/events?id=390";
+	private static final String RESPONSE = Util.read("event_0.json");
+
+    @BeforeClass
+    public static void before() {
+        System.setProperty("wiremock.port", WIREMOCK_RULE.port() + "");
+		stubFor(get(urlEqualTo(URL)).willReturn(
+				aResponse().withStatus(200)
+						.withHeader("Content-Type", "application/json")
+						.withBody(RESPONSE)));        
+    }
+    
+}

--- a/karate/src/test/java/karate/Util.java
+++ b/karate/src/test/java/karate/Util.java
@@ -1,0 +1,17 @@
+package karate;
+
+import java.io.InputStream;
+import org.apache.commons.io.IOUtils;
+
+public class Util {
+
+    public static String read(String name) {
+        try {
+            InputStream is = Util.class.getClassLoader().getResourceAsStream(name);
+            return IOUtils.toString(is, "utf-8");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/karate/src/test/java/karate/Xml2IntegrationTest.java
+++ b/karate/src/test/java/karate/Xml2IntegrationTest.java
@@ -1,0 +1,38 @@
+package karate;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.intuit.karate.junit4.Karate;
+import cucumber.api.CucumberOptions;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+@RunWith(Karate.class)
+@CucumberOptions(features = "classpath:karate/xml2-integration-test.feature")
+public class Xml2IntegrationTest {
+    
+    @ClassRule
+    public static WireMockClassRule WIREMOCK_RULE = new WireMockClassRule(wireMockConfig().dynamicPort());
+
+    @Rule
+    public WireMockClassRule instanceRule = WIREMOCK_RULE;
+    
+	private static final String URL = "/teachers";
+	private static final String RESPONSE = Util.read("teachers.xml");
+
+    @BeforeClass
+    public static void before() {
+        System.setProperty("wiremock.port", WIREMOCK_RULE.port() + "");
+		stubFor(get(urlEqualTo(URL)).willReturn(
+				aResponse().withStatus(200)
+						.withHeader("Content-Type", "application/xml")
+						.withBody(RESPONSE)));        
+    }
+    
+}

--- a/karate/src/test/java/karate/XmlIntegrationTest.java
+++ b/karate/src/test/java/karate/XmlIntegrationTest.java
@@ -1,0 +1,38 @@
+package karate;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.intuit.karate.junit4.Karate;
+import cucumber.api.CucumberOptions;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+@RunWith(Karate.class)
+@CucumberOptions(features = "classpath:karate/xml-integration-test.feature")
+public class XmlIntegrationTest {
+    
+    @ClassRule
+    public static WireMockClassRule WIREMOCK_RULE = new WireMockClassRule(wireMockConfig().dynamicPort());
+
+    @Rule
+    public WireMockClassRule instanceRule = WIREMOCK_RULE;
+    
+	private static final String URL = "/employees";
+	private static final String RESPONSE = Util.read("employees.xml");
+
+    @BeforeClass
+    public static void before() {
+        System.setProperty("wiremock.port", WIREMOCK_RULE.port() + "");
+		stubFor(post(urlEqualTo(URL)).willReturn(
+				aResponse().withStatus(200)
+						.withHeader("Content-Type", "application/xml")
+						.withBody(RESPONSE)));        
+    }
+    
+}

--- a/karate/src/test/java/karate/integration-test.feature
+++ b/karate/src/test/java/karate/integration-test.feature
@@ -1,0 +1,41 @@
+Feature: integration test
+
+Background: 
+  Given url 'http://localhost:' + wiremockPort
+  And path 'events'
+  And param id = 390
+  When method get
+
+Scenario: check for numeric value  
+  Then match response.odd.ck == 12.2
+
+Scenario: get success and check for value
+  Then status 200
+  And match response.id == 390
+
+Scenario: check array contents
+  Then match response.odds[*].price contains ['1.30', '5.25', '2.70', '1.20']
+
+Scenario: get and validate entire response
+  Then match response == read('classpath:event_0.json')
+
+Scenario: validate response structure
+  * def oddSchema = { price: '#string', status: '#? _ < 3', ck: '#number', name: '#regex[0-9X]' }
+  * def isValidTime = read('time-validator.js')
+  Then match response ==
+    """
+    { 
+      id: '#regex[0-9]+',
+      odd: '#(oddSchema)',
+      data: { 
+        countryId: '#number', 
+        countryName: '#string', 
+        leagueName: '#string', 
+        status: '#number', 
+        sportName: '#string',
+        time: '#? isValidTime(_)'
+      },
+      odds: '#array'  
+     }
+    """
+  And match each response.odds == oddSchema

--- a/karate/src/test/java/karate/integration2-test.feature
+++ b/karate/src/test/java/karate/integration2-test.feature
@@ -1,0 +1,10 @@
+Feature: integration test 2
+
+Scenario: get and check price for items having status greater thn zero
+  Given url 'http://localhost:' + wiremockPort
+  And path 'odds'
+  When method get
+  Then def temp = get response $.odds[?(@.status > 0)].price
+  And match temp == [5.25, 1.2]
+
+

--- a/karate/src/test/java/karate/time-validator.js
+++ b/karate/src/test/java/karate/time-validator.js
@@ -1,0 +1,11 @@
+function(s) {
+  var SimpleDateFormat = Java.type("java.text.SimpleDateFormat");
+  var sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+  try {
+    sdf.parse(s).time;
+    return true;
+  } catch(e) {
+    karate.log('*** invalid date string:', s);
+    return false;
+  }
+} 

--- a/karate/src/test/java/karate/xml-integration-test.feature
+++ b/karate/src/test/java/karate/xml-integration-test.feature
@@ -1,0 +1,31 @@
+Feature: xml integration test
+
+Background: 
+  Given url 'http://localhost:' + wiremockPort
+  And path 'employees'
+  And request ''
+  When method post  
+
+Scenario: check for single value via xpath
+  Then match /employees/employee/first-name == 'Jane'
+  
+Scenario: check for multiple values via xpath
+  Then match /employees/employee/first-name == 'Jane'
+  And match /employees/employee/last-name == 'Daisy'
+  And match /employees/employee/sex == 'f'
+
+Scenario: check for nested xml
+  Then match /employees/employee ==
+  """
+  <employee category="skilled">
+    <first-name>Jane</first-name>
+    <last-name>Daisy</last-name>
+    <sex>f</sex>
+  </employee>  
+  """
+
+Scenario: check that value contains
+  Then match /employees/employee/first-name contains 'Ja'
+
+Scenario: check using xpath function
+  Then match /employees/employee/first-name[text()='Jane'] == '#notnull'

--- a/karate/src/test/java/karate/xml2-integration-test.feature
+++ b/karate/src/test/java/karate/xml2-integration-test.feature
@@ -1,0 +1,7 @@
+Feature: xml integration test
+
+Scenario: check subjects for science teacher via xpath
+  Given url 'http://localhost:' + wiremockPort
+  And path 'teachers'
+  When method get
+  And match //teacher[@department='science']/subject contains ['math', 'physics']

--- a/karate/src/test/java/logback-test.xml
+++ b/karate/src/test/java/logback-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+ 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+  
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/karate.log</file>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>    
+   
+    <logger name="com.intuit" level="DEBUG"/>
+   
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+    </root>
+  
+</configuration>

--- a/karate/src/test/java/odds.json
+++ b/karate/src/test/java/odds.json
@@ -1,0 +1,28 @@
+{
+		"odds": [{
+			"price": 1.30,
+			"status": 0,
+			"ck": 12.2,
+			"name": "1"
+		},
+		{
+			"price": 5.25,
+			"status": 1,
+			"ck": 13.1,
+			"name": "X"
+		},
+		{
+			"price": 2.70,
+			"status": 0,
+			"ck": 12.2,
+			"name": "0"
+		},
+		{
+			"price": 1.20,
+			"status": 2,
+			"ck": 13.1,
+			"name": "2"
+		}
+		
+		]
+}

--- a/karate/src/test/java/teachers.xml
+++ b/karate/src/test/java/teachers.xml
@@ -1,0 +1,10 @@
+<teachers>
+	<teacher department="science" id='309'>
+		<subject>math</subject>
+		<subject>physics</subject>
+	</teacher>
+	<teacher department="arts" id='310'>
+		<subject>political education</subject>
+		<subject>english</subject>
+	</teacher>
+</teachers>


### PR DESCRIPTION
This is an exact port of the REST-assured examples, with some additions in cases where Karate has better support for XML (for e.g. XPath) and JSON (e.g. schema-like and regex) validation.

The README contains links to the [Karate home page](https://github.com/intuit/karate) as well as some good references and tutorials.

Do let me know if you need more information or changes !