### PR TITLE
corrected test to pull in profile-based config, fixe app context startup

### DIFF
--- a/persistence-modules/spring-boot-persistence/src/main/java/com/baeldung/boot/config/H2JpaConfig.java
+++ b/persistence-modules/spring-boot-persistence/src/main/java/com/baeldung/boot/config/H2JpaConfig.java
@@ -1,13 +1,9 @@
 package com.baeldung.boot.config;
 
-import java.util.Properties;
-
-import javax.persistence.EntityManagerFactory;
-import javax.sql.DataSource;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -17,10 +13,17 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+import java.util.Properties;
+
 @Configuration
 @EnableJpaRepositories(basePackages = { "com.baeldung.boot.repository", "com.baeldung.repository" })
 @PropertySource("classpath:persistence-generic-entity.properties")
 @EnableTransactionManagement
+@Profile("default") //only required to allow H2JpaConfig and H2TestProfileJPAConfig to coexist in same project
+                    //this demo project is showcasing several ways to achieve the same end, and class-level
+                    //Profile annotations are only necessary because the different techniques are sharing a project
 public class H2JpaConfig {
 
     @Autowired

--- a/persistence-modules/spring-boot-persistence/src/test/java/com/baeldung/SpringBootProfileIntegrationTest.java
+++ b/persistence-modules/spring-boot-persistence/src/test/java/com/baeldung/SpringBootProfileIntegrationTest.java
@@ -1,8 +1,9 @@
 package com.baeldung;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
+import com.baeldung.boot.Application;
+import com.baeldung.boot.domain.GenericEntity;
+import com.baeldung.boot.repository.GenericEntityRepository;
+import com.baeldung.config.H2TestProfileJPAConfig;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,13 +11,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.baeldung.boot.Application;
-import com.baeldung.boot.config.H2JpaConfig;
-import com.baeldung.boot.domain.GenericEntity;
-import com.baeldung.boot.repository.GenericEntityRepository;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = { Application.class, H2JpaConfig.class })
+@SpringBootTest(classes = { Application.class, H2TestProfileJPAConfig.class })
 @ActiveProfiles("test")
 public class SpringBootProfileIntegrationTest {
     @Autowired

--- a/persistence-modules/spring-boot-persistence/src/test/java/com/baeldung/config/H2TestProfileJPAConfig.java
+++ b/persistence-modules/spring-boot-persistence/src/test/java/com/baeldung/config/H2TestProfileJPAConfig.java
@@ -1,10 +1,5 @@
 package com.baeldung.config;
 
-import java.util.Properties;
-
-import javax.persistence.EntityManagerFactory;
-import javax.sql.DataSource;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,9 +12,16 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+import java.util.Properties;
+
 @Configuration
 @EnableJpaRepositories(basePackages = { "com.baeldung.repository", "com.baeldung.boot.repository" })
 @EnableTransactionManagement
+@Profile("test") //only required to allow H2JpaConfig and H2TestProfileJPAConfig to coexist in same project
+                 //this demo project is showcasing several ways to achieve the same end, and class-level
+                 //Profile annotations are only necessary because the different techniques are sharing a project
 public class H2TestProfileJPAConfig {
 
     @Autowired


### PR DESCRIPTION
- profile-based integ test points at profile-based JPA config
- marked two JPA config classes at class level by profile, to prevent clashes in bean names at startup