### PR TITLE
BAEL-1764 Code update for Spring RestTemplate Exception Handling article.

### DIFF
--- a/spring-rest-simple/pom.xml
+++ b/spring-rest-simple/pom.xml
@@ -31,8 +31,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-test</artifactId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.springframework.boot</groupId>-->
+            <!--<artifactId>spring-boot-test</artifactId>-->
+            <!--<scope>test</scope>-->
+        <!--</dependency>-->
 
         <!-- Spring -->
 
@@ -240,7 +246,7 @@
                 <artifactId>cargo-maven2-plugin</artifactId>
                 <version>${cargo-maven2-plugin.version}</version>
                 <configuration>
-                    <wait>true</wait>
+                    <!--<wait>true</wait> caused errors on commit-->
                     <container>
                         <containerId>tomcat8x</containerId>
                         <type>embedded</type>

--- a/spring-rest-simple/src/main/java/org/baeldung/config/WebConfig.java
+++ b/spring-rest-simple/src/main/java/org/baeldung/config/WebConfig.java
@@ -1,8 +1,5 @@
 package org.baeldung.config;
 
-import java.text.SimpleDateFormat;
-import java.util.List;
-
 import org.baeldung.config.converter.KryoHttpMessageConverter;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +15,9 @@ import org.springframework.oxm.xstream.XStreamMarshaller;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
 
 /*
  * Please note that main web configuration is in src/main/webapp/WEB-INF/api-servlet.xml

--- a/spring-rest-simple/src/main/java/org/baeldung/web/exception/NotFoundException.java
+++ b/spring-rest-simple/src/main/java/org/baeldung/web/exception/NotFoundException.java
@@ -1,0 +1,4 @@
+package org.baeldung.web.exception;
+
+public class NotFoundException extends RuntimeException {
+}

--- a/spring-rest-simple/src/main/java/org/baeldung/web/handler/RestTemplateResponseErrorHandler.java
+++ b/spring-rest-simple/src/main/java/org/baeldung/web/handler/RestTemplateResponseErrorHandler.java
@@ -1,8 +1,6 @@
 package org.baeldung.web.handler;
 
 import org.baeldung.web.exception.NotFoundException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
@@ -11,13 +9,13 @@ import org.springframework.web.client.ResponseErrorHandler;
 import java.io.IOException;
 
 @Component
-public class RestTemplateResponseErrorHandler implements ResponseErrorHandler {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(RestTemplateResponseErrorHandler.class);
-
+public class RestTemplateResponseErrorHandler
+    implements ResponseErrorHandler {
 
     @Override
-    public boolean hasError(ClientHttpResponse httpResponse) throws IOException {
+    public boolean hasError(ClientHttpResponse httpResponse)
+        throws IOException {
+
         return (httpResponse
           .getStatusCode()
           .series() == HttpStatus.Series.CLIENT_ERROR || httpResponse
@@ -26,28 +24,20 @@ public class RestTemplateResponseErrorHandler implements ResponseErrorHandler {
     }
 
     @Override
-    public void handleError(ClientHttpResponse httpResponse) throws IOException {
+    public void handleError(ClientHttpResponse httpResponse)
+        throws IOException {
+
         if (httpResponse
           .getStatusCode()
           .series() == HttpStatus.Series.SERVER_ERROR) {
-            this.handleServerError(httpResponse);
+            //Handle SERVER_ERROR
         } else if (httpResponse
           .getStatusCode()
           .series() == HttpStatus.Series.CLIENT_ERROR) {
-            this.handleClientError(httpResponse);
-        }
-    }
-
-    private void handleServerError(ClientHttpResponse httpResponse) {
-        //Handle Server specific errors
-    }
-
-    private void handleClientError(ClientHttpResponse httpResponse) throws IOException {
-        //Handle Client specific errors
-        if (httpResponse.getStatusCode() == HttpStatus.NOT_FOUND) {
-            //Log details here...
-            LOGGER.info("Throwing NotFoundException...");
-            throw new NotFoundException();
+            //Handle CLIENT_ERROR
+            if (httpResponse.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new NotFoundException();
+            }
         }
     }
 }

--- a/spring-rest-simple/src/main/java/org/baeldung/web/handler/RestTemplateResponseErrorHandler.java
+++ b/spring-rest-simple/src/main/java/org/baeldung/web/handler/RestTemplateResponseErrorHandler.java
@@ -1,0 +1,53 @@
+package org.baeldung.web.handler;
+
+import org.baeldung.web.exception.NotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResponseErrorHandler;
+
+import java.io.IOException;
+
+@Component
+public class RestTemplateResponseErrorHandler implements ResponseErrorHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RestTemplateResponseErrorHandler.class);
+
+
+    @Override
+    public boolean hasError(ClientHttpResponse httpResponse) throws IOException {
+        return (httpResponse
+          .getStatusCode()
+          .series() == HttpStatus.Series.CLIENT_ERROR || httpResponse
+          .getStatusCode()
+          .series() == HttpStatus.Series.SERVER_ERROR);
+    }
+
+    @Override
+    public void handleError(ClientHttpResponse httpResponse) throws IOException {
+        if (httpResponse
+          .getStatusCode()
+          .series() == HttpStatus.Series.SERVER_ERROR) {
+            this.handleServerError(httpResponse);
+        } else if (httpResponse
+          .getStatusCode()
+          .series() == HttpStatus.Series.CLIENT_ERROR) {
+            this.handleClientError(httpResponse);
+        }
+    }
+
+    private void handleServerError(ClientHttpResponse httpResponse) {
+        //Handle Server specific errors
+    }
+
+    private void handleClientError(ClientHttpResponse httpResponse) throws IOException {
+        //Handle Client specific errors
+        if (httpResponse.getStatusCode() == HttpStatus.NOT_FOUND) {
+            //Log details here...
+            LOGGER.info("Throwing NotFoundException...");
+            throw new NotFoundException();
+        }
+    }
+}

--- a/spring-rest-simple/src/main/java/org/baeldung/web/model/Bar.java
+++ b/spring-rest-simple/src/main/java/org/baeldung/web/model/Bar.java
@@ -1,0 +1,22 @@
+package org.baeldung.web.model;
+
+public class Bar {
+    private String id;
+    private String name;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/spring-rest-simple/src/main/java/org/baeldung/web/service/BarConsumerService.java
+++ b/spring-rest-simple/src/main/java/org/baeldung/web/service/BarConsumerService.java
@@ -1,0 +1,24 @@
+package org.baeldung.web.service;
+
+import org.baeldung.web.handler.RestTemplateResponseErrorHandler;
+import org.baeldung.web.model.Bar;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+
+@Service
+public class BarConsumerService {
+
+
+    @Autowired RestTemplateBuilder restTemplateBuilder;
+
+    public Bar fetchBarById(String barId) {
+        RestTemplate restTemplate = restTemplateBuilder
+          .errorHandler(new RestTemplateResponseErrorHandler())
+          .build();
+        return restTemplate.getForObject("/bars/4242", Bar.class);
+    }
+
+}

--- a/spring-rest-simple/src/main/java/org/baeldung/web/service/BarConsumerService.java
+++ b/spring-rest-simple/src/main/java/org/baeldung/web/service/BarConsumerService.java
@@ -7,17 +7,19 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-
 @Service
 public class BarConsumerService {
 
+    private RestTemplate restTemplate;
 
-    @Autowired RestTemplateBuilder restTemplateBuilder;
-
-    public Bar fetchBarById(String barId) {
+    @Autowired
+    public BarConsumerService(RestTemplateBuilder restTemplateBuilder) {
         RestTemplate restTemplate = restTemplateBuilder
           .errorHandler(new RestTemplateResponseErrorHandler())
           .build();
+    }
+
+    public Bar fetchBarById(String barId) {
         return restTemplate.getForObject("/bars/4242", Bar.class);
     }
 

--- a/spring-rest-simple/src/test/java/org/baeldung/web/handler/RestTemplateResponseErrorHandlerIntegrationTest.java
+++ b/spring-rest-simple/src/test/java/org/baeldung/web/handler/RestTemplateResponseErrorHandlerIntegrationTest.java
@@ -1,0 +1,54 @@
+package org.baeldung.web.handler;
+
+import org.baeldung.web.dto.Bazz;
+import org.baeldung.web.exception.NotFoundException;
+import org.baeldung.web.model.Bar;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.ExpectedCount;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {NotFoundException.class, Bar.class})
+@RestClientTest
+public class RestTemplateResponseErrorHandlerIntegrationTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RestTemplateResponseErrorHandler.class);
+
+  @Autowired private MockRestServiceServer server;
+  @Autowired private RestTemplateBuilder builder;
+
+
+  @Test(expected = NotFoundException.class)
+  public void givenCallToRemoteApi_when404ErrorReceived_throwNotFoundException() {
+    Assert.assertNotNull(this.builder);
+    Assert.assertNotNull(this.server);
+
+    RestTemplate restTemplate = this.builder
+      .errorHandler(new RestTemplateResponseErrorHandler())
+      .build();
+
+    this.server
+      .expect(ExpectedCount.once(), requestTo("/bars/4242"))
+      .andExpect(method(HttpMethod.GET))
+      .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+    Bar response = restTemplate.getForObject("/bars/4242", Bar.class);
+    this.server.verify();
+  }
+}


### PR DESCRIPTION
Here is the code for Spring RestTemplate Exception Handling mini-article.

I had to correct 2 things in the pom.xml 
a) the first one is in the codehaus cargo configuration and not related at all to my project. It was causing an error in the commit. 
b) the seond one was directly impacting my project probably because the spring-boot-test entry was old a bit so I replaced with spring-boot-starter-test. That way, I had all required test annotations working.

Finally, an error poped in the global build from the spring-rest-query-language sub-project.