### PR TITLE
BAEL-3294: Update Kotlin Builder Pattern article

### DIFF
--- a/core-kotlin/src/main/kotlin/com/baeldung/builder/FoodOrder.kt
+++ b/core-kotlin/src/main/kotlin/com/baeldung/builder/FoodOrder.kt
@@ -1,22 +1,8 @@
 package com.baeldung.builder
 
-class FoodOrder(
-  val bread: String?,
-  val condiments: String?,
-  val meat: String?,
-  val fish: String?
-) {
-    data class Builder(
-      var bread: String? = null,
-      var condiments: String? = null,
-      var meat: String? = null,
-      var fish: String? = null) {
-
-        fun bread(bread: String) = apply { this.bread = bread }
-        fun condiments(condiments: String) = apply { this.condiments = condiments }
-        fun meat(meat: String) = apply { this.meat = meat }
-        fun fish(fish: String) = apply { this.fish = fish }
-        fun build() = FoodOrder(bread, condiments, meat, fish)
-    }
-}
-
+data class FoodOrder(
+        val bread: String? = null,
+        val condiments: String? = null,
+        val meat: String? = null,
+        val fish: String? = null
+)

--- a/core-kotlin/src/main/kotlin/com/baeldung/builder/Main.kt
+++ b/core-kotlin/src/main/kotlin/com/baeldung/builder/Main.kt
@@ -1,9 +1,0 @@
-package com.baeldung.builder
-
-fun main(args: Array<String>) {
-    FoodOrder.Builder()
-      .bread("bread")
-      .condiments("condiments")
-      .meat("meat")
-      .fish("bread").let { println(it) }
-}

--- a/core-kotlin/src/test/kotlin/com/baeldung/builder/BuilderPatternUnitTest.kt
+++ b/core-kotlin/src/test/kotlin/com/baeldung/builder/BuilderPatternUnitTest.kt
@@ -6,30 +6,8 @@ import org.junit.jupiter.api.Test
 internal class BuilderPatternUnitTest {
 
     @Test
-    fun whenBuildingFoodOrderSettingValues_thenFieldsNotNull() {
-
-        val foodOrder = FoodOrder.Builder()
-                .bread("white bread")
-                .meat("bacon")
-                .fish("salmon")
-                .condiments("olive oil")
-                .build()
-
-        Assertions.assertNotNull(foodOrder.bread)
-        Assertions.assertNotNull(foodOrder.meat)
-        Assertions.assertNotNull(foodOrder.condiments)
-        Assertions.assertNotNull(foodOrder.fish)
-    }
-
-    @Test
     fun whenBuildingFoodOrderSettingValues_thenFieldsContainsValues() {
-
-        val foodOrder = FoodOrder.Builder()
-                .bread("white bread")
-                .meat("bacon")
-                .fish("salmon")
-                .condiments("olive oil")
-                .build()
+        val foodOrder = FoodOrder(bread = "white bread", meat = "bacon", fish = "salmon", condiments = "olive oil")
 
         Assertions.assertEquals("white bread", foodOrder.bread)
         Assertions.assertEquals("bacon", foodOrder.meat)
@@ -40,8 +18,7 @@ internal class BuilderPatternUnitTest {
     @Test
     fun whenBuildingFoodOrderWithoutSettingValues_thenFieldsNull() {
 
-        val foodOrder = FoodOrder.Builder()
-                .build()
+        val foodOrder = FoodOrder()
 
         Assertions.assertNull(foodOrder.bread)
         Assertions.assertNull(foodOrder.meat)


### PR DESCRIPTION
Builder pattern in languages with first-class support for named and default arguments is just a simple class filled with default-named args. That's it, no more boilerplate!

Arguments for the changes:
 - There was a useless main entry function, so I deleted it.
 - Two tests with the same examinations but different assertions. When something is equal to a `String`, it's definitely can not be `null`. So I've deleted a test, too.