### PR TITLE
Rename unit test to follow naming standards

### DIFF
--- a/quarkus/src/test/java/com/baeldung/quarkus/HelloResourceUnitTest.java
+++ b/quarkus/src/test/java/com/baeldung/quarkus/HelloResourceUnitTest.java
@@ -7,7 +7,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
-public class HelloResourceTest {
+public class HelloResourceUnitTest {
 
     @Test
     public void testHelloEndpoint() {

--- a/quarkus/src/test/java/com/baeldung/quarkus/NativeHelloResourceIT.java
+++ b/quarkus/src/test/java/com/baeldung/quarkus/NativeHelloResourceIT.java
@@ -3,7 +3,7 @@ package com.baeldung.quarkus;
 import io.quarkus.test.junit.SubstrateTest;
 
 @SubstrateTest
-public class NativeHelloResourceIT extends HelloResourceTest {
+public class NativeHelloResourceIT extends HelloResourceUnitTest {
 
     // Execute the same tests but in native mode.
 }


### PR DESCRIPTION
Rename unit test to follow naming standards