### PR TITLE
BAEL-2910 MockMvc Kotlin DSL

### DIFF
--- a/parent-kotlin/pom.xml
+++ b/parent-kotlin/pom.xml
@@ -26,6 +26,11 @@
             <id>kotlin-eap</id>
             <url>http://dl.bintray.com/kotlin/kotlin-eap</url>
         </repository>
+        <repository>
+            <id>spring-milestone</id>
+            <name>Spring Milestone Repository</name> 
+            <url>http://repo.spring.io/milestone</url> 
+        </repository>
     </repositories>
     
     <pluginRepositories>
@@ -40,7 +45,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
-				<version>2.0.1.RELEASE</version>
+				<version>2.2.0.M4</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -79,6 +84,10 @@
 			<groupId>io.ktor</groupId>
 			<artifactId>ktor-gson</artifactId>
 			<version>${ktor.io.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-kotlin</artifactId>
 		</dependency>
 
 		<dependency>

--- a/spring-mvc-kotlin/pom.xml
+++ b/spring-mvc-kotlin/pom.xml
@@ -15,12 +15,12 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-web</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-json</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.thymeleaf</groupId>
@@ -46,8 +46,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-mvc-kotlin/src/main/kotlin/com/baeldung/kotlin/mockmvc/MockMvcController.kt
+++ b/spring-mvc-kotlin/src/main/kotlin/com/baeldung/kotlin/mockmvc/MockMvcController.kt
@@ -1,0 +1,26 @@
+package com.baeldung.kotlin.mockmvc
+
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/mockmvc")
+class MockMvcController {
+
+    @RequestMapping(value = ["/validate"], method = [RequestMethod.POST], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun validate(@RequestBody request: Request): Response {
+        val error = if (request.name.first == "admin") {
+            null
+        } else {
+            ERROR
+        }
+        return Response(error)
+    }
+
+    companion object {
+        const val ERROR = "invalid user"
+    }
+}

--- a/spring-mvc-kotlin/src/main/kotlin/com/baeldung/kotlin/mockmvc/MockMvcModel.kt
+++ b/spring-mvc-kotlin/src/main/kotlin/com/baeldung/kotlin/mockmvc/MockMvcModel.kt
@@ -1,0 +1,10 @@
+package com.baeldung.kotlin.mockmvc
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+data class Name(val first: String, val last: String)
+
+data class Request(val name: Name)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class Response(val error: String?)

--- a/spring-mvc-kotlin/src/test/kotlin/com/baeldung/kotlin/mockmvc/MockMvcControllerTest.kt
+++ b/spring-mvc-kotlin/src/test/kotlin/com/baeldung/kotlin/mockmvc/MockMvcControllerTest.kt
@@ -1,0 +1,61 @@
+package com.baeldung.kotlin.mockmvc
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity.status
+import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+@RunWith(SpringRunner::class)
+@WebMvcTest
+class MockMvcControllerTest {
+
+    @Autowired lateinit var mockMvc: MockMvc
+    @Autowired lateinit var mapper: ObjectMapper
+
+    @Test
+    fun `when supported user is given then raw MockMvc-based validation is successful`() {
+        mockMvc.perform(MockMvcRequestBuilders
+                                .post("/mockmvc/validate")
+                                .accept(MediaType.APPLICATION_JSON)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(mapper.writeValueAsString(Request(Name("admin", "")))))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.content().string("{}"))
+    }
+
+    @Test
+    fun `when supported user is given then kotlin DSL-based validation is successful`() {
+        doTest(Request(Name("admin", "")), Response(null))
+    }
+
+    @Test
+    fun `when unsupported user is given then validation is failed`() {
+        doTest(Request(Name("some-name", "some-surname")), Response(MockMvcController.ERROR))
+    }
+
+    private fun doTest(input: Request, expectation: Response) {
+        mockMvc.post("/mockmvc/validate") {
+            contentType = MediaType.APPLICATION_JSON
+            content = mapper.writeValueAsString(input)
+            accept = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isOk }
+            content { contentType(MediaType.APPLICATION_JSON) }
+            content { json(mapper.writeValueAsString(expectation)) }
+        }
+    }
+}
+
+@SpringBootApplication
+class MockMvcApplication


### PR DESCRIPTION
* configured spring repo in the 'parent-kotlin' model
  to allow using spring's milestone artifacts
* configured jackson kotlin module in the 'parent-kotlin'
  to allow easy use of kotlin data classes with jackson
* switched spring-mvc-kotlin from explicit spring
  dependencies to spring-boot
* mockmvc dsl article's source and tests