### PR TITLE
Spring dependency injection types new example added

### DIFF
--- a/spring-core/src/main/java/com/baeldung/dependencyinjectiontypes/spring/ArticleFormatterWithConstructorInjection.java
+++ b/spring-core/src/main/java/com/baeldung/dependencyinjectiontypes/spring/ArticleFormatterWithConstructorInjection.java
@@ -1,0 +1,18 @@
+package com.baeldung.dependencyinjectiontypes.spring;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import com.baeldung.dependencyinjectiontypes.TextFormatter;
+
+public class ArticleFormatterWithConstructorInjection {
+
+	private TextFormatter formatter;
+
+	@Autowired
+    public ArticleFormatterWithConstructorInjection(TextFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    public String format(String text) {
+        return formatter.format(text);
+    }
+}

--- a/spring-core/src/main/java/com/baeldung/dependencyinjectiontypes/spring/ArticleFormatterWithSetterInjection.java
+++ b/spring-core/src/main/java/com/baeldung/dependencyinjectiontypes/spring/ArticleFormatterWithSetterInjection.java
@@ -1,0 +1,23 @@
+package com.baeldung.dependencyinjectiontypes.spring;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import com.baeldung.dependencyinjectiontypes.TextFormatter;
+
+public class ArticleFormatterWithSetterInjection {
+	
+	private TextFormatter formatter;
+
+    public ArticleFormatterWithSetterInjection(TextFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    @Autowired
+    public void setTextFormatter(TextFormatter formatter) {
+        this.formatter = formatter;
+    }
+    
+    public String format(String text) {
+        return formatter.format(text);
+    }
+
+}

--- a/spring-core/src/main/resources/dependencyinjectiontypes-context.xml
+++ b/spring-core/src/main/resources/dependencyinjectiontypes-context.xml
@@ -16,6 +16,16 @@
 		<constructor-arg ref="textFormatterBean" />
 	</bean>
 	
+	<bean id="articleFormatterWithSetterInjectionBean"
+		class="com.baeldung.dependencyinjectiontypes.spring.ArticleFormatterWithSetterInjection">
+		<property name="formatter" ref="textFormatterBean" />
+	</bean>
+	
+	<bean id="articleFormatterWithConstructorInjectionBean"
+		class="com.baeldung.dependencyinjectiontypes.spring.ArticleFormatterWithConstructorInjection">
+		<constructor-arg ref="textFormatterBean" />
+	</bean>
+	
 	
 	<bean id="textFormatterBean" class="com.baeldung.dependencyinjectiontypes.TextFormatter">
 	</bean>

--- a/spring-core/src/test/java/com/baeldung/dependencyinjectiontypes/spring/DependencyInjectionTypesTest.java
+++ b/spring-core/src/test/java/com/baeldung/dependencyinjectiontypes/spring/DependencyInjectionTypesTest.java
@@ -1,0 +1,35 @@
+package com.baeldung.dependencyinjectiontypes.spring;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class DependencyInjectionTypesTest {
+	
+	@Test
+    public void givenAutowiredAnnotation_WhenSetOnSetter_ThenDependencyValid() {
+        
+    	ApplicationContext context = new ClassPathXmlApplicationContext("dependencyinjectiontypes-context.xml");
+    	ArticleFormatterWithSetterInjection article = (ArticleFormatterWithSetterInjection) context.getBean("articleFormatterWithSetterInjectionBean");
+        
+    	String originalText = "This is a text !";
+    	String formattedArticle = article.format(originalText);
+    	
+    	assertTrue(originalText.toUpperCase().equals(formattedArticle));
+    }
+    
+    @Test
+    public void givenAutowiredAnnotation_WhenSetOnConstructor_ThenDependencyValid() {
+    	
+    	ApplicationContext context = new ClassPathXmlApplicationContext("dependencyinjectiontypes-context.xml");
+    	ArticleFormatterWithConstructorInjection article = (ArticleFormatterWithConstructorInjection) context.getBean("articleFormatterWithConstructorInjectionBean");
+        
+    	String originalText = "This is a text !";
+    	String formattedArticle = article.format(originalText);
+    	
+    	assertTrue(originalText.toUpperCase().equals(formattedArticle));
+    }
+
+}


### PR DESCRIPTION
Spring dependency injection types new example added including
1.  Setter injection 
2. Constructor injection
3. XML configuration
4. Test Cases