### PR TITLE
BAEL-2414 Stack traces and causal chain of causes samples

### DIFF
--- a/spring-boot-libraries/src/main/java/com/baeldung/boot/problem/advice/ExceptionHandler.java
+++ b/spring-boot-libraries/src/main/java/com/baeldung/boot/problem/advice/ExceptionHandler.java
@@ -5,5 +5,12 @@ import org.zalando.problem.spring.web.advice.ProblemHandling;
 
 @ControllerAdvice
 public class ExceptionHandler implements ProblemHandling {
+    
+    // The causal chain of causes is disabled by default, 
+    // but we can easily enable it by overriding the behavior:
+    @Override
+    public boolean isCausalChainsEnabled() {
+        return true;
+    }
 
 }

--- a/spring-boot-libraries/src/main/java/com/baeldung/boot/problem/configuration/ProblemDemoConfiguration.java
+++ b/spring-boot-libraries/src/main/java/com/baeldung/boot/problem/configuration/ProblemDemoConfiguration.java
@@ -12,6 +12,8 @@ public class ProblemDemoConfiguration {
 
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper().registerModules(new ProblemModule(), new ConstraintViolationProblemModule());
+        // In this example, stack traces support is enabled by default. 
+        // If you want to disable stack traces just use new ProblemModule() instead of new ProblemModule().withStackTraces()
+        return new ObjectMapper().registerModules(new ProblemModule().withStackTraces(), new ConstraintViolationProblemModule());
     }
 }

--- a/spring-boot-libraries/src/test/java/com/baeldung/boot/problem/controller/ProblemDemoControllerIntegrationTest.java
+++ b/spring-boot-libraries/src/test/java/com/baeldung/boot/problem/controller/ProblemDemoControllerIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.baeldung.boot.problem.controller;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -70,6 +72,30 @@ public class ProblemDemoControllerIntegrationTest {
             .andExpect(jsonPath("$.status", equalTo(403)))
             .andExpect(jsonPath("$.detail", equalTo("You can't delete this task")))
             .andExpect(status().isForbidden());
+    }
+    
+    @Test
+    public void whenMakeGetCallWithInvalidIdFormat_thenReturnBadRequestResponseWithStackTrace() throws Exception {
+        mockMvc.perform(get("/tasks/invalid-id").contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE))
+            .andDo(print())
+            .andExpect(jsonPath("$.title", equalTo("Bad Request")))
+            .andExpect(jsonPath("$.status", equalTo(400)))
+            .andExpect(jsonPath("$.stacktrace", notNullValue()))
+            .andExpect(status().isBadRequest());
+    }
+    
+    @Test
+    public void whenMakeGetCallWithInvalidIdFormat_thenReturnBadRequestResponseWithCause() throws Exception {
+        mockMvc.perform(get("/tasks/invalid-id").contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE))
+            .andDo(print())
+            .andExpect(jsonPath("$.title", equalTo("Bad Request")))
+            .andExpect(jsonPath("$.status", equalTo(400)))
+            .andExpect(jsonPath("$.cause", notNullValue()))
+            .andExpect(jsonPath("$.cause.title", equalTo("Internal Server Error")))
+            .andExpect(jsonPath("$.cause.status", equalTo(500)))
+            .andExpect(jsonPath("$.cause.detail", containsString("For input string:")))
+            .andExpect(jsonPath("$.cause.stacktrace", notNullValue()))
+            .andExpect(status().isBadRequest());
     }
 
 }


### PR DESCRIPTION
Enable stack traces and causal chain of causes. Add a couple of tests to validate stack trace and cause are included in responses.