### PR TITLE
toSet, toMap: adding examples with duplicates

### DIFF
--- a/core-java-8/src/test/java/com/baeldung/collectors/Java8CollectorsUnitTest.java
+++ b/core-java-8/src/test/java/com/baeldung/collectors/Java8CollectorsUnitTest.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class Java8CollectorsUnitTest {
 
     private final List<String> givenList = Arrays.asList("a", "bb", "ccc", "dd");
+    private final List<String> listWithDuplicates = Arrays.asList("a", "bb", "c", "d", "bb");
 
     @Test
     public void whenCollectingToList_shouldCollectToList() throws Exception {
@@ -52,6 +53,13 @@ public class Java8CollectorsUnitTest {
         final Set<String> result = givenList.stream().collect(toSet());
 
         assertThat(result).containsAll(givenList);
+    }
+
+    @Test
+    public void givenContainsDuplicateElements_whenCollectingToSet_shouldAddDuplicateElementsOnlyOnce() throws Exception {
+        final Set<String> result = listWithDuplicates.stream().collect(toSet());
+
+        assertThat(result).hasSize(4);
     }
 
     @Test
@@ -81,6 +89,13 @@ public class Java8CollectorsUnitTest {
         final Map<String, Integer> result = givenList.stream().collect(toMap(Function.identity(), String::length, (i1, i2) -> i1));
 
         assertThat(result).containsEntry("a", 1).containsEntry("bb", 2).containsEntry("ccc", 3).containsEntry("dd", 2);
+    }
+
+    @Test
+    public void givenContainsDuplicateElements_whenCollectingToMap_shouldThrowException() throws Exception {
+        assertThatThrownBy(() -> {
+            listWithDuplicates.stream().collect(toMap(Function.identity(), String::length));
+        }).isInstanceOf(IllegalStateException.class);
     }
 
     @Test

--- a/core-java-8/src/test/java/com/baeldung/collectors/Java8CollectorsUnitTest.java
+++ b/core-java-8/src/test/java/com/baeldung/collectors/Java8CollectorsUnitTest.java
@@ -48,7 +48,7 @@ public class Java8CollectorsUnitTest {
     }
 
     @Test
-    public void whenCollectingToList_shouldCollectToSet() throws Exception {
+    public void whenCollectingToSet_shouldCollectToSet() throws Exception {
         final Set<String> result = givenList.stream().collect(toSet());
 
         assertThat(result).containsAll(givenList);


### PR DESCRIPTION
### Collectors
Added tests with a list with duplicate elements:

* toSet -> gets added only once
* toMap -> IllegalStateException