### PR TITLE
Drop last 4 bytes of computed SHA-1 hash

### DIFF
--- a/core-java-modules/core-java/src/main/java/com/baeldung/uuid/UUIDGenerator.java
+++ b/core-java-modules/core-java/src/main/java/com/baeldung/uuid/UUIDGenerator.java
@@ -67,7 +67,7 @@ public class UUIDGenerator {
         } catch (NoSuchAlgorithmException nsae) {
             throw new InternalError("MD5 not supported", nsae);
         }
-        byte[] bytes = md.digest(name);
+        byte[] bytes = Arrays.copyOfRange(md.digest(name), 0, 16);
         bytes[6] &= 0x0f; /* clear version        */
         bytes[6] |= 0x50; /* set to version 5     */
         bytes[8] &= 0x3f; /* clear variant        */

--- a/core-java-modules/core-java/src/main/java/com/baeldung/uuid/UUIDGenerator.java
+++ b/core-java-modules/core-java/src/main/java/com/baeldung/uuid/UUIDGenerator.java
@@ -65,7 +65,7 @@ public class UUIDGenerator {
         try {
             md = MessageDigest.getInstance("SHA-1");
         } catch (NoSuchAlgorithmException nsae) {
-            throw new InternalError("MD5 not supported", nsae);
+            throw new InternalError("SHA-1 not supported", nsae);
         }
         byte[] bytes = Arrays.copyOfRange(md.digest(name), 0, 16);
         bytes[6] &= 0x0f; /* clear version        */

--- a/core-java-modules/core-java/src/main/java/com/baeldung/uuid/UUIDGenerator.java
+++ b/core-java-modules/core-java/src/main/java/com/baeldung/uuid/UUIDGenerator.java
@@ -3,6 +3,7 @@ package com.baeldung.uuid;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.UUID;
 
 public class UUIDGenerator {


### PR DESCRIPTION
Computation of a SHA-1 hash will generate 20 bytes. Applying this PR will drop the last 4 (they are not used for generating the UUID). This will make the assertion in the `constructType5UUID`-method pass. Fixes #7598. Also fixes a wrong message for an exception.