### PR TITLE
[BAEL-10301] core-java | fix unit tests

### DIFF
--- a/core-java/src/test/java/com/baeldung/abstractclasses/LowercaseFileReaderUnitTest.java
+++ b/core-java/src/test/java/com/baeldung/abstractclasses/LowercaseFileReaderUnitTest.java
@@ -2,17 +2,22 @@ package com.baeldung.abstractclasses;
 
 import com.baeldung.abstractclasses.filereaders.BaseFileReader;
 import com.baeldung.abstractclasses.filereaders.LowercaseFileReader;
+
+import java.net.URL;
+import java.nio.file.Paths;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
 public class LowercaseFileReaderUnitTest {
-    
+
     @Test
     public void givenLowercaseFileReaderInstance_whenCalledreadFile_thenCorrect() throws Exception {
-        String filePath = getClass().getClassLoader().getResource("files/test.txt").getPath().substring(1);
+        // We'll transform the resource URL path to URI to load the file correctly in Windows
+        URL url = getClass().getClassLoader().getResource("files/test.txt");
+        String filePath = Paths.get(url.toURI()).toString();
         BaseFileReader lowercaseFileReader = new LowercaseFileReader(filePath);
-        
+
         assertThat(lowercaseFileReader.readFile()).isInstanceOf(List.class);
     }
 }

--- a/core-java/src/test/java/com/baeldung/abstractclasses/StandardFileReaderUnitTest.java
+++ b/core-java/src/test/java/com/baeldung/abstractclasses/StandardFileReaderUnitTest.java
@@ -1,16 +1,23 @@
 package com.baeldung.abstractclasses;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.Test;
+
 import com.baeldung.abstractclasses.filereaders.BaseFileReader;
 import com.baeldung.abstractclasses.filereaders.StandardFileReader;
-import java.util.List;
-import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.Test;
 
 public class StandardFileReaderUnitTest {
 
     @Test
     public void givenStandardFileReaderInstance_whenCalledreadFile_thenCorrect() throws Exception {
-        String filePath = getClass().getClassLoader().getResource("files/test.txt").getPath().substring(1);
+        // We'll transform the resource URL path to URI to load the file correctly in Windows 
+        URL url = getClass().getClassLoader().getResource("files/test.txt");
+        String filePath = Paths.get(url.toURI()).toString();
         BaseFileReader standardFileReader = new StandardFileReader(filePath);
         
         assertThat(standardFileReader.readFile()).isInstanceOf(List.class);

--- a/core-java/src/test/java/com/baeldung/abstractclasses/UppercaseFileReaderUnitTest.java
+++ b/core-java/src/test/java/com/baeldung/abstractclasses/UppercaseFileReaderUnitTest.java
@@ -2,6 +2,9 @@ package com.baeldung.abstractclasses;
 
 import com.baeldung.abstractclasses.filereaders.BaseFileReader;
 import com.baeldung.abstractclasses.filereaders.UppercaseFileReader;
+
+import java.net.URL;
+import java.nio.file.Paths;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
@@ -10,7 +13,9 @@ public class UppercaseFileReaderUnitTest {
 
     @Test
     public void givenUppercaseFileReaderInstance_whenCalledreadFile_thenCorrect() throws Exception {
-        String filePath = getClass().getClassLoader().getResource("files/test.txt").getPath().substring(1);
+        // We'll transform the resource URL path to URI to load the file correctly in Windows 
+        URL url = getClass().getClassLoader().getResource("files/test.txt");
+        String filePath = Paths.get(url.toURI()).toString();
         BaseFileReader uppercaseFileReader = new UppercaseFileReader(filePath);
         
         assertThat(uppercaseFileReader.readFile()).isInstanceOf(List.class);

--- a/core-java/src/test/java/com/baeldung/simpledateformat/SimpleDateFormatUnitTest.java
+++ b/core-java/src/test/java/com/baeldung/simpledateformat/SimpleDateFormatUnitTest.java
@@ -25,7 +25,7 @@ public class SimpleDateFormatUnitTest {
 
   @Test
   public void givenSpecificDate_whenFormattedUsingDateFormat_thenCheckFormatCorrect() throws Exception {
-    DateFormat formatter = DateFormat.getDateInstance(DateFormat.SHORT);
+    DateFormat formatter = DateFormat.getDateInstance(DateFormat.SHORT, Locale.US);
     assertEquals("5/24/77", formatter.format(new Date(233345223232L)));
   }
 


### PR DESCRIPTION
Fixed:
* SimpleDateFormatUnitTest test, which formerly relied on the system locale to format a date.
* UppercaseFileReaderUnitTest, LowercaseFileReaderUnitTest and StandardFileReaderUnitTest, which were using an approach to generate a resource path that seems to be efficient only on Windows; on Linux it raises an exception when loading the resource. The new approach should be good for all cases, but we need further testing on a Windows environment