### PR TITLE
BAEL 1181 - Test Order in JUnit 5

### DIFF
--- a/junit5/src/test/java/com/baeldung/DefaultOrderOfExecutionTest.java
+++ b/junit5/src/test/java/com/baeldung/DefaultOrderOfExecutionTest.java
@@ -31,3 +31,4 @@ public class DefaultOrderOfExecutionTest {
         assertEquals(output.toString(), "cab");
     }
 }
+

--- a/junit5/src/test/java/com/baeldung/DefaultOrderOfExecutionTest.java
+++ b/junit5/src/test/java/com/baeldung/DefaultOrderOfExecutionTest.java
@@ -1,33 +1,33 @@
 package com.baeldung;
 
+import static org.junit.Assert.assertEquals;
+
+import org.junit.AfterClass;
 import org.junit.FixMethodOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runners.MethodSorters;
 
 @FixMethodOrder(MethodSorters.DEFAULT)
 public class DefaultOrderOfExecutionTest {
-    @Rule
-    public TestName testName = new TestName();
+    private static StringBuilder output = new StringBuilder("");
 
     @Test
     public void secondTest() {
-        printHashCode();
+        output.append("b");
     }
 
     @Test
     public void thirdTest() {
-        printHashCode();
+        output.append("c");
     }
 
     @Test
     public void firstTest() {
-        printHashCode();
+        output.append("a");
     }
 
-    private void printHashCode() {
-        System.out.println(testName.getMethodName() + ", hash = " + testName.getMethodName()
-            .hashCode());
+    @AfterClass
+    public static void assertOutput() {
+        assertEquals(output.toString(), "cab");
     }
 }

--- a/junit5/src/test/java/com/baeldung/DefaultOrderOfExecutionTest.java
+++ b/junit5/src/test/java/com/baeldung/DefaultOrderOfExecutionTest.java
@@ -1,0 +1,33 @@
+package com.baeldung;
+
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.DEFAULT)
+public class DefaultOrderOfExecutionTest {
+    @Rule
+    public TestName testName = new TestName();
+
+    @Test
+    public void secondTest() {
+        printHashCode();
+    }
+
+    @Test
+    public void thirdTest() {
+        printHashCode();
+    }
+
+    @Test
+    public void firstTest() {
+        printHashCode();
+    }
+
+    private void printHashCode() {
+        System.out.println(testName.getMethodName() + ", hash = " + testName.getMethodName()
+            .hashCode());
+    }
+}

--- a/junit5/src/test/java/com/baeldung/JVMOrderOfExecutionTest.java
+++ b/junit5/src/test/java/com/baeldung/JVMOrderOfExecutionTest.java
@@ -1,0 +1,32 @@
+package com.baeldung;
+
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.DEFAULT)
+public class JVMOrderOfExecutionTest {
+    @Rule
+    public TestName testName = new TestName();
+
+    @Test
+    public void secondTest() {
+        printMethodName();
+    }
+
+    @Test
+    public void thirdTest() {
+        printMethodName();
+    }
+
+    @Test
+    public void firstTest() {
+        printMethodName();
+    }
+
+    private void printMethodName() {
+        System.out.println(testName.getMethodName());
+    }
+}

--- a/junit5/src/test/java/com/baeldung/JVMOrderOfExecutionTest.java
+++ b/junit5/src/test/java/com/baeldung/JVMOrderOfExecutionTest.java
@@ -1,32 +1,25 @@
 package com.baeldung;
 
 import org.junit.FixMethodOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runners.MethodSorters;
 
 @FixMethodOrder(MethodSorters.JVM)
 public class JVMOrderOfExecutionTest {
-    @Rule
-    public TestName testName = new TestName();
+    private static StringBuilder output = new StringBuilder("");
 
     @Test
     public void secondTest() {
-        printMethodName();
+        output.append("b");
     }
 
     @Test
     public void thirdTest() {
-        printMethodName();
+        output.append("c");
     }
 
     @Test
     public void firstTest() {
-        printMethodName();
-    }
-
-    private void printMethodName() {
-        System.out.println(testName.getMethodName());
+        output.append("a");
     }
 }

--- a/junit5/src/test/java/com/baeldung/JVMOrderOfExecutionTest.java
+++ b/junit5/src/test/java/com/baeldung/JVMOrderOfExecutionTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runners.MethodSorters;
 
-@FixMethodOrder(MethodSorters.DEFAULT)
+@FixMethodOrder(MethodSorters.JVM)
 public class JVMOrderOfExecutionTest {
     @Rule
     public TestName testName = new TestName();

--- a/junit5/src/test/java/com/baeldung/NameAscendingOrderOfExecutionTest.java
+++ b/junit5/src/test/java/com/baeldung/NameAscendingOrderOfExecutionTest.java
@@ -1,32 +1,33 @@
 package com.baeldung;
 
+import static org.junit.Assert.assertEquals;
+
+import org.junit.AfterClass;
 import org.junit.FixMethodOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runners.MethodSorters;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class NameAscendingOrderOfExecutionTest {
-    @Rule
-    public TestName testName = new TestName();
+    private static StringBuilder output = new StringBuilder("");
 
     @Test
     public void secondTest() {
-        printMethodName();
+        output.append("b");
     }
 
     @Test
     public void thirdTest() {
-        printMethodName();
+        output.append("c");
     }
 
     @Test
     public void firstTest() {
-        printMethodName();
+        output.append("a");
     }
 
-    private void printMethodName() {
-        System.out.println(testName.getMethodName());
+    @AfterClass
+    public static void assertOutput() {
+        assertEquals(output.toString(), "abc");
     }
 }

--- a/junit5/src/test/java/com/baeldung/NameAscendingOrderOfExecutionTest.java
+++ b/junit5/src/test/java/com/baeldung/NameAscendingOrderOfExecutionTest.java
@@ -1,0 +1,32 @@
+package com.baeldung;
+
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class NameAscendingOrderOfExecutionTest {
+    @Rule
+    public TestName testName = new TestName();
+
+    @Test
+    public void secondTest() {
+        printMethodName();
+    }
+
+    @Test
+    public void thirdTest() {
+        printMethodName();
+    }
+
+    @Test
+    public void firstTest() {
+        printMethodName();
+    }
+
+    private void printMethodName() {
+        System.out.println(testName.getMethodName());
+    }
+}


### PR DESCRIPTION
This _Pull Request_ is related to the article written for the process of sorting the order of tests in JUnit 5.