### PR TITLE
mongod smallFiles flag is no longer supported

### DIFF
--- a/spring-cloud/spring-cloud-kubernetes/deployment-travel-client.sh
+++ b/spring-cloud/spring-cloud-kubernetes/deployment-travel-client.sh
@@ -1,5 +1,7 @@
 ### set docker env
 eval $(minikube docker-env)
+#fish shell
+#eval (minikube docker-env)
 
 ### build the repository
 #mvn clean  install

--- a/spring-cloud/spring-cloud-kubernetes/travel-agency-service/mongo-deployment.yaml
+++ b/spring-cloud/spring-cloud-kubernetes/travel-agency-service/mongo-deployment.yaml
@@ -28,8 +28,6 @@ spec:
     spec:
       containers:
       - args:
-        - mongod
-        - --smallfiles
         image: mongo:latest
         name: mongo
         env:


### PR DESCRIPTION
mongod smallFiles flag is no longer supported
removed it from the deployment script

also added a comment for the fish shell users, just suggestion.