### PR TITLE
A short example of real-time event streaming using Spring Webflux by inbox.saikat@gmail.com

### DIFF
--- a/spring-5-reactive/src/main/java/com/baeldung/reactive/ReactiveWebclient.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/reactive/ReactiveWebclient.java
@@ -1,0 +1,5 @@
+package com.baeldung.reactive;
+
+public class ReactiveWebclient {
+
+}

--- a/spring-5-reactive/src/main/java/com/baeldung/reactive/ReactiveWebclient.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/reactive/ReactiveWebclient.java
@@ -1,5 +1,39 @@
 package com.baeldung.reactive;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@SpringBootApplication
 public class ReactiveWebclient {
+
+    private static final Logger logger = LoggerFactory.getLogger(ReactiveWebclient.class);
+
+    @Bean
+    WebClient client() {
+        return WebClient.create("http://localhost:8080");
+    }
+
+    @Bean
+    ApplicationRunner demo(WebClient client) {
+        return args -> {
+            client.get()
+                .uri("/events")
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .retrieve()
+                .bodyToFlux(String.class)
+                .subscribe(logger::info);
+
+        };
+    }
+    
+    public static void main(String[] args) {
+        SpringApplication.run(ReactiveWebclient.class, args);
+    }
 
 }

--- a/spring-5-reactive/src/main/java/com/baeldung/reactive/ReactiveWebfluxServer.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/reactive/ReactiveWebfluxServer.java
@@ -1,0 +1,38 @@
+package com.baeldung.reactive;
+
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.util.Date;
+import java.util.stream.Stream;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Flux;
+import reactor.util.function.Tuple2;
+
+@SpringBootApplication
+@RestController
+public class ReactiveWebfluxServer {
+
+    @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE, value = "/events")
+    Flux<String> getEventStream() {
+        Flux<String> eventFlux = Flux.fromStream(Stream.generate(() -> getCurrentTimeStamp()));
+        Flux<Long> durationFlux = Flux.interval(Duration.ofSeconds(1));
+        return Flux.zip(eventFlux, durationFlux)
+            .map(Tuple2::getT1);
+
+    }
+
+    private String getCurrentTimeStamp() {
+        return new SimpleDateFormat("yyyy-MM-dd:HH-mm-ss").format(new Date());
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(ReactiveWebfluxServer.class, args);
+    }
+
+}

--- a/spring-5-reactive/src/main/java/com/baeldung/reactive/ReactiveWebfluxServer.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/reactive/ReactiveWebfluxServer.java
@@ -5,7 +5,6 @@ import java.time.Duration;
 import java.util.Date;
 import java.util.stream.Stream;
 
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,10 +28,6 @@ public class ReactiveWebfluxServer {
 
     private String getCurrentTimeStamp() {
         return new SimpleDateFormat("yyyy-MM-dd:HH-mm-ss").format(new Date());
-    }
-
-    public static void main(String[] args) {
-        SpringApplication.run(ReactiveWebfluxServer.class, args);
     }
 
 }


### PR DESCRIPTION
### A short example of real-time event streaming using Spring Webflux by inbox.saikat@gmail.com

A quick and practical example of the Spring Webflux support on the server side, and on the client side, a simple Reactive Web client.

The endpoint produces one event (i.e. current time stamp) per second infinitely and the client side simply consumes and logs the events as they arrive.