### PR TITLE
SemaPhoreDemo double acquire fix

### DIFF
--- a/core-java-modules/core-java-concurrency-basic/src/main/java/com/baeldung/concurrent/semaphore/SemaPhoreDemo.java
+++ b/core-java-modules/core-java-concurrency-basic/src/main/java/com/baeldung/concurrent/semaphore/SemaPhoreDemo.java
@@ -12,7 +12,6 @@ public class SemaPhoreDemo {
 		System.out.println("Number of threads waiting to acquire: " + semaphore.getQueueLength());
 
 		if (semaphore.tryAcquire()) {
-			semaphore.acquire();
 			// perform some critical operations
 			semaphore.release();
 		}

--- a/core-java-modules/core-java-concurrency-basic/src/main/java/com/baeldung/concurrent/semaphore/SemaPhoreDemo.java
+++ b/core-java-modules/core-java-concurrency-basic/src/main/java/com/baeldung/concurrent/semaphore/SemaPhoreDemo.java
@@ -11,7 +11,7 @@ public class SemaPhoreDemo {
 		System.out.println("Available permit : " + semaphore.availablePermits());
 		System.out.println("Number of threads waiting to acquire: " + semaphore.getQueueLength());
 
-		if (semaphore.tryAcquire()) 
+		if (semaphore.tryAcquire()) {
 			try {		
 			// perform some critical operations
 			} finally {

--- a/core-java-modules/core-java-concurrency-basic/src/main/java/com/baeldung/concurrent/semaphore/SemaPhoreDemo.java
+++ b/core-java-modules/core-java-concurrency-basic/src/main/java/com/baeldung/concurrent/semaphore/SemaPhoreDemo.java
@@ -11,9 +11,12 @@ public class SemaPhoreDemo {
 		System.out.println("Available permit : " + semaphore.availablePermits());
 		System.out.println("Number of threads waiting to acquire: " + semaphore.getQueueLength());
 
-		if (semaphore.tryAcquire()) {
+		if (semaphore.tryAcquire()) 
+			try {		
 			// perform some critical operations
-			semaphore.release();
+			} finally {
+				semaphore.release();
+			}
 		}
 
 	}


### PR DESCRIPTION
tryAcquire() [already acquires a permit, if one is available](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Semaphore.html#tryAcquire--) (no need to call acquire() after it)