### PR TITLE
Update ProxyAcceptCookiePolicy.java

### DIFF
--- a/core-java-networking/src/main/java/com/baeldung/networking/cookies/ProxyAcceptCookiePolicy.java
+++ b/core-java-networking/src/main/java/com/baeldung/networking/cookies/ProxyAcceptCookiePolicy.java
@@ -17,8 +17,8 @@ public class ProxyAcceptCookiePolicy implements CookiePolicy {
             host = uri.getHost();
         }
 
-        if (!HttpCookie.domainMatches(acceptedProxy, host)) {
-            return false;
+        if (HttpCookie.domainMatches(acceptedProxy, host)) {
+            return true;
         }
 
         return CookiePolicy.ACCEPT_ORIGINAL_SERVER.shouldAccept(uri, cookie);


### PR DESCRIPTION
The guide says: When we create an instance of ProxyAcceptCookiePolicy, we pass in a String of the domain address we would like to accept cookies from **in addition to** the original server.