### PR TITLE
use of static variables is concurrency problem

### DIFF
--- a/spring-thymeleaf/src/main/java/com/baeldung/thymeleaf/controller/BookController.java
+++ b/spring-thymeleaf/src/main/java/com/baeldung/thymeleaf/controller/BookController.java
@@ -2,6 +2,7 @@ package com.baeldung.thymeleaf.controller;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -21,18 +22,18 @@ import com.baeldung.thymeleaf.service.BookService;
 @Controller
 public class BookController {
 
-    private static int currentPage = 1;
-    private static int pageSize = 5;
 
     @Autowired
     private BookService bookService;
-  
+
     @RequestMapping(value = "/listBooks", method = RequestMethod.GET)
     public String listBooks(Model model, @RequestParam("page") Optional<Integer> page, @RequestParam("size") Optional<Integer> size) {
-        page.ifPresent(p -> currentPage = p);
-        size.ifPresent(s -> pageSize = s);
+        AtomicInteger currentPage = new AtomicInteger(1);
+        AtomicInteger pageSize = new AtomicInteger(5);
+        page.ifPresent(p -> currentPage.set(p));
+        size.ifPresent(s -> pageSize.set(s));
 
-        Page<Book> bookPage = bookService.findPaginated(PageRequest.of(currentPage - 1, pageSize));
+        Page<Book> bookPage = bookService.findPaginated(PageRequest.of(currentPage.get() - 1, pageSize.get()));
 
         model.addAttribute("bookPage", bookPage);
 

--- a/spring-thymeleaf/src/main/java/com/baeldung/thymeleaf/controller/BookController.java
+++ b/spring-thymeleaf/src/main/java/com/baeldung/thymeleaf/controller/BookController.java
@@ -26,8 +26,8 @@ public class BookController {
 
     @RequestMapping(value = "/listBooks", method = RequestMethod.GET)
     public String listBooks(Model model, @RequestParam("page") Optional<Integer> page, @RequestParam("size") Optional<Integer> size) {
-        int currentPage = page.orElse(1);
-        int pageSize = size.orElse(5);
+        final int currentPage = page.orElse(1);
+        final int pageSize = size.orElse(5);
 
         Page<Book> bookPage = bookService.findPaginated(PageRequest.of(currentPage - 1, pageSize));
 

--- a/spring-thymeleaf/src/main/java/com/baeldung/thymeleaf/controller/BookController.java
+++ b/spring-thymeleaf/src/main/java/com/baeldung/thymeleaf/controller/BookController.java
@@ -26,8 +26,8 @@ public class BookController {
 
     @RequestMapping(value = "/listBooks", method = RequestMethod.GET)
     public String listBooks(Model model, @RequestParam("page") Optional<Integer> page, @RequestParam("size") Optional<Integer> size) {
-        int currentPage = page.isPresent()?page.get():5;
-        int pageSize = size.isPresent()?size.get():1;
+        int currentPage = page.orElse(1);
+        int pageSize = size.orElse(5);
 
         Page<Book> bookPage = bookService.findPaginated(PageRequest.of(currentPage - 1, pageSize));
 

--- a/spring-thymeleaf/src/main/java/com/baeldung/thymeleaf/controller/BookController.java
+++ b/spring-thymeleaf/src/main/java/com/baeldung/thymeleaf/controller/BookController.java
@@ -2,7 +2,6 @@ package com.baeldung.thymeleaf.controller;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -22,18 +21,15 @@ import com.baeldung.thymeleaf.service.BookService;
 @Controller
 public class BookController {
 
-
     @Autowired
     private BookService bookService;
 
     @RequestMapping(value = "/listBooks", method = RequestMethod.GET)
     public String listBooks(Model model, @RequestParam("page") Optional<Integer> page, @RequestParam("size") Optional<Integer> size) {
-        AtomicInteger currentPage = new AtomicInteger(1);
-        AtomicInteger pageSize = new AtomicInteger(5);
-        page.ifPresent(p -> currentPage.set(p));
-        size.ifPresent(s -> pageSize.set(s));
+        int currentPage = page.isPresent()?page.get():5;
+        int pageSize = size.isPresent()?size.get():1;
 
-        Page<Book> bookPage = bookService.findPaginated(PageRequest.of(currentPage.get() - 1, pageSize.get()));
+        Page<Book> bookPage = bookService.findPaginated(PageRequest.of(currentPage - 1, pageSize));
 
         model.addAttribute("bookPage", bookPage);
 


### PR DESCRIPTION
Studying this tutorial code I noticed that it stores the current users request for a page of results in class static variables then reads those variables to render the page. If we get two concurrent requests we could have a second request clobber the first requests passed values and render the wrong page to the first user. 

If I try to make those values local variables the compiler says that "variable used in lamba expression should be final or effectively final". Intellij then suggests making them static, which is a concurrency bug, or atomic, and it performs the refactor to use local atomic variables which touches a lot of code to both declare, set and get the atomics. 

Using `orElse` to default the value is less code and does the job. Making them final also makes it clearer that they are parameters passed by the user and that allowing parameters to change in a method makes it harder to maintain code.  