### PR TITLE
Disabling Java Streams 2 in integration build as in main build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1147,7 +1147,7 @@
                 <module>java-rmi</module>
                 <module>java-spi</module>
                 <module>java-streams</module>
-                <module>java-streams-2</module>
+                <!-- <module>java-streams-2</module> --> <!-- We haven't upgraded to java 9. Fixing in BAEL-10841 -->
                 <module>java-strings</module>
                 <module>java-strings-2</module>
                 <module>java-vavr-stream</module>


### PR DESCRIPTION
@maibin - this is a workaround for the issue, I think. The reason the original build passed was that we'd removed the Java-9 project from the list of modules - hoping it would be resolved in a JIRA ticket later (advice from @lor6 ). I've completely that workaround with this PR.

An alternative would be to put the `maven compiler` plugin into the module build to see if it can be coerced into building in Java 9 - at the moment the module build for `java-streams-2` defines `<properties>` for the Java 9 version, but that won't be enough.