### PR TITLE
[BAEL-9493] Fix/Add Context Integration Tests for modules named in ticket

### DIFF
--- a/spring-cloud/spring-cloud-archaius/additional-sources-simple/src/main/java/com/baeldung/spring/cloud/archaius/additionalsources/config/ApplicationPropertiesConfigurations.java
+++ b/spring-cloud/spring-cloud-archaius/additional-sources-simple/src/main/java/com/baeldung/spring/cloud/archaius/additionalsources/config/ApplicationPropertiesConfigurations.java
@@ -1,8 +1,12 @@
 package com.baeldung.spring.cloud.archaius.additionalsources.config;
 
+import java.io.IOException;
+import java.net.URL;
+
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
 import com.netflix.config.DynamicConfiguration;
 import com.netflix.config.FixedDelayPollingScheduler;
@@ -13,8 +17,9 @@ import com.netflix.config.sources.URLConfigurationSource;
 public class ApplicationPropertiesConfigurations {
 
     @Bean
-    public AbstractConfiguration addApplicationPropertiesSource() {
-        PolledConfigurationSource source = new URLConfigurationSource("classpath:other-config.properties");
+    public AbstractConfiguration addApplicationPropertiesSource() throws IOException {
+        URL configPropertyURL = (new ClassPathResource("other-config.properties")).getURL();
+        PolledConfigurationSource source = new URLConfigurationSource(configPropertyURL);
         return new DynamicConfiguration(source, new FixedDelayPollingScheduler());
     }
 

--- a/spring-cloud/spring-cloud-archaius/additional-sources-simple/src/test/java/com/baeldung/spring/cloud/archaius/additionalsources/SpringContextIntegrationTest.java
+++ b/spring-cloud/spring-cloud-archaius/additional-sources-simple/src/test/java/com/baeldung/spring/cloud/archaius/additionalsources/SpringContextIntegrationTest.java
@@ -1,11 +1,9 @@
-package org.baeldung;
+package com.baeldung.spring.cloud.archaius.additionalsources;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import com.baeldung.spring.cloud.archaius.additionalsources.AdditionalSourcesSimpleApplication;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = AdditionalSourcesSimpleApplication.class)

--- a/spring-cloud/spring-cloud-aws/src/test/java/com/baeldung/spring/cloud/aws/SpringContextIntegrationTest.java
+++ b/spring-cloud/spring-cloud-aws/src/test/java/com/baeldung/spring/cloud/aws/SpringContextIntegrationTest.java
@@ -1,0 +1,15 @@
+package com.baeldung.spring.cloud.aws;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = SpringCloudAwsApplication.class)
+public class SpringContextIntegrationTest {
+
+    @Test
+    public void whenSpringContextIsBootstrapped_thenNoExceptions() {
+    }
+}

--- a/spring-cloud/spring-cloud-config/server/src/test/java/com/baeldung/spring/cloud/config/server/SpringContextLiveTest.java
+++ b/spring-cloud/spring-cloud-config/server/src/test/java/com/baeldung/spring/cloud/config/server/SpringContextLiveTest.java
@@ -1,18 +1,22 @@
 package com.baeldung.spring.cloud.config.server;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
+
+/**
+ * 
+ * The context will load successfully with some properties provided by docker
+ *
+ */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = ConfigServer.class)
 @WebAppConfiguration
-@Ignore
-public class ConfigServerListIntegrationTest {
+public class SpringContextLiveTest {
     @Test
-    public void contextLoads() {
+    public void whenSpringContextIsBootstrapped_thenNoExceptions() {
     }
 }

--- a/spring-cloud/spring-cloud-eureka/pom.xml
+++ b/spring-cloud/spring-cloud-eureka/pom.xml
@@ -21,6 +21,15 @@
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <properties>
         <spring-boot.version>2.0.1.RELEASE</spring-boot.version>

--- a/spring-cloud/spring-cloud-eureka/spring-cloud-eureka-client/pom.xml
+++ b/spring-cloud/spring-cloud-eureka/spring-cloud-eureka-client/pom.xml
@@ -26,12 +26,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring-boot.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring-boot.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/spring-cloud/spring-cloud-eureka/spring-cloud-eureka-client/src/test/java/com/baeldung/spring/cloud/eureka/client/SpringContextIntegrationTest.java
+++ b/spring-cloud/spring-cloud-eureka/spring-cloud-eureka-client/src/test/java/com/baeldung/spring/cloud/eureka/client/SpringContextIntegrationTest.java
@@ -1,17 +1,16 @@
-package org.baeldung;
+package com.baeldung.spring.cloud.eureka.client;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.baeldung.spring.cloud.aws.InstanceProfileAwsApplication;
-
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = InstanceProfileAwsApplication.class)
+@SpringBootTest
 public class SpringContextIntegrationTest {
-
+    
     @Test
     public void whenSpringContextIsBootstrapped_thenNoExceptions() {
     }
+
 }

--- a/spring-cloud/spring-cloud-eureka/spring-cloud-eureka-feign-client/src/test/java/com/baeldung/spring/cloud/feign/client/SpringContextIntegrationTest.java
+++ b/spring-cloud/spring-cloud-eureka/spring-cloud-eureka-feign-client/src/test/java/com/baeldung/spring/cloud/feign/client/SpringContextIntegrationTest.java
@@ -1,0 +1,16 @@
+package com.baeldung.spring.cloud.feign.client;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class SpringContextIntegrationTest {
+
+    @Test
+    public void whenSpringContextIsBootstrapped_thenNoExceptions() {
+    }
+
+}

--- a/spring-cloud/spring-cloud-eureka/spring-cloud-eureka-server/src/test/java/com/baeldung/spring/cloud/eureka/server/SpringContextIntegrationTest.java
+++ b/spring-cloud/spring-cloud-eureka/spring-cloud-eureka-server/src/test/java/com/baeldung/spring/cloud/eureka/server/SpringContextIntegrationTest.java
@@ -1,0 +1,16 @@
+package com.baeldung.spring.cloud.eureka.server;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class SpringContextIntegrationTest {
+
+    @Test
+    public void whenSpringContextIsBootstrapped_thenNoExceptions() {
+    }
+
+}

--- a/spring-cloud/spring-cloud-hystrix/feign-rest-consumer/src/test/java/com/baeldung/spring/cloud/hystrix/rest/consumer/SpringContextIntegrationTest.java
+++ b/spring-cloud/spring-cloud-hystrix/feign-rest-consumer/src/test/java/com/baeldung/spring/cloud/hystrix/rest/consumer/SpringContextIntegrationTest.java
@@ -1,0 +1,18 @@
+package com.baeldung.spring.cloud.hystrix.rest.consumer;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = RestConsumerFeignApplication.class)
+@WebAppConfiguration
+public class SpringContextIntegrationTest {
+
+    @Test
+    public void whenSpringContextIsBootstrapped_thenNoExceptions() {
+    }
+
+}

--- a/spring-cloud/spring-cloud-hystrix/rest-consumer/pom.xml
+++ b/spring-cloud/spring-cloud-hystrix/rest-consumer/pom.xml
@@ -40,6 +40,13 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
             <version>${spring-boot-starter-web.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <version>${spring-boot-starter-web.version}</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -53,5 +60,10 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    
+    <properties>
+        <!-- we need the Mockito version provided by Spring Boot -->
+        <mockito.version>1.10.19</mockito.version>
+    </properties>
 
 </project>

--- a/spring-cloud/spring-cloud-hystrix/rest-consumer/src/test/java/com/baeldung/spring/cloud/hystrix/rest/consumer/SpringContextIntegrationTest.java
+++ b/spring-cloud/spring-cloud-hystrix/rest-consumer/src/test/java/com/baeldung/spring/cloud/hystrix/rest/consumer/SpringContextIntegrationTest.java
@@ -1,18 +1,18 @@
-package org.baeldung;
+package com.baeldung.spring.cloud.hystrix.rest.consumer;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import com.baeldung.spring.cloud.config.server.ConfigServer;
-
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = ConfigServer.class)
+@ContextConfiguration(classes = RestConsumerApplication.class)
 @WebAppConfiguration
 public class SpringContextIntegrationTest {
+
     @Test
-    public void contextLoads() {
+    public void whenSpringContextIsBootstrapped_thenNoExceptions() {
     }
+
 }

--- a/spring-cloud/spring-cloud-hystrix/rest-producer/pom.xml
+++ b/spring-cloud/spring-cloud-hystrix/rest-producer/pom.xml
@@ -20,6 +20,18 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring-boot-starter-web.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot-starter-web.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+    
+    <properties>
+        <!-- we need the Mockito version provided by Spring Boot -->
+        <mockito.version>1.10.19</mockito.version>
+    </properties>
 
 </project>

--- a/spring-cloud/spring-cloud-hystrix/rest-producer/src/test/java/com/baeldung/spring/cloud/hystrix/rest/producer/SpringContextIntegrationTest.java
+++ b/spring-cloud/spring-cloud-hystrix/rest-producer/src/test/java/com/baeldung/spring/cloud/hystrix/rest/producer/SpringContextIntegrationTest.java
@@ -1,0 +1,16 @@
+package com.baeldung.spring.cloud.hystrix.rest.producer;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class SpringContextIntegrationTest {
+
+    @Test
+    public void whenSpringContextIsBootstrapped_thenNoExceptions() {
+    }
+
+}

--- a/spring-cloud/spring-cloud-zuul-eureka-integration/eureka-client/pom.xml
+++ b/spring-cloud/spring-cloud-zuul-eureka-integration/eureka-client/pom.xml
@@ -25,6 +25,13 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring-boot-starter-web.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot-starter-web.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/spring-cloud/spring-cloud-zuul-eureka-integration/eureka-client/src/test/java/com/baeldung/spring/cloud/eureka/client/SpringContextIntegrationTest.java
+++ b/spring-cloud/spring-cloud-zuul-eureka-integration/eureka-client/src/test/java/com/baeldung/spring/cloud/eureka/client/SpringContextIntegrationTest.java
@@ -1,0 +1,16 @@
+package com.baeldung.spring.cloud.eureka.client;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class SpringContextIntegrationTest {
+
+    @Test
+    public void whenSpringContextIsBootstrapped_thenNoExceptions() {
+    }
+
+}

--- a/spring-cloud/spring-cloud-zuul-eureka-integration/eureka-server/pom.xml
+++ b/spring-cloud/spring-cloud-zuul-eureka-integration/eureka-server/pom.xml
@@ -25,7 +25,13 @@
             <artifactId>commons-configuration</artifactId>
             <version>${commons-config.version}</version>
         </dependency>
-
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot-starter-web.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/spring-cloud/spring-cloud-zuul-eureka-integration/eureka-server/src/test/java/com/baeldung/spring/cloud/eureka/server/SpringContextIntegrationTest.java
+++ b/spring-cloud/spring-cloud-zuul-eureka-integration/eureka-server/src/test/java/com/baeldung/spring/cloud/eureka/server/SpringContextIntegrationTest.java
@@ -1,0 +1,16 @@
+package com.baeldung.spring.cloud.eureka.server;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class SpringContextIntegrationTest {
+
+    @Test
+    public void whenSpringContextIsBootstrapped_thenNoExceptions() {
+    }
+
+}

--- a/spring-cloud/spring-cloud-zuul-eureka-integration/zuul-server/pom.xml
+++ b/spring-cloud/spring-cloud-zuul-eureka-integration/zuul-server/pom.xml
@@ -33,6 +33,13 @@
             <artifactId>rxjava</artifactId>
             <version>${rxjava.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot-starter-web.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <dependencyManagement>

--- a/spring-cloud/spring-cloud-zuul-eureka-integration/zuul-server/src/test/java/com/baeldung/spring/cloud/zuul/config/SpringContextIntegrationTest.java
+++ b/spring-cloud/spring-cloud-zuul-eureka-integration/zuul-server/src/test/java/com/baeldung/spring/cloud/zuul/config/SpringContextIntegrationTest.java
@@ -1,0 +1,16 @@
+package com.baeldung.spring.cloud.zuul.config;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class SpringContextIntegrationTest {
+
+    @Test
+    public void whenSpringContextIsBootstrapped_thenNoExceptions() {
+    }
+
+}


### PR DESCRIPTION
JIRA: http://team.baeldung.com/browse/BAEL-9493

Notes:
- I used the following command to run integration tests:
`mvn clean test -P integration-lite-first,integration-lite-second,integration-heavy`
- Some Spring-Boot versions are incompatible with the Mockito version that is specified in the parent-modules pom.
Normally, we'd leave it to the spring-boot dependency to specify what version is needed, but under these circumstances, we have to declare the Mockito version 'manually', which can be a problem when we upgrade the module's spring-boot version.
Maybe we want to reconsider constraining dependencies versions in the parent-modules pom??
- I've been analyzing the other projects under spring-cloud, and **apart** from the ones that would be coverend in [BAEL-9494](http://team.baeldung.com/browse/BAEL-9494), it seems other 15 projects are failing or doesn't have a _SpringContextIntegrationTest.java_ test.
- We probably want to update the snippet in section 6.2 of [this article](https://www.baeldung.com/netflix-archaius-spring-cloud-integration) with [this code change](https://github.com/eugenp/tutorials/pull/6648/files#diff-540ab9c981b9dd3060608b215e2c2b56R22). I can make that change if want me to.