### PR TITLE
[BAEL-1209] Java RMI

### DIFF
--- a/java-rmi/src/client.policy
+++ b/java-rmi/src/client.policy
@@ -1,0 +1,3 @@
+grant codeBase "file:." {
+    permission java.security.AllPermission;
+};

--- a/java-rmi/src/com/baeldung/rmi/ClientImpl.java
+++ b/java-rmi/src/com/baeldung/rmi/ClientImpl.java
@@ -1,0 +1,31 @@
+package com.baeldung.rmi;
+
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
+import java.rmi.registry.Registry;
+
+public class ClientImpl {
+
+	public static void main(String[] args) {
+		
+		if (System.getSecurityManager() == null) {
+			System.setSecurityManager(new SecurityManager());
+		}
+		
+		try {
+			
+			Registry registry = LocateRegistry.getRegistry(args[0], Integer.valueOf(args[1]));
+			
+			ServerInterface server = (ServerInterface) registry.lookup("Server");
+			
+			String responseMessage = server.sendMessage("Client Message");
+			
+		} catch (RemoteException e) {
+			e.printStackTrace();
+		} catch (NotBoundException nb) {
+			nb.printStackTrace();
+		}
+	}
+	
+}

--- a/java-rmi/src/com/baeldung/rmi/ServerImpl.java
+++ b/java-rmi/src/com/baeldung/rmi/ServerImpl.java
@@ -1,0 +1,42 @@
+package com.baeldung.rmi;
+
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
+import java.rmi.registry.Registry;
+import java.rmi.server.UnicastRemoteObject;
+
+public class ServerImpl implements ServerInterface {
+
+	@Override
+	public String sendMessage(String clientMessage) throws RemoteException {
+		
+		String serverMessage = null;
+		if (clientMessage.equals("Client Message"))
+			serverMessage = "Server Message";
+		
+		return serverMessage;
+	}
+	
+	public static void main(String[] args) {
+		
+		if (System.getSecurityManager() == null) {
+            System.setSecurityManager(new SecurityManager());
+        }
+		
+		try {
+			
+			ServerInterface server = new ServerImpl();
+			
+			ServerInterface stub = (ServerInterface) UnicastRemoteObject.exportObject((ServerInterface) server, 0);
+			
+			Registry registry = LocateRegistry.createRegistry(1099);
+			
+			registry.rebind("Server", stub);
+			
+		} catch (RemoteException e) {
+			e.printStackTrace();
+		}
+		
+	}
+	
+}

--- a/java-rmi/src/com/baeldung/rmi/ServerInterface.java
+++ b/java-rmi/src/com/baeldung/rmi/ServerInterface.java
@@ -1,0 +1,9 @@
+package com.baeldung.rmi;
+
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+
+public interface ServerInterface extends Remote {
+	
+	public String sendMessage(String requestMessage) throws RemoteException;
+}

--- a/java-rmi/src/server.policy
+++ b/java-rmi/src/server.policy
@@ -1,0 +1,3 @@
+grant codeBase "file:." {
+    permission java.security.AllPermission;
+};

--- a/java-rmi/test/com/baeldung/rmi/JavaRMITest.java
+++ b/java-rmi/test/com/baeldung/rmi/JavaRMITest.java
@@ -1,0 +1,60 @@
+package com.baeldung.rmi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
+import java.rmi.registry.Registry;
+import java.rmi.server.UnicastRemoteObject;
+
+import org.junit.Test;
+
+public class JavaRMITest {
+	
+	@Test
+	public void WhenRunServer_ServerIsStarted() {
+		
+		try {
+			
+			ServerInterface server = new ServerImpl();
+			
+			ServerInterface stub = (ServerInterface) UnicastRemoteObject.exportObject((ServerInterface) server, 0);
+			
+			Registry registry = LocateRegistry.createRegistry(1099);
+			
+			registry.rebind("Server", stub);
+			
+			assertTrue(true);
+			
+		} catch (RemoteException e) {
+			fail("Exception Occured");
+		}
+	}
+	
+	@Test
+	public void WhenClientSendsMessageToServer_ServerSendsResponseMessage() {
+		
+		try {
+			
+			Registry registry = LocateRegistry.getRegistry("127.0.0.1", 1099);
+			
+			ServerInterface server = (ServerInterface) registry.lookup("Server");
+			
+			String responseMessage = server.sendMessage("Client Message");
+			
+			String expectedMessage = "Server Message";
+			
+			assertEquals(responseMessage, expectedMessage);
+			
+		} catch (RemoteException e) {
+			fail("Exception Occured");
+		} catch (NotBoundException nb) {
+			fail("Exception Occured");
+		}
+		
+	}
+
+}


### PR DESCRIPTION
Files for BAEL-1209: Java RMI.

Run the program using following commands:

java -Djava.security.policy=server.policy com/baeldung/rmi/ServerImpl

java -Djava.security.policy=client.policy com/baeldung/rmi/ClientImpl <rmi_registry_hostname> <port_number>

for e.g.
java -Djava.security.policy=client.policy com/baeldung/rmi/ClientImpl 127.0.0.1 1099