### PR TITLE
BAEL-1959 Classpath contains multiple bindings

### DIFF
--- a/libraries/pom.xml
+++ b/libraries/pom.xml
@@ -505,6 +505,16 @@
             <groupId>org.docx4j</groupId>
             <artifactId>docx4j</artifactId>
             <version>${docx4j.version}</version>
+	    <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
Updated pom.xml to exclude log4j binding