### PR TITLE
[BAEL-2026] core-java-collections core-java-9 | find all items in collection that meet a condition

### DIFF
--- a/core-java-9/pom.xml
+++ b/core-java-9/pom.xml
@@ -20,9 +20,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-runner</artifactId>
+            <version>${junit.platform.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -50,6 +62,8 @@
 
     <properties>
         <!-- testing -->
+        <assertj.version>3.10.0</assertj.version>
+        <junit.platform.version>1.2.0</junit.platform.version>
         <awaitility.version>1.7.0</awaitility.version>
         <maven.compiler.source>1.9</maven.compiler.source>
         <maven.compiler.target>1.9</maven.compiler.target>

--- a/core-java-9/src/main/java/com/baeldung/java9/language/stream/StreamsGroupingCollectionFilter.java
+++ b/core-java-9/src/main/java/com/baeldung/java9/language/stream/StreamsGroupingCollectionFilter.java
@@ -1,0 +1,27 @@
+package com.baeldung.java9.language.stream;
+
+import static java.util.stream.Collectors.filtering;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public class StreamsGroupingCollectionFilter {
+
+    static public Map<Integer, List<Integer>> findEvenNumbersAfterGroupingByQuantityOfDigits(Collection<Integer> baseCollection) {
+        Function<Integer, Integer> getQuantityOfDigits = item -> (int) Math.log10(item) + 1;
+
+        return baseCollection.stream()
+            .collect(groupingBy(getQuantityOfDigits, filtering(item -> item % 2 == 0, toList())));
+    }
+
+    static public Map<Integer, List<Integer>> findEvenNumbersBeforeGroupingByQuantityOfDigits(Collection<Integer> baseCollection) {
+
+        return baseCollection.stream()
+            .filter(item -> item % 2 == 0)
+            .collect(groupingBy(item -> (int) Math.log10(item) + 1, toList()));
+    }
+}

--- a/core-java-9/src/test/java/com/baeldung/java9/language/stream/CollectionFilterUnitTest.java
+++ b/core-java-9/src/test/java/com/baeldung/java9/language/stream/CollectionFilterUnitTest.java
@@ -18,7 +18,6 @@ public class CollectionFilterUnitTest {
 
     private static final Collection<Integer> BASE_INTEGER_COLLECTION = Arrays.asList(9, 12, 55, 56, 101, 115, 8002, 223, 2668, 19, 8);
     private static final Map<Integer, List<Integer>> EXPECTED_EVEN_FILTERED_AFTER_GROUPING_MAP = createExpectedFilterAfterGroupingMap();
-
     private static Map<Integer, List<Integer>> createExpectedFilterAfterGroupingMap() {
         Map<Integer, List<Integer>> map = new HashMap<>();
         map.put(1, Arrays.asList(8));
@@ -30,7 +29,6 @@ public class CollectionFilterUnitTest {
     }
 
     private static final Map<Integer, List<Integer>> EXPECTED_EVEN_FILTERED_BEFORE_GROUPING_MAP = createExpectedFilterBeforeGroupingMap();
-
     private static Map<Integer, List<Integer>> createExpectedFilterBeforeGroupingMap() {
         Map<Integer, List<Integer>> map = new HashMap<>();
         map.put(1, Arrays.asList(8));

--- a/core-java-9/src/test/java/com/baeldung/java9/language/stream/CollectionFilterUnitTest.java
+++ b/core-java-9/src/test/java/com/baeldung/java9/language/stream/CollectionFilterUnitTest.java
@@ -1,0 +1,53 @@
+package com.baeldung.java9.language.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+public class CollectionFilterUnitTest {
+
+    private static final Collection<Integer> BASE_INTEGER_COLLECTION = Arrays.asList(9, 12, 55, 56, 101, 115, 8002, 223, 2668, 19, 8);
+    private static final Map<Integer, List<Integer>> EXPECTED_EVEN_FILTERED_AFTER_GROUPING_MAP = createExpectedFilterAfterGroupingMap();
+
+    private static Map<Integer, List<Integer>> createExpectedFilterAfterGroupingMap() {
+        Map<Integer, List<Integer>> map = new HashMap<>();
+        map.put(1, Arrays.asList(8));
+        map.put(2, Arrays.asList(12, 56));
+        map.put(3, Collections.emptyList());
+        map.put(4, Arrays.asList(8002, 2668));
+        return map;
+
+    }
+
+    private static final Map<Integer, List<Integer>> EXPECTED_EVEN_FILTERED_BEFORE_GROUPING_MAP = createExpectedFilterBeforeGroupingMap();
+
+    private static Map<Integer, List<Integer>> createExpectedFilterBeforeGroupingMap() {
+        Map<Integer, List<Integer>> map = new HashMap<>();
+        map.put(1, Arrays.asList(8));
+        map.put(2, Arrays.asList(12, 56));
+        map.put(4, Arrays.asList(8002, 2668));
+        return map;
+
+    }
+
+    @Test
+    public void givenAStringCollection_whenFilteringFourLetterWords_thenObtainTheFilteredCollection() {
+        Map<Integer, List<Integer>> filteredAfterGroupingMap = StreamsGroupingCollectionFilter.findEvenNumbersAfterGroupingByQuantityOfDigits(BASE_INTEGER_COLLECTION);
+        Map<Integer, List<Integer>> filteredBeforeGroupingMap = StreamsGroupingCollectionFilter.findEvenNumbersBeforeGroupingByQuantityOfDigits(BASE_INTEGER_COLLECTION);
+
+        assertThat(filteredAfterGroupingMap).containsAllEntriesOf(EXPECTED_EVEN_FILTERED_AFTER_GROUPING_MAP);
+        assertThat(filteredBeforeGroupingMap).doesNotContainKey(3)
+            .containsAllEntriesOf(EXPECTED_EVEN_FILTERED_BEFORE_GROUPING_MAP);
+    }
+
+}

--- a/core-java-collections/pom.xml
+++ b/core-java-collections/pom.xml
@@ -39,12 +39,12 @@
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections-api</artifactId>
-            <version>9.2.0</version>
+            <version>${eclipse.collections.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
-            <version>9.2.0</version>
+            <version>${eclipse.collections.version}</version>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
@@ -67,5 +67,6 @@
         <collections-generic.version>4.01</collections-generic.version>
         <avaitility.version>1.7.0</avaitility.version>
         <assertj.version>3.6.1</assertj.version>
+        <eclipse.collections.version>9.2.0</eclipse.collections.version>
     </properties>
 </project>

--- a/core-java-collections/pom.xml
+++ b/core-java-collections/pom.xml
@@ -37,14 +37,31 @@
             <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+            <version>9.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+            <version>9.2.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-runner</artifactId>
+            <version>${junit.platform.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>
+        <junit.platform.version>1.2.0</junit.platform.version>
         <commons-lang3.version>3.5</commons-lang3.version>
         <commons-collections4.version>4.1</commons-collections4.version>
         <collections-generic.version>4.01</collections-generic.version>

--- a/core-java-collections/src/main/java/com/baeldung/java/filtering/CollectionUtilsCollectionFilter.java
+++ b/core-java-collections/src/main/java/com/baeldung/java/filtering/CollectionUtilsCollectionFilter.java
@@ -8,13 +8,7 @@ import org.apache.commons.collections4.Predicate;
 public class CollectionUtilsCollectionFilter {
 
     static public Collection<Integer> findEvenNumbers(Collection<Integer> baseCollection) {
-        Predicate<Integer> apacheEventNumberPredicate = new Predicate<Integer>() {
-
-            @Override
-            public boolean evaluate(Integer object) {
-                return object % 2 == 0;
-            }
-        };
+        Predicate<Integer> apacheEventNumberPredicate = item -> item % 2 == 0;
 
         CollectionUtils.filter(baseCollection, apacheEventNumberPredicate);
         return baseCollection;

--- a/core-java-collections/src/main/java/com/baeldung/java/filtering/CollectionUtilsCollectionFilter.java
+++ b/core-java-collections/src/main/java/com/baeldung/java/filtering/CollectionUtilsCollectionFilter.java
@@ -1,0 +1,22 @@
+package com.baeldung.java.filtering;
+
+import java.util.Collection;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
+
+public class CollectionUtilsCollectionFilter {
+
+    static public Collection<Integer> findEvenNumbers(Collection<Integer> baseCollection) {
+        Predicate<Integer> apacheEventNumberPredicate = new Predicate<Integer>() {
+
+            @Override
+            public boolean evaluate(Integer object) {
+                return object % 2 == 0;
+            }
+        };
+
+        CollectionUtils.filter(baseCollection, apacheEventNumberPredicate);
+        return baseCollection;
+    }
+}

--- a/core-java-collections/src/main/java/com/baeldung/java/filtering/EclipseCollectionsCollectionFilter.java
+++ b/core-java-collections/src/main/java/com/baeldung/java/filtering/EclipseCollectionsCollectionFilter.java
@@ -1,0 +1,32 @@
+package com.baeldung.java.filtering;
+
+import java.util.Collection;
+
+import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.utility.Iterate;
+
+public class EclipseCollectionsCollectionFilter {
+
+    static public Collection<Integer> findEvenNumbers(Collection<Integer> baseCollection) {
+        Predicate<Integer> eclipsePredicate = item -> item % 2 == 0;
+        Collection<Integer> filteredList = Lists.mutable.ofAll(baseCollection)
+            .select(eclipsePredicate);
+
+        return filteredList;
+    }
+
+    static public Collection<Integer> findEvenNumbersUsingIterate(Collection<Integer> baseCollection) {
+        Predicate<Integer> eclipsePredicate = new Predicate<Integer>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public boolean accept(Integer arg0) {
+                return arg0 % 2 == 0;
+            }
+        };
+        Collection<Integer> filteredList = Iterate.select(baseCollection, eclipsePredicate);
+
+        return filteredList;
+    }
+}

--- a/core-java-collections/src/main/java/com/baeldung/java/filtering/GuavaCollectionFilter.java
+++ b/core-java-collections/src/main/java/com/baeldung/java/filtering/GuavaCollectionFilter.java
@@ -8,13 +8,8 @@ import com.google.common.collect.Collections2;
 public class GuavaCollectionFilter {
 
     static public Collection<Integer> findEvenNumbers(Collection<Integer> baseCollection) {
-        Predicate<Integer> guavaPredicate = new Predicate<Integer>() {
+        Predicate<Integer> guavaPredicate = item -> item % 2 == 0;
 
-            @Override
-            public boolean apply(Integer input) {
-                return input % 2 == 0;
-            }
-        };
         Collection<Integer> filteredCollection = Collections2.filter(baseCollection, guavaPredicate);
         return filteredCollection;
     }

--- a/core-java-collections/src/main/java/com/baeldung/java/filtering/GuavaCollectionFilter.java
+++ b/core-java-collections/src/main/java/com/baeldung/java/filtering/GuavaCollectionFilter.java
@@ -1,0 +1,22 @@
+package com.baeldung.java.filtering;
+
+import java.util.Collection;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+
+public class GuavaCollectionFilter {
+
+    static public Collection<Integer> findEvenNumbers(Collection<Integer> baseCollection) {
+        Predicate<Integer> guavaPredicate = new Predicate<Integer>() {
+
+            @Override
+            public boolean apply(Integer input) {
+                return input % 2 == 0;
+            }
+        };
+        Collection<Integer> filteredCollection = Collections2.filter(baseCollection, guavaPredicate);
+        return filteredCollection;
+    }
+
+}

--- a/core-java-collections/src/main/java/com/baeldung/java/filtering/StreamsCollectionFilter.java
+++ b/core-java-collections/src/main/java/com/baeldung/java/filtering/StreamsCollectionFilter.java
@@ -16,22 +16,11 @@ public class StreamsCollectionFilter {
         return filterCollectionHelperMethod(baseCollection, item -> item % 2 == 0);
     }
 
-    static public Collection<Integer> findEvenNumbersUsingLambda(Collection<Integer> baseCollection) {
-        return baseCollection.stream()
-            .filter(item -> item % 2 == 0)
-            .collect(Collectors.toList());
-    }
-
-    static public Collection<Integer> findEvenNumbersUsingPredicate(Collection<Integer> baseCollection) {
-        Predicate<Integer> evenNumberPredicate = new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer i) {
-                return i % 2 == 0;
-            }
-        };
+    static public Collection<Integer> findEvenNumbers(Collection<Integer> baseCollection) {
+        Predicate<Integer> streamsPredicate = item -> item % 2 == 0;
 
         return baseCollection.stream()
-            .filter(evenNumberPredicate)
+            .filter(streamsPredicate)
             .collect(Collectors.toList());
     }
 }

--- a/core-java-collections/src/main/java/com/baeldung/java/filtering/StreamsCollectionFilter.java
+++ b/core-java-collections/src/main/java/com/baeldung/java/filtering/StreamsCollectionFilter.java
@@ -1,0 +1,37 @@
+package com.baeldung.java.filtering;
+
+import java.util.Collection;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class StreamsCollectionFilter {
+
+    public static <T> Collection<T> filterCollectionHelperMethod(Collection<T> baseCollection, Predicate<T> predicate) {
+        return baseCollection.stream()
+            .filter(predicate)
+            .collect(Collectors.toList());
+    }
+
+    static public Collection<Integer> findEvenNumbersUsingHelperMethod(Collection<Integer> baseCollection) {
+        return filterCollectionHelperMethod(baseCollection, item -> item % 2 == 0);
+    }
+
+    static public Collection<Integer> findEvenNumbersUsingLambda(Collection<Integer> baseCollection) {
+        return baseCollection.stream()
+            .filter(item -> item % 2 == 0)
+            .collect(Collectors.toList());
+    }
+
+    static public Collection<Integer> findEvenNumbersUsingPredicate(Collection<Integer> baseCollection) {
+        Predicate<Integer> evenNumberPredicate = new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer i) {
+                return i % 2 == 0;
+            }
+        };
+
+        return baseCollection.stream()
+            .filter(evenNumberPredicate)
+            .collect(Collectors.toList());
+    }
+}

--- a/core-java-collections/src/test/java/com/baeldung/java/filtering/CollectionFiltersUnitTest.java
+++ b/core-java-collections/src/test/java/com/baeldung/java/filtering/CollectionFiltersUnitTest.java
@@ -27,15 +27,13 @@ public class CollectionFiltersUnitTest {
 
     @Test
     public void givenAnIntegerCollection_whenFilteringEvenValues_thenObtainTheFilteredCollectionForAllCases() {
-        Collection<Integer> filteredWithStreams1 = StreamsCollectionFilter.findEvenNumbersUsingLambda(BASE_INTEGER_COLLECTION);
-        Collection<Integer> filteredWithStreams2 = StreamsCollectionFilter.findEvenNumbersUsingPredicate(BASE_INTEGER_COLLECTION);
+        Collection<Integer> filteredWithStreams1 = StreamsCollectionFilter.findEvenNumbers(BASE_INTEGER_COLLECTION);
         Collection<Integer> filteredWithCollectionUtils = CollectionUtilsCollectionFilter.findEvenNumbers(new ArrayList<>(BASE_INTEGER_COLLECTION));
         Collection<Integer> filteredWithEclipseCollections = EclipseCollectionsCollectionFilter.findEvenNumbers(BASE_INTEGER_COLLECTION);
         Collection<Integer> filteredWithEclipseCollectionsUsingIterate = EclipseCollectionsCollectionFilter.findEvenNumbersUsingIterate(BASE_INTEGER_COLLECTION);
         Collection<Integer> filteredWithGuava = GuavaCollectionFilter.findEvenNumbers(BASE_INTEGER_COLLECTION);
 
-        assertThat(filteredWithStreams1).hasSameElementsAs(filteredWithStreams2)
-            .hasSameElementsAs(filteredWithCollectionUtils)
+        assertThat(filteredWithStreams1).hasSameElementsAs(filteredWithCollectionUtils)
             .hasSameElementsAs(filteredWithEclipseCollections)
             .hasSameElementsAs(filteredWithEclipseCollectionsUsingIterate)
             .hasSameElementsAs(filteredWithEclipseCollectionsUsingIterate)

--- a/core-java-collections/src/test/java/com/baeldung/java/filtering/CollectionFiltersUnitTest.java
+++ b/core-java-collections/src/test/java/com/baeldung/java/filtering/CollectionFiltersUnitTest.java
@@ -1,0 +1,46 @@
+package com.baeldung.java.filtering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+public class CollectionFiltersUnitTest {
+
+    private static final Collection<Integer> BASE_INTEGER_COLLECTION = Arrays.asList(9, 14, 2, 7, 1, 5, 8);
+    private static final Collection<Integer> EXPECTED_EVEN_FILTERED_COLLECTION = Arrays.asList(14, 2, 8);
+
+    @Test
+    public void givenAStringCollection_whenFilteringFourLetterWords_thenObtainTheFilteredCollection() {
+        final Collection<String> baseStrings = Arrays.asList("java", "baeldung", "type", "example", "other");
+
+        Collection<String> filtered = StreamsCollectionFilter.filterCollectionHelperMethod(baseStrings, item -> item.length() == 4);
+
+        assertThat(filtered).containsExactlyInAnyOrder("java", "type");
+    }
+
+    @Test
+    public void givenAnIntegerCollection_whenFilteringEvenValues_thenObtainTheFilteredCollectionForAllCases() {
+        Collection<Integer> filteredWithStreams1 = StreamsCollectionFilter.findEvenNumbersUsingLambda(BASE_INTEGER_COLLECTION);
+        Collection<Integer> filteredWithStreams2 = StreamsCollectionFilter.findEvenNumbersUsingPredicate(BASE_INTEGER_COLLECTION);
+        Collection<Integer> filteredWithCollectionUtils = CollectionUtilsCollectionFilter.findEvenNumbers(new ArrayList<>(BASE_INTEGER_COLLECTION));
+        Collection<Integer> filteredWithEclipseCollections = EclipseCollectionsCollectionFilter.findEvenNumbers(BASE_INTEGER_COLLECTION);
+        Collection<Integer> filteredWithEclipseCollectionsUsingIterate = EclipseCollectionsCollectionFilter.findEvenNumbersUsingIterate(BASE_INTEGER_COLLECTION);
+        Collection<Integer> filteredWithGuava = GuavaCollectionFilter.findEvenNumbers(BASE_INTEGER_COLLECTION);
+
+        assertThat(filteredWithStreams1).hasSameElementsAs(filteredWithStreams2)
+            .hasSameElementsAs(filteredWithCollectionUtils)
+            .hasSameElementsAs(filteredWithEclipseCollections)
+            .hasSameElementsAs(filteredWithEclipseCollectionsUsingIterate)
+            .hasSameElementsAs(filteredWithEclipseCollectionsUsingIterate)
+            .hasSameElementsAs(filteredWithGuava)
+            .hasSameElementsAs(EXPECTED_EVEN_FILTERED_COLLECTION);
+    }
+
+}


### PR DESCRIPTION
Note: _mvn clean install_ FAILS (at least locally) in module 'core-java-9' due to PMD violations, the reason seems to be that it finds test classes that doesn't match the expected pattern (*UnitTest.java, *IntegrationTest.java,... )

Jira: http://jira.baeldung.com/browse/BAEL-2026

IP: http://inprogress.baeldung.com/wp-admin/post.php?post=98524&action=edit