### PR TITLE
BAEL-2278 | spring-5-reactive | adding cases for publishOn different threads

### DIFF
--- a/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/chronjobs/ChronJobs.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/chronjobs/ChronJobs.java
@@ -119,4 +119,36 @@ public class ChronJobs {
         logger.info("process 4 with approach 4");
         service.processUsingApproachFourWithCheckpoint(fluxFoo);
     }
+
+    @Scheduled(fixedRate = 20000)
+    public void consumeFiniteFluxWitParallelScheduler() {
+        Flux<Foo> fluxFoo = client.get()
+            .uri("/functional-reactive/periodic-foo-2")
+            .accept(MediaType.TEXT_EVENT_STREAM)
+            .retrieve()
+            .bodyToFlux(FooDto.class)
+            .delayElements(Duration.ofMillis(100))
+            .map(dto -> {
+                logger.debug("process 5-parallel with dto id {} name{}", dto.getId(), dto.getName());
+                return new Foo(dto);
+            });
+        logger.info("process 5-parallel with approach 5-parallel");
+        service.processUsingApproachFivePublishingToDifferentParallelThreads(fluxFoo);
+    }
+
+    @Scheduled(fixedRate = 20000)
+    public void consumeFiniteFluxWithSingleSchedulers() {
+        Flux<Foo> fluxFoo = client.get()
+            .uri("/functional-reactive/periodic-foo-2")
+            .accept(MediaType.TEXT_EVENT_STREAM)
+            .retrieve()
+            .bodyToFlux(FooDto.class)
+            .delayElements(Duration.ofMillis(100))
+            .map(dto -> {
+                logger.debug("process 5-single with dto id {} name{}", dto.getId(), dto.getName());
+                return new Foo(dto);
+            });
+        logger.info("process 5-single with approach 5-single");
+        service.processUsingApproachFivePublishingToDifferentSingleThreads(fluxFoo);
+    }
 }

--- a/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/model/Foo.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/model/Foo.java
@@ -6,8 +6,13 @@ import org.springframework.data.annotation.Id;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class Foo {
 

--- a/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/model/FooDto.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/model/FooDto.java
@@ -1,9 +1,13 @@
 package com.baeldung.debugging.consumer.model;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class FooDto {
 


### PR DESCRIPTION
Added cases using subscribeOn and publishOn when debuggin reactive streams, for analysis.

Checking a sample in the logs, with `log()` included to see whats happening behing the scene:
```
13:10:54.869 [five-single-starter-15] INFO  reactor.Flux.OnAssembly.5 - | onSubscribe([Fuseable] FluxOnAssembly.OnAssemblySubscriber)
13:10:54.870 [five-single-starter-15] INFO  reactor.Flux.OnAssembly.5 - | request(256)
13:10:55.005 [parallel-2] INFO  reactor.Flux.OnAssembly.5 - | onNext(com.baeldung.debugging.consumer.model.Foo@170944f)
13:10:55.007 [five-single-foo-14] INFO  c.b.d.consumer.service.FooReporter - Reporting for approach FIVE-SINGLE: Foo with id '0' name 'theFo' and quantity '0'
13:10:55.110 [parallel-3] INFO  reactor.Flux.OnAssembly.5 - | onNext(com.baeldung.debugging.consumer.model.Foo@834dc9c)
13:10:55.111 [five-single-foo-14] INFO  c.b.d.consumer.service.FooReporter - Reporting for approach FIVE-SINGLE: Foo with id '1' name 'theFo' and quantity '1'
13:10:55.217 [parallel-4] INFO  reactor.Flux.OnAssembly.5 - | onNext(com.baeldung.debugging.consumer.model.Foo@52d8ed0f)
13:10:55.218 [five-single-foo-14] INFO  c.b.d.consumer.service.FooReporter - Reporting for approach FIVE-SINGLE: Foo with id '2' name 'theFo' and quantity '0'
13:10:55.321 [parallel-1] INFO  reactor.Flux.OnAssembly.5 - | onNext(com.baeldung.debugging.consumer.model.Foo@11295706)
13:10:55.322 [five-single-foo-14] INFO  c.b.d.consumer.service.FooReporter - Reporting for approach FIVE-SINGLE: Foo with id '3' name 'theFo' and quantity '5'
13:10:55.425 [parallel-2] INFO  reactor.Flux.OnAssembly.5 - | onNext(com.baeldung.debugging.consumer.model.Foo@c5b916e)
13:10:55.426 [five-single-foo-14] INFO  reactor.Flux.OnAssembly.5 - | cancel()
13:10:55.443 [five-single-bar-13] ERROR c.b.d.consumer.service.FooService - Approach 5-single failed!
java.lang.StringIndexOutOfBoundsException: String index out of range: 15
	at java.lang.String.substring(String.java:1963)
	at com.baeldung.debugging.consumer.service.FooNameHelper.lambda$substringFooName$1(FooNameHelper.java:36)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:107)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.runAsync(FluxPublishOn.java:396)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.run(FluxPublishOn.java:480)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Assembly trace from producer [reactor.core.publisher.FluxMapFuseable] :
	reactor.core.publisher.Flux.map(Flux.java:5077)
	com.baeldung.debugging.consumer.service.FooNameHelper.substringFooName(FooNameHelper.java:30)
	com.baeldung.debugging.consumer.service.FooNameHelper.concatAndSubstringFooName(FooNameHelper.java:13)
	com.baeldung.debugging.consumer.service.FooService.processUsingApproachFivePublishingToDifferentSingleThreads(FooService.java:110)
	com.baeldung.debugging.consumer.chronjobs.ChronJobs.consumeFiniteFluxWithSingleSchedulers(ChronJobs.java:152)
	org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84)
	org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
Error has been observed by the following operator(s):
	|_	Flux.map(FooNameHelper.java:30)
	|_	Flux.map(FooQuantityHelper.java:24)
	|_	Flux.map(FooReporter.java:15)
	|_	Flux.publishOn(FooService.java:112)
	|_	Flux.map(FooNameHelper.java:18)
	|_	Flux.map(FooNameHelper.java:30)
```

And a log as it was before, to compare:
```
19:01:29.092 [parallel-4] ERROR c.b.d.consumer.service.FooService - The following error happened on processFoo method!
java.lang.StringIndexOutOfBoundsException: String index out of range: 15
	at java.lang.String.substring(String.java:1963)
	at com.baeldung.debugging.consumer.service.FooNameHelper.lambda$substringFooName$1(FooNameHelper.java:36)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:107)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxPeekFuseable$PeekFuseableSubscriber.onNext(FluxPeekFuseable.java:198)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.innerNext(FluxConcatMap.java:271)
	at reactor.core.publisher.FluxConcatMap$ConcatMapInner.onNext(FluxConcatMap.java:803)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1083)
	at reactor.core.publisher.MonoDelayUntil$DelayUntilCoordinator.signal(MonoDelayUntil.java:211)
	at reactor.core.publisher.MonoDelayUntil$DelayUntilTrigger.onComplete(MonoDelayUntil.java:290)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onComplete(FluxOnAssembly.java:460)
	at reactor.core.publisher.MonoDelay$MonoDelayRunnable.run(MonoDelay.java:118)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:50)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:27)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Assembly trace from producer [reactor.core.publisher.FluxMapFuseable] :
	reactor.core.publisher.Flux.map(Flux.java:5077)
	com.baeldung.debugging.consumer.service.FooNameHelper.substringFooName(FooNameHelper.java:30)
	com.baeldung.debugging.consumer.service.FooNameHelper.concatAndSubstringFooName(FooNameHelper.java:13)
	com.baeldung.debugging.consumer.service.FooService.processFoo(FooService.java:25)
	com.baeldung.debugging.consumer.chronjobs.ChronJobs.consumeInfiniteFlux(ChronJobs.java:42)
	org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84)
	org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
Error has been observed by the following operator(s):
	|_	Flux.map(FooNameHelper.java:30)
	|_	Flux.map(FooQuantityHelper.java:24)
	|_	Flux.map(FooReporter.java:15)
	|_	Flux.map(FooNameHelper.java:18)
	|_	Flux.map(FooNameHelper.java:30)
```

* Also fixing small defect on model definition