### PR TITLE
BAEL-2445: adding example for the intersection of two lists

### DIFF
--- a/core-java-collections/src/test/java/org/baeldung/java/lists/ListJUnitTest.java
+++ b/core-java-collections/src/test/java/org/baeldung/java/lists/ListJUnitTest.java
@@ -5,6 +5,10 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+
+import java.util.stream.Collectors;
 
 public class ListJUnitTest {
 
@@ -17,5 +21,27 @@ public class ListJUnitTest {
         Assert.assertEquals(list1, list2);
         Assert.assertNotSame(list1, list2);
         Assert.assertNotEquals(list1, list3);
+    }
+
+    @Test
+    public void whenIntersection_ShouldReturnCommonElements() throws Exception {
+        List<String> list = Arrays.asList("red", "blue", "blue", "green", "red");
+        List<String> otherList = Arrays.asList("red", "green", "green", "yellow");
+
+        Set<String> commonElements = new HashSet(Arrays.asList("red", "green"));
+
+        Set<String> result = list.stream()
+          .distinct()
+          .filter(otherList::contains)
+          .collect(Collectors.toSet());
+
+        Assert.assertEquals(commonElements, result);
+
+        Set<String> inverseResult = otherList.stream()
+          .distinct()
+          .filter(list::contains)
+          .collect(Collectors.toSet());
+
+        Assert.assertEquals(commonElements, inverseResult);
     }
 }


### PR DESCRIPTION
* adding a unit test where we determine the intersection of two lists
* applying the intersection for the same two lists in the other order as well