### PR TITLE
spring-5-reactive-security: fixing EmployeeControllerIntegrationTest

### DIFF
--- a/spring-5-reactive-security/src/test/java/com/baeldung/reactive/webflux/EmployeeControllerIntegrationTest.java
+++ b/spring-5-reactive-security/src/test/java/com/baeldung/reactive/webflux/EmployeeControllerIntegrationTest.java
@@ -15,7 +15,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import com.baeldung.reactive.actuator.Spring5ReactiveApplication;
+import com.baeldung.webflux.EmployeeSpringApplication;
 import com.baeldung.webflux.Employee;
 import com.baeldung.webflux.EmployeeRepository;
 
@@ -23,7 +23,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes=Spring5ReactiveApplication.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes=EmployeeSpringApplication.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class EmployeeControllerIntegrationTest {
 


### PR DESCRIPTION
Hi,

it seems that `com.baeldung.reactive.webflux.EmployeeControllerIntegrationTest` in the project `spring-5-reactive-security` is red at the moment:

```
cd spring-5-reactive-security
mvn test -Dtest=EmployeeControllerIntegrationTest -Dgib.enabled=false
```

=>

```
[ERROR] Failures: 
[ERROR]   EmployeeControllerIntegrationTest.givenEmployeeId_whenGetEmployeeById_thenCorrectEmployee:46 Status expected:<200> but was:<404>
...
[ERROR]   EmployeeControllerIntegrationTest.whenGetAllEmployees_thenCorrectEmployees:71 Status expected:<200> but was:<404>
```

Changing the `classes` property of the `@SpringBootTest` should fix it:

=>

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 28.8 s - in com.baeldung.reactive.webflux.EmployeeControllerIntegrationTest
```