### PR TITLE
fix parent.relativePath config for maven submodules in separate folders

### DIFF
--- a/guava-modules/guava-18/pom.xml
+++ b/guava-modules/guava-18/pom.xml
@@ -11,7 +11,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <dependencies>

--- a/guava-modules/guava-19/pom.xml
+++ b/guava-modules/guava-19/pom.xml
@@ -11,7 +11,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../../</relativePath>
     </parent>
 
     <dependencies>

--- a/guava-modules/guava-21/pom.xml
+++ b/guava-modules/guava-21/pom.xml
@@ -11,7 +11,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
      </parent>
 
     <dependencies>

--- a/logging-modules/log-mdc/pom.xml
+++ b/logging-modules/log-mdc/pom.xml
@@ -12,7 +12,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <dependencies>

--- a/logging-modules/log4j/pom.xml
+++ b/logging-modules/log4j/pom.xml
@@ -11,7 +11,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <dependencies>

--- a/logging-modules/log4j2/pom.xml
+++ b/logging-modules/log4j2/pom.xml
@@ -9,7 +9,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../../</relativePath>
     </parent>
 
     <dependencies>

--- a/persistence-modules/java-cassandra/pom.xml
+++ b/persistence-modules/java-cassandra/pom.xml
@@ -11,7 +11,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
      </parent>
      
     <dependencies>

--- a/persistence-modules/java-mongodb/pom.xml
+++ b/persistence-modules/java-mongodb/pom.xml
@@ -11,7 +11,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>                
+        <relativePath>../../</relativePath>                
      </parent>
      
     <dependencies>

--- a/persistence-modules/liquibase/pom.xml
+++ b/persistence-modules/liquibase/pom.xml
@@ -6,7 +6,7 @@
         <artifactId>parent-modules</artifactId>
         <groupId>com.baeldung</groupId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/persistence-modules/querydsl/pom.xml
+++ b/persistence-modules/querydsl/pom.xml
@@ -15,7 +15,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <properties>

--- a/persistence-modules/redis/pom.xml
+++ b/persistence-modules/redis/pom.xml
@@ -15,7 +15,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <dependencies>

--- a/persistence-modules/solr/pom.xml
+++ b/persistence-modules/solr/pom.xml
@@ -12,7 +12,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <properties>

--- a/persistence-modules/spring-data-cassandra/pom.xml
+++ b/persistence-modules/spring-data-cassandra/pom.xml
@@ -13,7 +13,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <properties>

--- a/persistence-modules/spring-data-gemfire/pom.xml
+++ b/persistence-modules/spring-data-gemfire/pom.xml
@@ -12,7 +12,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <properties>

--- a/persistence-modules/spring-data-neo4j/pom.xml
+++ b/persistence-modules/spring-data-neo4j/pom.xml
@@ -10,7 +10,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <dependencies>

--- a/persistence-modules/spring-data-redis/pom.xml
+++ b/persistence-modules/spring-data-redis/pom.xml
@@ -11,7 +11,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <properties>

--- a/persistence-modules/spring-data-solr/pom.xml
+++ b/persistence-modules/spring-data-solr/pom.xml
@@ -12,7 +12,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <properties>

--- a/persistence-modules/spring-hibernate-3/pom.xml
+++ b/persistence-modules/spring-hibernate-3/pom.xml
@@ -11,7 +11,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <dependencies>

--- a/persistence-modules/spring-hibernate-5/pom.xml
+++ b/persistence-modules/spring-hibernate-5/pom.xml
@@ -11,7 +11,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <dependencies>

--- a/testing-modules/groovy-spock/pom.xml
+++ b/testing-modules/groovy-spock/pom.xml
@@ -17,7 +17,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../../</relativePath>
     </parent>
 
     <build>

--- a/testing-modules/junit-5/pom.xml
+++ b/testing-modules/junit-5/pom.xml
@@ -14,7 +14,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <properties>

--- a/testing-modules/mockito-2/pom.xml
+++ b/testing-modules/mockito-2/pom.xml
@@ -12,7 +12,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../../</relativePath>
     </parent>
 
     <profiles>

--- a/testing-modules/mockito/pom.xml
+++ b/testing-modules/mockito/pom.xml
@@ -11,7 +11,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../../</relativePath>
     </parent>
 
     <dependencies>

--- a/testing-modules/mocks/pom.xml
+++ b/testing-modules/mocks/pom.xml
@@ -6,7 +6,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../../</relativePath>
     </parent>
 
     <artifactId>mocks</artifactId>

--- a/testing-modules/rest-assured/pom.xml
+++ b/testing-modules/rest-assured/pom.xml
@@ -10,7 +10,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../../</relativePath>
     </parent>
 
     <dependencies>

--- a/testing-modules/rest-testing/pom.xml
+++ b/testing-modules/rest-testing/pom.xml
@@ -11,7 +11,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <dependencies>

--- a/testing-modules/selenium-junit-testng/pom.xml
+++ b/testing-modules/selenium-junit-testng/pom.xml
@@ -9,7 +9,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>        
+        <relativePath>../../</relativePath>        
     </parent>
 
     <build>

--- a/testing-modules/testing/pom.xml
+++ b/testing-modules/testing/pom.xml
@@ -10,7 +10,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../../</relativePath>
     </parent>
 
     <dependencies>

--- a/testing-modules/testng/pom.xml
+++ b/testing-modules/testng/pom.xml
@@ -11,7 +11,7 @@
         <groupId>com.baeldung</groupId>
         <artifactId>parent-modules</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../../</relativePath>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
since some module have been moved to sub directories other than the root directory, pom.xml config should be adjusted accordingly.