### PR TITLE
rename client databases and switch from 3 to 2 of them

### DIFF
--- a/spring-boot/src/main/java/org/baeldung/dsrouting/ClientDatabase.java
+++ b/spring-boot/src/main/java/org/baeldung/dsrouting/ClientDatabase.java
@@ -2,6 +2,6 @@ package org.baeldung.dsrouting;
 
 public enum ClientDatabase {
 
-    ACME_WIDGETS, WIDGETS_ARE_US, WIDGET_DEPOT
+    CLIENT_A, CLIENT_B
 
 }

--- a/spring-boot/src/test/java/org/baeldung/dsrouting/DataSourceRoutingTestConfiguration.java
+++ b/spring-boot/src/test/java/org/baeldung/dsrouting/DataSourceRoutingTestConfiguration.java
@@ -22,41 +22,30 @@ public class DataSourceRoutingTestConfiguration {
     @Bean
     public DataSource clientDatasource() {
         Map<Object, Object> targetDataSources = new HashMap<>();
-        DataSource acmeWidgetsDatasource = acmeWidgetsDatasource();
-        DataSource widgetsAreUsDatasource = widgetsAreUsDatasource();
-        DataSource widgetsDepotDatasource = widgetsDepotDatasource();
-        targetDataSources.put(ClientDatabase.ACME_WIDGETS, acmeWidgetsDatasource);
-        targetDataSources.put(ClientDatabase.WIDGETS_ARE_US, widgetsAreUsDatasource);
-        targetDataSources.put(ClientDatabase.WIDGET_DEPOT, widgetsDepotDatasource);
+        DataSource clientADatasource = clientADatasource();
+        DataSource clientBDatasource = clientBDatasource();
+        targetDataSources.put(ClientDatabase.CLIENT_A, clientADatasource);
+        targetDataSources.put(ClientDatabase.CLIENT_B, clientBDatasource);
 
         ClientDataSourceRouter clientRoutingDatasource = new ClientDataSourceRouter();
         clientRoutingDatasource.setTargetDataSources(targetDataSources);
-        clientRoutingDatasource.setDefaultTargetDataSource(acmeWidgetsDatasource);
+        clientRoutingDatasource.setDefaultTargetDataSource(clientADatasource);
         return clientRoutingDatasource;
     }
 
-    private DataSource acmeWidgetsDatasource() {
+    private DataSource clientADatasource() {
         EmbeddedDatabaseBuilder dbBuilder = new EmbeddedDatabaseBuilder();
         EmbeddedDatabase embeddedDb = dbBuilder.setType(EmbeddedDatabaseType.H2)
-            .setName("ACMEWIDGETS")
+            .setName("CLIENT_A")
             .addScript("classpath:dsrouting-db.sql")
             .build();
         return embeddedDb;
     }
 
-    private DataSource widgetsAreUsDatasource() {
+    private DataSource clientBDatasource() {
         EmbeddedDatabaseBuilder dbBuilder = new EmbeddedDatabaseBuilder();
         EmbeddedDatabase embeddedDb = dbBuilder.setType(EmbeddedDatabaseType.H2)
-            .setName("WIDGETSAREUS")
-            .addScript("classpath:dsrouting-db.sql")
-            .build();
-        return embeddedDb;
-    }
-
-    private DataSource widgetsDepotDatasource() {
-        EmbeddedDatabaseBuilder dbBuilder = new EmbeddedDatabaseBuilder();
-        EmbeddedDatabase embeddedDb = dbBuilder.setType(EmbeddedDatabaseType.H2)
-            .setName("WIDGETDEPOT")
+            .setName("CLIENT_B")
             .addScript("classpath:dsrouting-db.sql")
             .build();
         return embeddedDb;

--- a/spring-boot/src/test/java/org/baeldung/dsrouting/DataSourceRoutingTests.java
+++ b/spring-boot/src/test/java/org/baeldung/dsrouting/DataSourceRoutingTests.java
@@ -24,23 +24,18 @@ public class DataSourceRoutingTests {
 
     @Before
     public void setup() {
-        final String SQL_ACME_WIDGETS = "insert into client (id, name) values (1, 'ACME WIDGETS')";
-        final String SQL_WIDGETS_ARE_US = "insert into client (id, name) values (2, 'WIDGETS ARE US')";
-        final String SQL_WIDGET_DEPOT = "insert into client (id, name) values (3, 'WIDGET DEPOT')";
+        final String SQL_CLIENT_A = "insert into client (id, name) values (1, 'CLIENT A')";
+        final String SQL_CLIENT_B = "insert into client (id, name) values (2, 'CLIENT B')";
 
         JdbcTemplate jdbcTemplate = new JdbcTemplate();
         jdbcTemplate.setDataSource(routingDatasource);
 
-        ClientDatabaseContextHolder.set(ClientDatabase.ACME_WIDGETS);
-        jdbcTemplate.execute(SQL_ACME_WIDGETS);
+        ClientDatabaseContextHolder.set(ClientDatabase.CLIENT_A);
+        jdbcTemplate.execute(SQL_CLIENT_A);
         ClientDatabaseContextHolder.clear();
 
-        ClientDatabaseContextHolder.set(ClientDatabase.WIDGETS_ARE_US);
-        jdbcTemplate.execute(SQL_WIDGETS_ARE_US);
-        ClientDatabaseContextHolder.clear();
-
-        ClientDatabaseContextHolder.set(ClientDatabase.WIDGET_DEPOT);
-        jdbcTemplate.execute(SQL_WIDGET_DEPOT);
+        ClientDatabaseContextHolder.set(ClientDatabase.CLIENT_B);
+        jdbcTemplate.execute(SQL_CLIENT_B);
         ClientDatabaseContextHolder.clear();
     }
 
@@ -48,15 +43,11 @@ public class DataSourceRoutingTests {
     public void givenClientDbs_whenContextsSwitch_thenRouteToCorrectDatabase() throws Exception {
 
         // test ACME WIDGETS
-        String clientName = clientService.getClientName(ClientDatabase.ACME_WIDGETS);
-        assertEquals(clientName, "ACME WIDGETS");
+        String clientName = clientService.getClientName(ClientDatabase.CLIENT_A);
+        assertEquals(clientName, "CLIENT A");
 
         // test WIDGETS_ARE_US
-        clientName = clientService.getClientName(ClientDatabase.WIDGETS_ARE_US);
-        assertEquals(clientName, "WIDGETS ARE US");
-
-        // test WIDGET_DEPOT
-        clientName = clientService.getClientName(ClientDatabase.WIDGET_DEPOT);
-        assertEquals(clientName, "WIDGET DEPOT");
+        clientName = clientService.getClientName(ClientDatabase.CLIENT_B);
+        assertEquals(clientName, "CLIENT B");
     }
 }


### PR DESCRIPTION
Updates example to use plainer names for client database context and changes example to use 2 contexts instead of 3.