### PR TITLE
FileOutputStream is never closed

### DIFF
--- a/core-java-io/src/main/java/com/baeldung/download/FileDownload.java
+++ b/core-java-io/src/main/java/com/baeldung/download/FileDownload.java
@@ -45,6 +45,7 @@ public class FileDownload {
             FileOutputStream fileOutputStream = new FileOutputStream(localFilename); FileChannel fileChannel = fileOutputStream.getChannel()) {
 
             fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+            fileOutputStream.close();
         }
     }
 


### PR DESCRIPTION
The output file stream is not closed, so it is still in use by the Java process after the code runs. I noticed this when trying to delete the output files right afterwards.