### PR TITLE
BAEL-18143 Fix spring-jooq issue related to dialect

### DIFF
--- a/spring-jooq/src/test/java/com/baeldung/jooq/introduction/ExceptionTranslator.java
+++ b/spring-jooq/src/test/java/com/baeldung/jooq/introduction/ExceptionTranslator.java
@@ -12,7 +12,7 @@ public class ExceptionTranslator extends DefaultExecuteListener {
     @Override
     public void exception(ExecuteContext context) {
         SQLDialect dialect = context.configuration().dialect();
-        SQLExceptionTranslator translator = new SQLErrorCodeSQLExceptionTranslator(dialect.name());
+        SQLExceptionTranslator translator = new SQLErrorCodeSQLExceptionTranslator(dialect.thirdParty().springDbName());
 
         context.exception(translator.translate("Access database using jOOQ", context.sql(), context.sqlException()));
     }


### PR DESCRIPTION
- Updated SQLErrorCodeSQLExceptionTranslator to use dialect.thirdParty().springDbName()