### PR TITLE
[BAEL-17697] - Fixed integration tests

### DIFF
--- a/spring-di/src/main/java/com/baeldung/sample/AppConfig.java
+++ b/spring-di/src/main/java/com/baeldung/sample/AppConfig.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan("org.baeldung.sample")
+@ComponentScan("com.baeldung.sample")
 public class AppConfig {
 
 }


### PR DESCRIPTION
After the move, the 'ComponentScan' path was set wrongly in the AppConfig class. 