### PR TITLE
BAEL-9683 Fix tutorials default-first build - ref# 156

### DIFF
--- a/java-numbers/src/test/java/com/baeldung/maths/MathSinUnitTest.java
+++ b/java-numbers/src/test/java/com/baeldung/maths/MathSinUnitTest.java
@@ -1,20 +1,21 @@
 package com.baeldung.maths;
 
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 public class MathSinUnitTest {
 
-    @Test
-    public void givenAnAngleInDegrees_whenUsingToRadians_thenResultIsInRadians() {
-        double angleInDegrees = 30;
-        double sinForDegrees = Math.sin(Math.toRadians(angleInDegrees)); // 0.5
+	@Test
+	public void givenAnAngleInDegrees_whenUsingToRadians_thenResultIsInRadians() {
+		double angleInDegrees = 30;
+		double sinForDegrees = Math.sin(Math.toRadians(angleInDegrees)); // 0.5
 
-        double thirtyDegreesInRadians = 1/6 * Math.PI;
-        double sinForRadians = Math.sin(thirtyDegreesInRadians); // 0.5
+		double thirtyDegreesInRadians = (double) 1 / 6 * Math.PI;
+		double sinForRadians = Math.sin(thirtyDegreesInRadians); // 0.5
 
-        assertTrue(sinForDegrees == sinForRadians);
-    }
+		assertThat(sinForDegrees, is(sinForRadians));
+	}
 
 }

--- a/java-numbers/src/test/java/com/baeldung/maths/MathSinUnitTest.java
+++ b/java-numbers/src/test/java/com/baeldung/maths/MathSinUnitTest.java
@@ -7,15 +7,15 @@ import org.junit.jupiter.api.Test;
 
 public class MathSinUnitTest {
 
-	@Test
-	public void givenAnAngleInDegrees_whenUsingToRadians_thenResultIsInRadians() {
-		double angleInDegrees = 30;
-		double sinForDegrees = Math.sin(Math.toRadians(angleInDegrees)); // 0.5
+    @Test
+    public void givenAnAngleInDegrees_whenUsingToRadians_thenResultIsInRadians() {
+        double angleInDegrees = 30;
+        double sinForDegrees = Math.sin(Math.toRadians(angleInDegrees)); // 0.5
 
-		double thirtyDegreesInRadians = (double) 1 / 6 * Math.PI;
-		double sinForRadians = Math.sin(thirtyDegreesInRadians); // 0.5
+        double thirtyDegreesInRadians = (double) 1 / 6 * Math.PI;
+        double sinForRadians = Math.sin(thirtyDegreesInRadians); // 0.5
 
-		assertThat(sinForDegrees, is(sinForRadians));
-	}
+        assertThat(sinForDegrees, is(sinForRadians));
+    }
 
 }


### PR DESCRIPTION
- Fix assertion error - loss of precision was happening because double was being divided by an integer