### PR TITLE
Create WebFlux server and WebClient

### DIFF
--- a/spring-5-reactive/src/main/java/META-INF/MANIFEST.MF
+++ b/spring-5-reactive/src/main/java/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Class-Path: 
+

--- a/spring-5-reactive/src/main/java/com/baeldung/reactive/client/Client.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/reactive/client/Client.java
@@ -1,0 +1,42 @@
+package com.baeldung.reactive.client;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * Client that consumes the stream produced by the reactive server 
+ * at hardcoded url http://localhost:8080/stream.
+ */
+public class Client {
+
+    /**
+     * Infinite stream of integer numbers 
+     */
+    private Flux<Long> flux;
+
+    public Client() {
+        flux = WebClient.create("http://localhost:8080")
+            .get()
+            .uri("/stream")
+            .accept(MediaType.APPLICATION_STREAM_JSON)
+            .exchange()
+            .flatMapMany(response -> response.bodyToFlux(Long.class));
+    }
+
+    /**
+     * Subscribe to the stream of data
+     */
+    public void consume() {
+        flux.subscribe(i -> store(i), e -> System.out.println(e.getMessage()));
+    }
+
+    /**
+     * A mock for the function that stores integer numbers from the stream.
+     * @param number single stream's number 
+     */
+    private void store(Long number) {
+        System.out.println("Storing: " + number);
+    }
+}

--- a/spring-5-reactive/src/main/java/com/baeldung/reactive/client/Main.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/reactive/client/Main.java
@@ -1,0 +1,17 @@
+package com.baeldung.reactive.client;
+
+/**
+ * A program that set up the client for consuming the stream produced in {@link StreamController}.
+ */
+public class Main {
+
+    public static void main(String[] args) {
+        Client client = new Client();
+        client.consume();
+
+        while (true) {
+        }
+
+    }
+
+}

--- a/spring-5-reactive/src/main/java/com/baeldung/reactive/controller/StreamController.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/reactive/controller/StreamController.java
@@ -1,0 +1,29 @@
+package com.baeldung.reactive.controller;
+
+import java.time.Duration;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * Controller that produces infinite stream of integer numbers 
+ *
+ */
+@RestController
+public class StreamController {
+    /**
+     * Produce an infinite stream of integers (Long). 
+     * 
+     * The stream starts with zero, once a second publish another integer 
+     * incremented by one.
+     * 
+     * @return a stream of Long
+     */
+    @GetMapping(path = "/stream", produces = MediaType.APPLICATION_STREAM_JSON_VALUE)
+    public Flux<Long> getSequence() {
+        return Flux.interval(Duration.ofSeconds(1));
+    }
+}


### PR DESCRIPTION
Implementation of reactive server and client with Spring WebFlux. 
This code is a part of the article "Real-Time Event Streaming with Spring Webflux".