### PR TITLE
Parameter of type User instead of String name.

### DIFF
--- a/core-java-8/src/main/java/com/baeldung/java_8_features/User.java
+++ b/core-java-8/src/main/java/com/baeldung/java_8_features/User.java
@@ -34,7 +34,7 @@ public class User {
         return result;
     }
 
-    public boolean isLegalName(String name) {
-        return name.length() > 3 && name.length() < 16;
+    public boolean isLegalName(User user) {
+	return user.getName().length() > 3 && user.getName().length() < 16;
     }
 }


### PR DESCRIPTION
 For correct use of Predicate in anyMatch.