### PR TITLE
To enable multiple execution of a job with the same parameters

### DIFF
--- a/spring-batch/src/main/java/org/baeldung/batch/App.java
+++ b/spring-batch/src/main/java/org/baeldung/batch/App.java
@@ -3,6 +3,7 @@ package org.baeldung.batch;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
@@ -21,7 +22,11 @@ public class App {
         final Job job = (Job) context.getBean("firstBatchJob");
         System.out.println("Starting the batch job");
         try {
-            final JobExecution execution = jobLauncher.run(job, new JobParameters());
+			// To enable multiple execution of a job with the same parameters
+			JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("jobID", String.valueOf(System.currentTimeMillis()))
+                    .toJobParameters();
+            final JobExecution execution = jobLauncher.run(job, jobParameters);
             System.out.println("Job Status : " + execution.getStatus());
             System.out.println("Job succeeded");
         } catch (final Exception e) {


### PR DESCRIPTION
In production environment there is always the need to execute a single job for multiple time. In this case, if we assume that we want to persist all the job execution meta-data (do not drop and create schema again), spring-batch has a interesting behavior. It prevents the job execution if you run it with the same parameters for multiple time. If you look at the generated meta-data, you can see that the job **EXIT_CODE** is **NOOP** and the exit message is "_All steps already completed or no steps configured for this job._".
To prevent this behavior it is a good practice to add current system time as a job parameter.