### PR TITLE
[BAEL-9524] spring-boot | parent-boot-1 to parent-boot-2 for spring-boot

### DIFF
--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -179,7 +179,6 @@
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
                 <version>${git-commit-id-plugin.version}</version>
-
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>
@@ -196,7 +195,6 @@
                         <phase>package</phase>
                     </execution>
                 </executions>
-
                 <configuration>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-boot</artifactId>
@@ -54,6 +55,14 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-ehcache</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -143,10 +152,10 @@
             <artifactId>chaos-monkey-spring-boot</artifactId>
             <version>${chaos.monkey.version}</version>
         </dependency>
-        
+
         <dependency>
-        	<groupId>javax.validation</groupId>
-        	<artifactId>validation-api</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
     </dependencies>
 
@@ -170,6 +179,28 @@
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
                 <version>${git-commit-id-plugin.version}</version>
+
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                    <execution>
+                        <id>validate-the-git-infos</id>
+                        <goals>
+                            <goal>validateRevision</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                </configuration>
             </plugin>
 
         </plugins>
@@ -223,7 +254,7 @@
         <graphql-spring-boot-starter.version>3.6.0</graphql-spring-boot-starter.version>
         <graphql-java-tools.version>3.2.0</graphql-java-tools.version>
         <guava.version>18.0</guava.version>
-		<git-commit-id-plugin.version>2.2.4</git-commit-id-plugin.version>
+        <git-commit-id-plugin.version>2.2.4</git-commit-id-plugin.version>
     </properties>
 
 </project>

--- a/spring-boot/src/main/java/com/baeldung/dynamicvalidation/ContactInfoValidator.java
+++ b/spring-boot/src/main/java/com/baeldung/dynamicvalidation/ContactInfoValidator.java
@@ -30,7 +30,7 @@ public class ContactInfoValidator implements ConstraintValidator<ContactInfo, St
         if (StringUtils.isEmptyOrWhitespace(expressionType)) {
             LOG.error("Contact info type missing!");
         } else {
-            pattern = expressionRepository.findOne(expressionType).map(ContactInfoExpression::getPattern).orElse("");
+            pattern = expressionRepository.findById(expressionType).map(ContactInfoExpression::getPattern).orElse("");
         }
     }
 

--- a/spring-boot/src/main/java/com/baeldung/dynamicvalidation/DynamicValidationApp.java
+++ b/spring-boot/src/main/java/com/baeldung/dynamicvalidation/DynamicValidationApp.java
@@ -9,7 +9,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class DynamicValidationApp {
     @RolesAllowed("*")
     public static void main(String[] args) {
-        System.setProperty("security.basic.enabled", "false");
         SpringApplication.run(DynamicValidationApp.class, args);
     }
+    
+    
 }

--- a/spring-boot/src/main/java/com/baeldung/dynamicvalidation/DynamicValidationApp.java
+++ b/spring-boot/src/main/java/com/baeldung/dynamicvalidation/DynamicValidationApp.java
@@ -11,6 +11,4 @@ public class DynamicValidationApp {
     public static void main(String[] args) {
         SpringApplication.run(DynamicValidationApp.class, args);
     }
-    
-    
 }

--- a/spring-boot/src/main/java/com/baeldung/dynamicvalidation/dao/ContactInfoExpressionRepository.java
+++ b/spring-boot/src/main/java/com/baeldung/dynamicvalidation/dao/ContactInfoExpressionRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.repository.Repository;
 import com.baeldung.dynamicvalidation.model.ContactInfoExpression;
 
 public interface ContactInfoExpressionRepository extends Repository<ContactInfoExpression, String> {
-    Optional<ContactInfoExpression> findOne(String id);
+    Optional<ContactInfoExpression> findById(String id);
 }

--- a/spring-boot/src/main/java/com/baeldung/failureanalyzer/FailureAnalyzerApplication.java
+++ b/spring-boot/src/main/java/com/baeldung/failureanalyzer/FailureAnalyzerApplication.java
@@ -9,7 +9,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class FailureAnalyzerApplication {
     @RolesAllowed("*")
     public static void main(String[] args) {
-        System.setProperty("security.basic.enabled", "false");
         SpringApplication.run(FailureAnalyzerApplication.class, args);
     }
 }

--- a/spring-boot/src/main/java/com/baeldung/internationalization/InternationalizationApp.java
+++ b/spring-boot/src/main/java/com/baeldung/internationalization/InternationalizationApp.java
@@ -9,7 +9,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class InternationalizationApp {
     @RolesAllowed("*")
     public static void main(String[] args) {
-        System.setProperty("security.basic.enabled", "false");
         SpringApplication.run(InternationalizationApp.class, args);
     }
 }

--- a/spring-boot/src/main/java/com/baeldung/rss/RssApp.java
+++ b/spring-boot/src/main/java/com/baeldung/rss/RssApp.java
@@ -1,10 +1,10 @@
 package com.baeldung.rss;
 
+import javax.annotation.security.RolesAllowed;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
-
-import javax.annotation.security.RolesAllowed;
 
 @SpringBootApplication
 @ComponentScan(basePackages = "com.baeldung.rss")
@@ -12,7 +12,6 @@ public class RssApp {
 
     @RolesAllowed("*")
     public static void main(String[] args) {
-        System.setProperty("security.basic.enabled", "false");
         SpringApplication.run(RssApp.class, args);
     }
 

--- a/spring-boot/src/main/java/com/baeldung/toggle/ToggleApplication.java
+++ b/spring-boot/src/main/java/com/baeldung/toggle/ToggleApplication.java
@@ -9,7 +9,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class ToggleApplication {
     @RolesAllowed("*")
     public static void main(String[] args) {
-        System.setProperty("security.basic.enabled", "false");
         SpringApplication.run(ToggleApplication.class, args);
     }
 }

--- a/spring-boot/src/main/java/org/baeldung/session/exception/Application.java
+++ b/spring-boot/src/main/java/org/baeldung/session/exception/Application.java
@@ -4,8 +4,6 @@ import org.baeldung.demo.model.Foo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.context.annotation.Bean;
-import org.springframework.orm.jpa.vendor.HibernateJpaSessionFactoryBean;
 
 @EntityScan(basePackageClasses = Foo.class)
 @SpringBootApplication
@@ -14,10 +12,5 @@ public class Application {
         System.setProperty("spring.config.name", "exception");
         System.setProperty("spring.profiles.active", "exception");
         SpringApplication.run(Application.class, args);
-    }
-
-    @Bean
-    public HibernateJpaSessionFactoryBean sessionFactory() {
-        return new HibernateJpaSessionFactoryBean();
     }
 }

--- a/spring-boot/src/main/java/org/baeldung/session/exception/repository/FooRepositoryImpl.java
+++ b/spring-boot/src/main/java/org/baeldung/session/exception/repository/FooRepositoryImpl.java
@@ -1,5 +1,7 @@
 package org.baeldung.session.exception.repository;
 
+import javax.persistence.EntityManagerFactory;
+
 import org.baeldung.demo.model.Foo;
 import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,16 +12,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class FooRepositoryImpl implements FooRepository {
     @Autowired
-    private SessionFactory sessionFactory;
+    private EntityManagerFactory emf;
 
     @Override
     public void save(Foo foo) {
-        sessionFactory.getCurrentSession().saveOrUpdate(foo);
+        emf.unwrap(SessionFactory.class).getCurrentSession().saveOrUpdate(foo);
     }
 
     @Override
     public Foo get(Integer id) {
-        return sessionFactory.getCurrentSession().get(Foo.class, id);
+        return emf.unwrap(SessionFactory.class).getCurrentSession().get(Foo.class, id);
     }
-
 }

--- a/spring-boot/src/main/resources/application.properties
+++ b/spring-boot/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto = update
 
 management.endpoints.jmx.domain=Spring Sample Application
-management.endpoints.jmx.uniqueNames=true
+spring.jmx.unique-names=true
 
 management.endpoints.web.exposure.include=*
 management.endpoint.shutdown.enabled=true
@@ -17,7 +17,6 @@ management.endpoint.shutdown.enabled=true
 ##endpoints.jolokia.path=jolokia
 
 spring.jmx.enabled=true
-management.endpoints.jmx.enabled=true
 
 ## for pretty printing of json when endpoints accessed over HTTP
 http.mappers.jsonPrettyPrint=true

--- a/spring-boot/src/test/java/com/baeldung/annotation/servletcomponentscan/SpringBootWithServletComponentIntegrationTest.java
+++ b/spring-boot/src/test/java/com/baeldung/annotation/servletcomponentscan/SpringBootWithServletComponentIntegrationTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SpringBootAnnotatedApp.class)
-@TestPropertySource(properties = { "security.basic.enabled=false" })
 public class SpringBootWithServletComponentIntegrationTest {
 
     @Autowired

--- a/spring-boot/src/test/java/com/baeldung/annotation/servletcomponentscan/SpringBootWithoutServletComponentIntegrationTest.java
+++ b/spring-boot/src/test/java/com/baeldung/annotation/servletcomponentscan/SpringBootWithoutServletComponentIntegrationTest.java
@@ -19,7 +19,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SpringBootPlainApp.class)
-@TestPropertySource(properties = { "security.basic.enabled=false" })
 public class SpringBootWithoutServletComponentIntegrationTest {
 
     @Autowired

--- a/spring-boot/src/test/java/com/baeldung/displayallbeans/DisplayBeanIntegrationTest.java
+++ b/spring-boot/src/test/java/com/baeldung/displayallbeans/DisplayBeanIntegrationTest.java
@@ -1,31 +1,34 @@
 package com.baeldung.displayallbeans;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.beans.BeansEndpoint.ContextBeans;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.context.WebApplicationContext;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties = { "management.port=0", "endpoints.beans.id=springbeans", "endpoints.beans.sensitive=false" })
+@TestPropertySource(properties = { "management.port=0", "management.endpoints.web.exposure.include=*" })
 public class DisplayBeanIntegrationTest {
 
     @LocalServerPort
@@ -40,6 +43,8 @@ public class DisplayBeanIntegrationTest {
     @Autowired
     private WebApplicationContext context;
 
+    private static final String ACTUATOR_PATH = "/actuator";
+
     @Test
     public void givenRestTemplate_whenAccessServerUrl_thenHttpStatusOK() throws Exception {
         ResponseEntity<String> entity = this.testRestTemplate.getForEntity("http://localhost:" + this.port + "/displayallbeans", String.class);
@@ -49,22 +54,27 @@ public class DisplayBeanIntegrationTest {
 
     @Test
     public void givenRestTemplate_whenAccessEndpointUrl_thenHttpStatusOK() throws Exception {
-        @SuppressWarnings("rawtypes")
-        ResponseEntity<List> entity = this.testRestTemplate.getForEntity("http://localhost:" + this.mgt + "/springbeans", List.class);
+        ParameterizedTypeReference<Map<String, ContextBeans>> responseType = new ParameterizedTypeReference<Map<String, ContextBeans>>() {
+        };
+        RequestEntity<Void> requestEntity = RequestEntity.get(new URI("http://localhost:" + this.mgt + ACTUATOR_PATH + "/beans"))
+            .accept(MediaType.APPLICATION_JSON)
+            .build();
+        ResponseEntity<Map<String, ContextBeans>> entity = this.testRestTemplate.exchange(requestEntity, responseType);
 
         then(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     @Test
     public void givenRestTemplate_whenAccessEndpointUrl_thenReturnsBeanNames() throws Exception {
-        @SuppressWarnings("rawtypes")
-        ResponseEntity<List> entity = this.testRestTemplate.getForEntity("http://localhost:" + this.mgt + "/springbeans", List.class);
+        RequestEntity<Void> requestEntity = RequestEntity.get(new URI("http://localhost:" + this.mgt + ACTUATOR_PATH + "/beans"))
+            .accept(MediaType.APPLICATION_JSON)
+            .build();
+        ResponseEntity<BeanActuatorResponse> entity = this.testRestTemplate.exchange(requestEntity, BeanActuatorResponse.class);
 
-        List<Map<String, Object>> allBeans = (List) ((Map) entity.getBody().get(0)).get("beans");
-        List<String> beanNamesList = allBeans.stream().map(x -> (String) x.get("bean")).collect(Collectors.toList());
+        Collection<String> beanNamesList = entity.getBody()
+            .getBeans();
 
-        assertThat(beanNamesList, hasItem("fooController"));
-        assertThat(beanNamesList, hasItem("fooService"));
+        assertThat(beanNamesList).contains("fooController", "fooService");
     }
 
     @Test
@@ -72,7 +82,20 @@ public class DisplayBeanIntegrationTest {
         String[] beanNames = context.getBeanDefinitionNames();
 
         List<String> beanNamesList = Arrays.asList(beanNames);
-        assertTrue(beanNamesList.contains("fooController"));
-        assertTrue(beanNamesList.contains("fooService"));
+        assertThat(beanNamesList).contains("fooController", "fooService");
+    }
+
+    private static class BeanActuatorResponse {
+        private Map<String, Map<String, Map<String, Map<String, Object>>>> contexts;
+
+        public Collection<String> getBeans() {
+            return this.contexts.get("application")
+                .get("beans")
+                .keySet();
+        }
+
+        public Map<String, Map<String, Map<String, Map<String, Object>>>> getContexts() {
+            return contexts;
+        }
     }
 }

--- a/spring-boot/src/test/java/com/baeldung/git/CommitIdIntegrationTest.java
+++ b/spring-boot/src/test/java/com/baeldung/git/CommitIdIntegrationTest.java
@@ -1,17 +1,19 @@
 package com.baeldung.git;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = CommitIdApplication.class)
+@TestPropertySource(properties = { "spring.jmx.default-domain=test" })
 public class CommitIdIntegrationTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(CommitIdIntegrationTest.class);

--- a/spring-boot/src/test/java/com/baeldung/intro/AppLiveTest.java
+++ b/spring-boot/src/test/java/com/baeldung/intro/AppLiveTest.java
@@ -18,7 +18,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
-@TestPropertySource(properties = { "security.basic.enabled=false" })
 public class AppLiveTest {
 
     @Autowired

--- a/spring-boot/src/test/java/com/baeldung/kong/KongLoadBalanceLiveTest.java
+++ b/spring-boot/src/test/java/com/baeldung/kong/KongLoadBalanceLiveTest.java
@@ -1,28 +1,34 @@
 package com.baeldung.kong;
 
-import com.baeldung.kong.domain.APIObject;
-import com.baeldung.kong.domain.TargetObject;
-import com.baeldung.kong.domain.UpstreamObject;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
+
+import java.net.URI;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.net.URI;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
+import com.baeldung.kong.domain.APIObject;
+import com.baeldung.kong.domain.TargetObject;
+import com.baeldung.kong.domain.UpstreamObject;
 
 /**
  * @author aiet
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = DEFINED_PORT, classes = StockApp.class)
+@SpringBootTest(webEnvironment = DEFINED_PORT, classes = StockApp.class, properties = "server.servlet.contextPath=/springbootapp")
 public class KongLoadBalanceLiveTest {
 
     @Before
@@ -55,13 +61,13 @@ public class KongLoadBalanceLiveTest {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Host", "balanced.stock.api");
         for (int i = 0; i < 1000; i++) {
-            RequestEntity<String> requestEntity = new RequestEntity<>(headers, HttpMethod.GET, new URI("http://localhost:8000/stock/btc"));
+            RequestEntity<String> requestEntity = new RequestEntity<>(headers, HttpMethod.GET, new URI("http://localhost:8000/springbootapp/stock/btc"));
             ResponseEntity<String> stockPriceResp = restTemplate.exchange(requestEntity, String.class);
             assertEquals("10000", stockPriceResp.getBody());
         }
 
-        int releaseCount = restTemplate.getForObject("http://localhost:9090/stock/reqcount", Integer.class);
-        int testCount = restTemplate.getForObject("http://localhost:8080/stock/reqcount", Integer.class);
+        int releaseCount = restTemplate.getForObject("http://localhost:9090/springbootapp/stock/reqcount", Integer.class);
+        int testCount = restTemplate.getForObject("http://localhost:8080/springbootapp/stock/reqcount", Integer.class);
 
         assertTrue(Math.round(releaseCount * 1.0 / testCount) == 4);
     }

--- a/spring-boot/src/test/java/com/baeldung/mongodb/ManualEmbeddedMongoDbIntegrationTest.java
+++ b/spring-boot/src/test/java/com/baeldung/mongodb/ManualEmbeddedMongoDbIntegrationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.util.SocketUtils;
 
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
@@ -32,16 +33,16 @@ class ManualEmbeddedMongoDbIntegrationTest {
     @BeforeEach
     void setup() throws Exception {
         String ip = "localhost";
-        int port = 27017;
+        int randomPort = SocketUtils.findAvailableTcpPort();
 
         IMongodConfig mongodConfig = new MongodConfigBuilder().version(Version.Main.PRODUCTION)
-            .net(new Net(ip, port, Network.localhostIsIPv6()))
+            .net(new Net(ip, randomPort, Network.localhostIsIPv6()))
             .build();
 
         MongodStarter starter = MongodStarter.getDefaultInstance();
         mongodExecutable = starter.prepare(mongodConfig);
         mongodExecutable.start();
-        mongoTemplate = new MongoTemplate(new MongoClient(ip, port), "test");
+        mongoTemplate = new MongoTemplate(new MongoClient(ip, randomPort), "test");
     }
 
     @DisplayName("Given object When save object using MongoDB template Then object can be found")

--- a/spring-boot/src/test/resources/application.properties
+++ b/spring-boot/src/test/resources/application.properties
@@ -2,7 +2,6 @@ spring.mail.host=localhost
 spring.mail.port=8025
 spring.mail.properties.mail.smtp.auth=false
 
-security.basic.enabled=false
 
 # spring.datasource.x
 spring.datasource.driver-class-name=org.h2.Driver
@@ -11,9 +10,10 @@ spring.datasource.username=sa
 spring.datasource.password=sa
 
 # hibernate.X
-hibernate.dialect=org.hibernate.dialect.H2Dialect
-hibernate.show_sql=true
-hibernate.hbm2ddl.auto=create-drop
-hibernate.cache.use_second_level_cache=true
-hibernate.cache.use_query_cache=true
-hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.EhCacheRegionFactory
+spring.jpa.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.show_sql=true
+spring.jpa.hibernate.hbm2ddl.auto=create-drop
+spring.jpa.hibernate.cache.use_second_level_cache=true
+spring.jpa.hibernate.cache.use_query_cache=true
+spring.jpa.hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.EhCacheRegionFactory

--- a/spring-boot/src/test/resources/exception.properties
+++ b/spring-boot/src/test/resources/exception.properties
@@ -1,6 +1,6 @@
 # Security
-security.user.name=admin
-security.user.password=password
+spring.security.user.name=admin
+spring.security.user.password=password
 
 spring.dao.exceptiontranslation.enabled=false
 spring.profiles.active=exception


### PR DESCRIPTION
JIRA: http://team.baeldung.com/browse/BAEL-9524

Fixed issues due to parent-boot-2 migration of module _spring-boot_ (migration to Spring-boot 2):
* Configured Hiberante 5 correctly
* Configured Git plugin correctly
* Changed hibernate methods to comply with new method naming conventions
* Removed and replaced deprecated properties
* Updated Actuator test to use new response structure and endpoint naming restrictions
* Using random port in Mongo integration test, to avoid clashing with a potential instance using the mongo default port
* Fixed Kong LiveTests configurations, project now using context path

**Integration tests** are now passing:
![capture](https://user-images.githubusercontent.com/7059941/48655985-43067480-ea06-11e8-885a-39aa421dfdc4.JPG)

**LiveTests** are now passing:
![kongloadbalancelivetest](https://user-images.githubusercontent.com/7059941/48656003-62050680-ea06-11e8-948a-3aad2c52a614.JPG)
![kongapilivetest](https://user-images.githubusercontent.com/7059941/48656004-629d9d00-ea06-11e8-8cbd-1bb51d017039.JPG)
![applivetest](https://user-images.githubusercontent.com/7059941/48656005-629d9d00-ea06-11e8-8df9-be2ed52db99e.JPG)

And there are **no Unit Tests** in the project