### PR TITLE
[BAEL-9524] spring-boot | migrating to parent-boot-2 - further fixes

### DIFF
--- a/spring-boot/src/main/resources/META-INF/spring.factories
+++ b/spring-boot/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.diagnostics.FailureAnalyzer=com.baeldung.failureanalyzer.MyBeanNotOfRequiredTypeFailureAnalyzer

--- a/spring-boot/src/test/java/com/baeldung/failureanalyzer/FailureAnalyzerAppIntegrationTest.java
+++ b/spring-boot/src/test/java/com/baeldung/failureanalyzer/FailureAnalyzerAppIntegrationTest.java
@@ -1,0 +1,47 @@
+package com.baeldung.failureanalyzer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.SpringApplication;
+
+import com.baeldung.failureanalyzer.utils.ListAppender;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class FailureAnalyzerAppIntegrationTest {
+
+    private static final String EXPECTED_ANALYSIS_DESCRIPTION_TITLE = "Description:";
+    private static final String EXPECTED_ANALYSIS_DESCRIPTION_CONTENT = "The bean myDAO could not be injected as com.baeldung.failureanalyzer.MyDAO because it is of type com.baeldung.failureanalyzer.MySecondDAO";
+    private static final String EXPECTED_ANALYSIS_ACTION_TITLE = "Action:";
+    private static final String EXPECTED_ANALYSIS_ACTION_CONTENT = "Consider creating a bean with name myDAO of type com.baeldung.failureanalyzer.MyDAO";
+
+    @BeforeEach
+    public void clearLogList() {
+        ListAppender.clearEventList();
+    }
+
+    @Test
+    public void givenBeanCreationErrorInContext_whenContextLoaded_thenFailureAnalyzerLogsReport() {
+        try {
+            SpringApplication.run(FailureAnalyzerApplication.class);
+        } catch (BeanCreationException e) {
+            Collection<String> allLoggedEntries = ListAppender.getEvents()
+                .stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .collect(Collectors.toList());
+            assertThat(allLoggedEntries).anyMatch(entry -> entry.contains(EXPECTED_ANALYSIS_DESCRIPTION_TITLE))
+                .anyMatch(entry -> entry.contains(EXPECTED_ANALYSIS_DESCRIPTION_CONTENT))
+                .anyMatch(entry -> entry.contains(EXPECTED_ANALYSIS_ACTION_TITLE))
+                .anyMatch(entry -> entry.contains(EXPECTED_ANALYSIS_ACTION_CONTENT));
+            return;
+        }
+        throw new IllegalStateException("Context load should be failing due to a BeanCreationException!");
+    }
+
+}

--- a/spring-boot/src/test/java/com/baeldung/failureanalyzer/utils/ListAppender.java
+++ b/spring-boot/src/test/java/com/baeldung/failureanalyzer/utils/ListAppender.java
@@ -1,0 +1,25 @@
+package com.baeldung.failureanalyzer.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+
+public class ListAppender extends AppenderBase<ILoggingEvent> {
+    
+    static private List<ILoggingEvent> events = new ArrayList<>();
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        events.add(eventObject);
+    }
+    
+    public static List<ILoggingEvent> getEvents() {
+        return events;
+    }
+    
+    public static void clearEventList() {
+        events.clear();
+    }
+}

--- a/spring-boot/src/test/resources/logback-test.xml
+++ b/spring-boot/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include
+        resource="org/springframework/boot/logging/logback/base.xml" />
+    <appender name="LISTAPPENDER"
+        class="com.baeldung.failureanalyzer.utils.ListAppender">
+    </appender>
+    <logger
+        name="org.springframework.boot.diagnostics.LoggingFailureAnalysisReporter">
+        <appender-ref ref="LISTAPPENDER" />
+    </logger>
+    <root level="info">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration> 


### PR DESCRIPTION
JIRA: http://team.baeldung.com/browse/BAEL-9524
FailureAnalyzer Application was not working as expected, it was not actually reporting the failure with a description and an action.
Now it does:
![failureanalyzer](https://user-images.githubusercontent.com/7059941/48678447-a90c0c80-eb6a-11e8-8ea8-7f1e8eacd4bc.JPG)
Plus I added a test to validate the FailureAnalyzer is being configured in the context, that the report is being carried out (being logged).