### PR TITLE
There is no PasswordEncoder mapped for the id "null"

### DIFF
--- a/spring-boot-security/src/main/java/com/baeldung/springbootsecurity/basic_auth/config/BasicAuthConfiguration.java
+++ b/spring-boot-security/src/main/java/com/baeldung/springbootsecurity/basic_auth/config/BasicAuthConfiguration.java
@@ -15,11 +15,11 @@ public class BasicAuthConfiguration extends WebSecurityConfigurerAdapter {
         auth
           .inMemoryAuthentication()
           .withUser("user")
-          .password("password")
+          .password("{noop}password")
           .roles("USER")
           .and()
           .withUser("admin")
-          .password("admin")
+          .password("{noop}admin")
           .roles("USER", "ADMIN");
     }
 


### PR DESCRIPTION
I was reading this tutorial https://www.baeldung.com/spring-boot-security-autoconfiguration
and spring boot will crash if you don't specify {noop} in the password since the tutorial is using in memory auth & there is no encoder present.

Fixes: java.lang.IllegalArgumentException: There is no PasswordEncoder mapped for the id "null"
	at org.springframework.security.crypto.password.DelegatingPasswordEncoder$UnmappedIdPasswordEncoder.matches(DelegatingPasswordEncoder.java:244) ~[spring-security-core-5.1.1.RELEASE.jar:5.1.1.RELEASE]