### PR TITLE
Generate flux of numbers every second till a given count (infinity if count less than 0)

### DIFF
--- a/spring-5-reactive/src/main/java/com/baeldung/reactive/controller/InfiniteFluxController.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/reactive/controller/InfiniteFluxController.java
@@ -1,0 +1,55 @@
+package com.baeldung.reactive.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+
+@RestController
+public class InfiniteFluxController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InfiniteFluxController.class);
+
+    @GetMapping(path = "/numbers/{count}", produces = MediaType.APPLICATION_STREAM_JSON_VALUE)
+    public Flux<Long> infiniteStream(@PathVariable("count") long count) {
+
+        Flux<Long> generateFlux = Flux.generate(() -> 0L, (state, sink) -> {
+            sink.next(state++);
+            if (count > -1 && state > count) { //if count is less than 0 then the Flux is practically infinite
+                sink.complete();
+            }
+            return state;
+        });
+
+        return generateFlux.delayElements(Duration.ofSeconds(1));
+    }
+
+
+    @GetMapping("/numbers")
+    public HttpStatus self() {
+
+        WebClient webClient = WebClient.builder()
+            .baseUrl("http://localhost:8080")
+            .build();
+
+        int countTillNumber = 5;
+
+        webClient.get()
+            .uri("/numbers/" + countTillNumber)
+            .accept(MediaType.APPLICATION_STREAM_JSON)
+            .retrieve()
+            .bodyToFlux(Long.class)
+            .subscribe(number -> LOGGER.info(String.valueOf(number)),
+                    (throwable -> LOGGER.error("An unexpected error occurred. See trace", throwable)),
+                    () -> System.out.println("Flux data transfer complete"));
+        return HttpStatus.OK;
+    }
+
+}

--- a/spring-5-reactive/src/test/java/com/baeldung/reactive/controller/InfiniteFluxControllerIntegrationTests.java
+++ b/spring-5-reactive/src/test/java/com/baeldung/reactive/controller/InfiniteFluxControllerIntegrationTests.java
@@ -1,0 +1,52 @@
+package com.baeldung.reactive.controller;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class InfiniteFluxControllerIntegrationTests {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InfiniteFluxControllerIntegrationTests.class);
+
+    private static WebClient client;
+    private static String SERVER_PORT = "8080";
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        client = WebClient.builder()
+            .baseUrl("http://localhost:" + SERVER_PORT)
+            .build();
+    }
+
+    @Test
+    public void whenPositiveNumberCountIsGiven_thenFetchAndLogTillCount() {
+
+        int countTillNumber = 5;
+
+        Flux<Long> longFlux = client.get()
+            .uri("/numbers/" + countTillNumber)
+            .accept(MediaType.APPLICATION_STREAM_JSON)
+            .retrieve()
+            .bodyToFlux(Long.class);
+
+        Duration verificationTime = StepVerifier.create(longFlux)
+            .expectNext(0L, 1L, 2L, 3L, 4L, 5L)
+            .expectComplete()
+            .verify();
+        LOGGER.info("Verified successfully in {} seconds", verificationTime.get(ChronoUnit.SECONDS));
+
+    }
+}


### PR DESCRIPTION
-A GET end-point to generate a flux of numbers which sends the subscriber a number each second till the given count. If the count is less than 0, then the flux is basically infinite
-Another end-point acting as a client to subscribe to the first end-point and log the results.
-An integration test using the reactor-test API to verify the expected output in the flux