### PR TITLE
[BAEL-3315] Added missing code snippets from the Java 8 Date/Time article

### DIFF
--- a/java-dates/src/main/java/com/baeldung/datetime/UseDateTimeFormatter.java
+++ b/java-dates/src/main/java/com/baeldung/datetime/UseDateTimeFormatter.java
@@ -1,0 +1,21 @@
+package com.baeldung.datetime;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.Locale;
+
+public class UseDateTimeFormatter {
+    public String formatAsIsoDate(LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ISO_DATE);
+    }
+
+    public String formatCustom(LocalDateTime localDateTime, String pattern) {
+        return localDateTime.format(DateTimeFormatter.ofPattern(pattern));
+    }
+
+    public String formatWithStyleAndLocale(LocalDateTime localDateTime, FormatStyle formatStyle, Locale locale) {
+        return localDateTime.format(DateTimeFormatter.ofLocalizedDateTime(formatStyle)
+            .withLocale(locale));
+    }
+}

--- a/java-dates/src/main/java/com/baeldung/datetime/UseLocalDate.java
+++ b/java-dates/src/main/java/com/baeldung/datetime/UseLocalDate.java
@@ -36,8 +36,13 @@ class UseLocalDate {
     }
 
     LocalDate getFirstDayOfMonth() {
-        LocalDate firstDayOfMonth = LocalDate.now().with(TemporalAdjusters.firstDayOfMonth());
+        LocalDate firstDayOfMonth = LocalDate.now()
+            .with(TemporalAdjusters.firstDayOfMonth());
         return firstDayOfMonth;
+    }
+
+    boolean isLeapYear(LocalDate localDate) {
+        return localDate.isLeapYear();
     }
 
     LocalDateTime getStartOfDay(LocalDate localDate) {

--- a/java-dates/src/main/java/com/baeldung/datetime/UseLocalDateTime.java
+++ b/java-dates/src/main/java/com/baeldung/datetime/UseLocalDateTime.java
@@ -2,6 +2,7 @@ package com.baeldung.datetime;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
 
 public class UseLocalDateTime {
@@ -21,4 +22,7 @@ public class UseLocalDateTime {
         return endOfDate;
     }
 
+    LocalDateTime ofEpochSecond(int epochSecond, ZoneOffset zoneOffset) {
+        return LocalDateTime.ofEpochSecond(epochSecond, 0, zoneOffset);
+    }
 }

--- a/java-dates/src/main/java/com/baeldung/datetime/UseLocalTime.java
+++ b/java-dates/src/main/java/com/baeldung/datetime/UseLocalTime.java
@@ -9,6 +9,10 @@ public class UseLocalTime {
         return LocalTime.of(hour, min, seconds);
     }
 
+    LocalTime getLocalTimeUsingFactoryOfMethod(int hour, int min) {
+        return LocalTime.of(hour, min);
+    }
+
     LocalTime getLocalTimeUsingParseMethod(String timeRepresentation) {
         return LocalTime.parse(timeRepresentation);
     }

--- a/java-dates/src/main/java/com/baeldung/datetime/UseOffsetDateTime.java
+++ b/java-dates/src/main/java/com/baeldung/datetime/UseOffsetDateTime.java
@@ -1,0 +1,11 @@
+package com.baeldung.datetime;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+public class UseOffsetDateTime {
+    public OffsetDateTime offsetOfLocalDateTimeAndOffset(LocalDateTime localDateTime, ZoneOffset offset) {
+        return OffsetDateTime.of(localDateTime, offset);
+    }
+}

--- a/java-dates/src/main/java/com/baeldung/datetime/UseZonedDateTime.java
+++ b/java-dates/src/main/java/com/baeldung/datetime/UseZonedDateTime.java
@@ -12,31 +12,35 @@ class UseZonedDateTime {
         return ZonedDateTime.of(localDateTime, zoneId);
     }
 
+    ZonedDateTime getZonedDateTimeUsingParseMethod(String parsableString) {
+        return ZonedDateTime.parse(parsableString);
+    }
+
     ZonedDateTime getStartOfDay(LocalDate localDate, ZoneId zone) {
-        ZonedDateTime startofDay = localDate.atStartOfDay()
+        ZonedDateTime startOfDay = localDate.atStartOfDay()
             .atZone(zone);
-        return startofDay;
+        return startOfDay;
     }
 
     ZonedDateTime getStartOfDayShorthand(LocalDate localDate, ZoneId zone) {
-        ZonedDateTime startofDay = localDate.atStartOfDay(zone);
-        return startofDay;
+        ZonedDateTime startOfDay = localDate.atStartOfDay(zone);
+        return startOfDay;
     }
 
     ZonedDateTime getStartOfDayFromZonedDateTime(ZonedDateTime zonedDateTime) {
-        ZonedDateTime startofDay = zonedDateTime.toLocalDateTime()
+        ZonedDateTime startOfDay = zonedDateTime.toLocalDateTime()
             .toLocalDate()
             .atStartOfDay(zonedDateTime.getZone());
-        return startofDay;
+        return startOfDay;
     }
 
     ZonedDateTime getStartOfDayAtMinTime(ZonedDateTime zonedDateTime) {
-        ZonedDateTime startofDay = zonedDateTime.with(ChronoField.HOUR_OF_DAY, 0);
-        return startofDay;
+        ZonedDateTime startOfDay = zonedDateTime.with(ChronoField.HOUR_OF_DAY, 0);
+        return startOfDay;
     }
 
     ZonedDateTime getStartOfDayAtMidnightTime(ZonedDateTime zonedDateTime) {
-        ZonedDateTime startofDay = zonedDateTime.with(ChronoField.NANO_OF_DAY, 0);
-        return startofDay;
+        ZonedDateTime startOfDay = zonedDateTime.with(ChronoField.NANO_OF_DAY, 0);
+        return startOfDay;
     }
 }

--- a/java-dates/src/test/java/com/baeldung/date/DateDiffUnitTest.java
+++ b/java-dates/src/test/java/com/baeldung/date/DateDiffUnitTest.java
@@ -1,6 +1,6 @@
 package com.baeldung.date;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -16,7 +16,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class DateDiffUnitTest {
 
@@ -31,14 +31,14 @@ public class DateDiffUnitTest {
 
         assertEquals(diff, 6);
     }
-    
+
     @Test
     public void givenTwoDatesInJava8_whenDifferentiating_thenWeGetSix() {
         LocalDate now = LocalDate.now();
         LocalDate sixDaysBehind = now.minusDays(6);
 
         Period period = Period.between(now, sixDaysBehind);
-        int diff = period.getDays();
+        int diff = Math.abs(period.getDays());
 
         assertEquals(diff, 6);
     }
@@ -68,7 +68,8 @@ public class DateDiffUnitTest {
     public void givenTwoZonedDateTimesInJava8_whenDifferentiating_thenWeGetSix() {
         LocalDateTime ldt = LocalDateTime.now();
         ZonedDateTime now = ldt.atZone(ZoneId.of("America/Montreal"));
-        ZonedDateTime sixDaysBehind = now.withZoneSameInstant(ZoneId.of("Asia/Singapore")).minusDays(6);
+        ZonedDateTime sixDaysBehind = now.withZoneSameInstant(ZoneId.of("Asia/Singapore"))
+            .minusDays(6);
         long diff = ChronoUnit.DAYS.between(sixDaysBehind, now);
         assertEquals(diff, 6);
     }

--- a/java-dates/src/test/java/com/baeldung/date/comparison/Java8DateTimeApiGeneralComparisonsUnitTest.java
+++ b/java-dates/src/test/java/com/baeldung/date/comparison/Java8DateTimeApiGeneralComparisonsUnitTest.java
@@ -1,11 +1,15 @@
 package com.baeldung.date.comparison;
 
-import org.junit.Test;
-
-import java.time.*;
-
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.junit.Test;
 
 public class Java8DateTimeApiGeneralComparisonsUnitTest {
 
@@ -54,10 +58,8 @@ public class Java8DateTimeApiGeneralComparisonsUnitTest {
 
     @Test
     public void givenZonedDateTimes_whenComparing_thenAssertsPass() {
-        ZonedDateTime timeInNewYork = ZonedDateTime.of(2019, 8, 10, 8, 0, 0, 0,
-          ZoneId.of("America/New_York"));
-        ZonedDateTime timeInBerlin = ZonedDateTime.of(2019, 8, 10, 14, 0, 0, 0,
-          ZoneId.of("Europe/Berlin"));
+        ZonedDateTime timeInNewYork = ZonedDateTime.of(2019, 8, 10, 8, 0, 0, 0, ZoneId.of("America/New_York"));
+        ZonedDateTime timeInBerlin = ZonedDateTime.of(2019, 8, 10, 14, 0, 0, 0, ZoneId.of("Europe/Berlin"));
 
         assertThat(timeInNewYork.isAfter(timeInBerlin), is(false));
         assertThat(timeInNewYork.isBefore(timeInBerlin), is(false));
@@ -79,5 +81,15 @@ public class Java8DateTimeApiGeneralComparisonsUnitTest {
         assertThat(firstTime.equals(secondTime), is(false));
 
         assertThat(firstTime.compareTo(secondTime), is(-1));
+    }
+
+    @Test
+    public void givenMinMaxLocalTimes_whenComparing_thenAssertsPass() {
+        LocalTime minTime = LocalTime.MIN;
+        LocalTime time = LocalTime.of(8, 30);
+        LocalTime maxTime = LocalTime.MAX;
+
+        assertThat(minTime.isBefore(time), is(true));
+        assertThat(time.isBefore(maxTime), is(true));
     }
 }

--- a/java-dates/src/test/java/com/baeldung/dateapi/JavaDurationUnitTest.java
+++ b/java-dates/src/test/java/com/baeldung/dateapi/JavaDurationUnitTest.java
@@ -1,15 +1,38 @@
 package com.baeldung.dateapi;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 
 import org.junit.Test;
 
 public class JavaDurationUnitTest {
+
+    @Test
+    public void givenATimePlus30Seconds_whenRequestingDuration_thenExpect30() {
+        LocalTime initialTime = LocalTime.of(6, 30, 0);
+        LocalTime finalTime = initialTime.plus(Duration.ofSeconds(30));
+
+        long seconds = Duration.between(initialTime, finalTime)
+            .getSeconds();
+
+        assertThat(seconds).isEqualTo(30);
+    }
+
+    @Test
+    public void givenATimePlus30Seconds_whenRequestingSecondsBetween_thenExpect30() {
+        LocalTime initialTime = LocalTime.of(6, 30, 0);
+        LocalTime finalTime = initialTime.plus(Duration.ofSeconds(30));
+
+        long seconds = ChronoUnit.SECONDS.between(initialTime, finalTime);
+
+        assertThat(seconds).isEqualTo(30);
+    }
 
     @Test
     public void test2() {
@@ -29,11 +52,15 @@ public class JavaDurationUnitTest {
         Duration fromMinutes = Duration.ofMinutes(60);
         assertEquals(1, fromMinutes.toHours());
 
-        assertEquals(120, duration.plusSeconds(60).getSeconds());
-        assertEquals(30, duration.minusSeconds(30).getSeconds());
+        assertEquals(120, duration.plusSeconds(60)
+            .getSeconds());
+        assertEquals(30, duration.minusSeconds(30)
+            .getSeconds());
 
-        assertEquals(120, duration.plus(60, ChronoUnit.SECONDS).getSeconds());
-        assertEquals(30, duration.minus(30, ChronoUnit.SECONDS).getSeconds());
+        assertEquals(120, duration.plus(60, ChronoUnit.SECONDS)
+            .getSeconds());
+        assertEquals(30, duration.minus(30, ChronoUnit.SECONDS)
+            .getSeconds());
 
         Duration fromChar1 = Duration.parse("P1DT1H10M10.5S");
         Duration fromChar2 = Duration.parse("PT10M");

--- a/java-dates/src/test/java/com/baeldung/dateapi/JavaPeriodUnitTest.java
+++ b/java-dates/src/test/java/com/baeldung/dateapi/JavaPeriodUnitTest.java
@@ -1,17 +1,40 @@
 package com.baeldung.dateapi;
 
-import org.apache.log4j.Logger;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.time.temporal.ChronoUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import org.apache.log4j.Logger;
+import org.junit.Test;
 
 public class JavaPeriodUnitTest {
 
     private static final Logger LOG = Logger.getLogger(JavaPeriodUnitTest.class);
+
+    @Test
+    public void givenADatePlus5Days_whenRequestingPeriod_thenExpectFive() {
+        LocalDate initialDate = LocalDate.parse("2007-05-10");
+        LocalDate finalDate = initialDate.plus(Period.ofDays(5));
+
+        int days = Period.between(initialDate, finalDate)
+            .getDays();
+
+        assertThat(days).isEqualTo(5);
+    }
+
+    @Test
+    public void givenADatePlus5Days_whenRequestingDaysBetween_thenExpectFive() {
+        LocalDate initialDate = LocalDate.parse("2007-05-10");
+        LocalDate finalDate = initialDate.plus(Period.ofDays(5));
+
+        long days = ChronoUnit.DAYS.between(initialDate, finalDate);
+
+        assertThat(days).isEqualTo(5);
+    }
 
     @Test
     public void whenTestPeriod_thenOk() {
@@ -24,8 +47,10 @@ public class JavaPeriodUnitTest {
         LOG.info(String.format("Years:%d months:%d days:%d", period.getYears(), period.getMonths(), period.getDays()));
 
         assertFalse(period.isNegative());
-        assertEquals(56, period.plusDays(50).getDays());
-        assertEquals(9, period.minusMonths(2).getMonths());
+        assertEquals(56, period.plusDays(50)
+            .getDays());
+        assertEquals(9, period.minusMonths(2)
+            .getMonths());
 
         Period fromUnits = Period.of(3, 10, 10);
         Period fromDays = Period.ofDays(50);

--- a/java-dates/src/test/java/com/baeldung/datetime/UseDateTimeFormatterUnitTest.java
+++ b/java-dates/src/test/java/com/baeldung/datetime/UseDateTimeFormatterUnitTest.java
@@ -1,0 +1,36 @@
+package com.baeldung.datetime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.format.FormatStyle;
+import java.util.Locale;
+
+import org.junit.Test;
+
+public class UseDateTimeFormatterUnitTest {
+    private final UseDateTimeFormatter subject = new UseDateTimeFormatter();
+    private final LocalDateTime localDateTime = LocalDateTime.of(2015, Month.JANUARY, 25, 6, 30);
+
+    @Test
+    public void givenALocalDate_whenFormattingAsIso_thenPass() {
+        String result = subject.formatAsIsoDate(localDateTime);
+
+        assertThat(result).isEqualTo("2015-01-25");
+    }
+
+    @Test
+    public void givenALocalDate_whenFormattingWithPattern_thenPass() {
+        String result = subject.formatCustom(localDateTime, "yyyy/MM/dd");
+
+        assertThat(result).isEqualTo("2015/01/25");
+    }
+
+    @Test
+    public void givenALocalDate_whenFormattingWithStyleAndLocale_thenPass() {
+        String result = subject.formatWithStyleAndLocale(localDateTime, FormatStyle.MEDIUM, Locale.UK);
+
+        assertThat(result).isEqualTo("25 Jan 2015, 06:30:00");
+    }
+}

--- a/java-dates/src/test/java/com/baeldung/datetime/UseLocalDateTimeUnitTest.java
+++ b/java-dates/src/test/java/com/baeldung/datetime/UseLocalDateTimeUnitTest.java
@@ -7,12 +7,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneOffset;
 
 import org.junit.Test;
 
 public class UseLocalDateTimeUnitTest {
 
-    UseLocalDateTime useLocalDateTime = new UseLocalDateTime();
+    private UseLocalDateTime useLocalDateTime = new UseLocalDateTime();
 
     @Test
     public void givenString_whenUsingParse_thenLocalDateTime() {
@@ -32,5 +33,29 @@ public class UseLocalDateTimeUnitTest {
         assertThat(endOfDayFromGivenDirectly).isEqualTo(endOfDayFromGiven);
         assertThat(endOfDayFromGivenDirectly.toLocalTime()).isEqualTo(LocalTime.MAX);
         assertThat(endOfDayFromGivenDirectly.toString()).isEqualTo("2018-06-23T23:59:59.999999999");
+    }
+
+    @Test
+    public void givenLocalDateTimeInFebruary_whenRequestingMonth_thenMonthIsFebruary() {
+        LocalDateTime givenLocalDateTime = LocalDateTime.of(2015, Month.FEBRUARY, 20, 6, 30);
+
+        assertThat(givenLocalDateTime.getMonth()).isEqualTo(Month.FEBRUARY);
+    }
+
+    @Test
+    public void givenLocalDateTime_whenManipulating_thenResultIsAsExpected() {
+        LocalDateTime givenLocalDateTime = LocalDateTime.parse("2015-02-20T06:30:00");
+
+        LocalDateTime manipulatedLocalDateTime = givenLocalDateTime.plusDays(1);
+        manipulatedLocalDateTime = manipulatedLocalDateTime.minusHours(2);
+
+        assertThat(manipulatedLocalDateTime).isEqualTo(LocalDateTime.of(2015, Month.FEBRUARY, 21, 4, 30));
+    }
+
+    @Test
+    public void whenRequestTimeFromEpoch_thenResultIsAsExpected() {
+        LocalDateTime result = useLocalDateTime.ofEpochSecond(1465817690, ZoneOffset.UTC);
+
+        assertThat(result.toString()).isEqualTo("2016-06-13T11:34:50");
     }
 }

--- a/java-dates/src/test/java/com/baeldung/datetime/UseLocalDateUnitTest.java
+++ b/java-dates/src/test/java/com/baeldung/datetime/UseLocalDateUnitTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 
 public class UseLocalDateUnitTest {
 
-    UseLocalDate useLocalDate = new UseLocalDate();
+    private UseLocalDate useLocalDate = new UseLocalDate();
 
     @Test
     public void givenValues_whenUsingFactoryOf_thenLocalDate() {
@@ -86,6 +86,33 @@ public class UseLocalDateUnitTest {
         assertThat(endOfDayWithMax).isEqualTo(endOfDayFromLocalTime);
         assertThat(endOfDayWithMax.toLocalTime()).isEqualTo(LocalTime.MAX);
         assertThat(endOfDayWithMax.toString()).isEqualTo("2018-06-23T23:59:59.999999999");
+    }
+
+    @Test
+    public void givenTheYear2000_whenCheckingForLeapYear_thenReturnTrue() {
+        LocalDate given = LocalDate.parse("2000-06-23");
+
+        boolean leapYear = useLocalDate.isLeapYear(given);
+
+        assertThat(leapYear).isEqualTo(true);
+    }
+
+    @Test
+    public void givenTheYear2004_whenCheckingForLeapYear_thenReturnTrue() {
+        LocalDate given = LocalDate.parse("2004-06-23");
+
+        boolean leapYear = useLocalDate.isLeapYear(given);
+
+        assertThat(leapYear).isEqualTo(true);
+    }
+
+    @Test
+    public void givenTheYear2019_whenCheckingForLeapYear_thenReturnFalse() {
+        LocalDate given = LocalDate.parse("2019-06-23");
+
+        boolean leapYear = useLocalDate.isLeapYear(given);
+
+        assertThat(leapYear).isEqualTo(false);
     }
 
 }

--- a/java-dates/src/test/java/com/baeldung/datetime/UseLocalTimeUnitTest.java
+++ b/java-dates/src/test/java/com/baeldung/datetime/UseLocalTimeUnitTest.java
@@ -7,21 +7,30 @@ import org.junit.Test;
 
 public class UseLocalTimeUnitTest {
 
-    UseLocalTime useLocalTime = new UseLocalTime();
+    private UseLocalTime useLocalTime = new UseLocalTime();
 
     @Test
     public void givenValues_whenUsingFactoryOf_thenLocalTime() {
-        Assert.assertEquals("07:07:07", useLocalTime.getLocalTimeUsingFactoryOfMethod(7, 7, 7).toString());
+        Assert.assertEquals("07:07:07", useLocalTime.getLocalTimeUsingFactoryOfMethod(7, 7, 7)
+            .toString());
+    }
+
+    @Test
+    public void givenValues_whenUsingFactoryOfWithoutSeconds_thenLocalTime() {
+        Assert.assertEquals("07:07", useLocalTime.getLocalTimeUsingFactoryOfMethod(7, 7)
+            .toString());
     }
 
     @Test
     public void givenString_whenUsingParse_thenLocalTime() {
-        Assert.assertEquals("06:30", useLocalTime.getLocalTimeUsingParseMethod("06:30").toString());
+        Assert.assertEquals("06:30", useLocalTime.getLocalTimeUsingParseMethod("06:30")
+            .toString());
     }
 
     @Test
     public void givenTime_whenAddHour_thenLocalTime() {
-        Assert.assertEquals("07:30", useLocalTime.addAnHour(LocalTime.of(6, 30)).toString());
+        Assert.assertEquals("07:30", useLocalTime.addAnHour(LocalTime.of(6, 30))
+            .toString());
     }
 
     @Test

--- a/java-dates/src/test/java/com/baeldung/datetime/UseOffsetDateTimeUnitTest.java
+++ b/java-dates/src/test/java/com/baeldung/datetime/UseOffsetDateTimeUnitTest.java
@@ -1,0 +1,24 @@
+package com.baeldung.datetime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import org.junit.Test;
+
+public class UseOffsetDateTimeUnitTest {
+    private final UseOffsetDateTime subject = new UseOffsetDateTime();
+
+    @Test
+    public void givenAZoneOffSetAndLocalDateTime_whenCombing_thenValidResult() {
+        ZoneOffset offset = ZoneOffset.of("+02:00");
+        LocalDateTime localDateTime = LocalDateTime.of(2015, Month.FEBRUARY, 20, 6, 30);
+
+        OffsetDateTime result = subject.offsetOfLocalDateTimeAndOffset(localDateTime, offset);
+
+        assertThat(result.toString()).isEqualTo("2015-02-20T06:30+02:00");
+    }
+}

--- a/java-dates/src/test/java/com/baeldung/datetime/UseToInstantUnitTest.java
+++ b/java-dates/src/test/java/com/baeldung/datetime/UseToInstantUnitTest.java
@@ -1,0 +1,33 @@
+package com.baeldung.datetime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import org.junit.Test;
+
+public class UseToInstantUnitTest {
+
+    private UseToInstant subject = new UseToInstant();
+
+    @Test
+    public void givenAGregorianCalenderDate_whenConvertingToLocalDate_thenAsExpected() {
+        GregorianCalendar givenCalender = new GregorianCalendar(2018, Calendar.JULY, 28);
+
+        LocalDateTime localDateTime = subject.convertDateToLocalDate(givenCalender);
+
+        assertThat(localDateTime).isEqualTo("2018-07-28T00:00:00");
+    }
+
+    @Test
+    public void givenADate_whenConvertingToLocalDate_thenAsExpected() {
+        Date givenDate = new Date(1465817690000L);
+
+        LocalDateTime localDateTime = subject.convertDateToLocalDate(givenDate);
+
+        assertThat(localDateTime).isEqualTo("2016-06-13T13:34:50");
+    }
+}

--- a/java-dates/src/test/java/com/baeldung/datetime/UseZonedDateTimeUnitTest.java
+++ b/java-dates/src/test/java/com/baeldung/datetime/UseZonedDateTimeUnitTest.java
@@ -7,19 +7,27 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 public class UseZonedDateTimeUnitTest {
 
-    UseZonedDateTime zonedDateTime = new UseZonedDateTime();
+    private UseZonedDateTime zonedDateTime = new UseZonedDateTime();
 
     @Test
     public void givenZoneId_thenZonedDateTime() {
         ZoneId zoneId = ZoneId.of("Europe/Paris");
         ZonedDateTime zonedDatetime = zonedDateTime.getZonedDateTime(LocalDateTime.parse("2016-05-20T06:30"), zoneId);
         Assert.assertEquals(zoneId, ZoneId.from(zonedDatetime));
+    }
+
+    @Test
+    public void whenRequestingZones_thenAtLeastOneIsReturned() {
+        Set<String> allZoneIds = ZoneId.getAvailableZoneIds();
+
+        assertThat(allZoneIds.size()).isGreaterThan(1);
     }
 
     @Test
@@ -41,5 +49,16 @@ public class UseZonedDateTimeUnitTest {
         assertThat(startOfOfDayWithMethod.toLocalTime()).isEqualTo(LocalTime.MIDNIGHT);
         assertThat(startOfOfDayWithMethod.toLocalTime()
             .toString()).isEqualTo("00:00");
+    }
+
+    @Test
+    public void givenAStringWithTimeZone_whenParsing_thenEqualsExpected() {
+        ZonedDateTime resultFromString = zonedDateTime.getZonedDateTimeUsingParseMethod("2015-05-03T10:15:30+01:00[Europe/Paris]");
+        ZonedDateTime resultFromLocalDateTime = ZonedDateTime.of(2015, 5, 3, 11, 15, 30, 0, ZoneId.of("Europe/Paris"));
+
+        assertThat(resultFromString.getZone()).isEqualTo(ZoneId.of("Europe/Paris"));
+        assertThat(resultFromLocalDateTime.getZone()).isEqualTo(ZoneId.of("Europe/Paris"));
+
+        assertThat(resultFromString).isEqualTo(resultFromLocalDateTime);
     }
 }


### PR DESCRIPTION
[BAEL-3315] Added missing code snippets from the Java 8 Date/Time article

Also:
- formatted changed files with Eclipse profile
- corrected failing test: givenTwoDatesInJava8_whenDifferentiating_thenWeGetSix

Please note that this project is excluded from the build:

```xml
<!-- <module>java-dates</module> --> <!-- We haven't upgraded to java 9. Fixing in BAEL-10841 -->
```

But here is the output from running it locally:
```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.baeldung:java-dates:jar:0.1.0-SNAPSHOT
[WARNING] 'dependencies.dependency.version' for com.darwinsys:hirondelle-date4j:jar is either LATEST or RELEASE (both of them are being deprecated) @ line 43, column 22
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] gitflow-incremental-builder is disabled.
[INFO] 
[INFO] ----------------------< com.baeldung:java-dates >-----------------------
[INFO] Building java-dates 0.1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ java-dates ---
[INFO] Deleting /Users/martinvw/baeldung/tutorials/java-dates/target
[INFO] 
[INFO] --- directory-maven-plugin:0.3.1:directory-of (directories) @ java-dates ---
[INFO] Directory of com.baeldung:parent-modules set to: /Users/martinvw/baeldung/tutorials
[INFO] 
[INFO] --- maven-install-plugin:2.5.1:install-file (install-jar-lib) @ java-dates ---
[INFO] Installing /Users/martinvw/baeldung/tutorials/custom-pmd-0.0.1.jar to /Users/martinvw/.m2/repository/org/baeldung/pmd/custom-pmd/0.0.1/custom-pmd-0.0.1.jar
[INFO] Installing /var/folders/xz/mgcb037n69d4jc8p9x5x7lch0000gn/T/mvninstall9904825698520572967.pom to /Users/martinvw/.m2/repository/org/baeldung/pmd/custom-pmd/0.0.1/custom-pmd-0.0.1.pom
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ java-dates ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO] 
[INFO] --- maven-compiler-plugin:3.7.0:compile (default-compile) @ java-dates ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 23 source files to /Users/martinvw/baeldung/tutorials/java-dates/target/classes
[INFO] 
[INFO] >>> maven-pmd-plugin:3.8:check (default) > :pmd @ java-dates >>>
[INFO] 
[INFO] --- maven-pmd-plugin:3.8:pmd (pmd) @ java-dates ---
[WARNING] There are 23 PMD processing errors:
[WARNING] /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseDuration.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseDuration.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/date/comparison/DateTimeComparisonUtils.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/date/comparison/DateTimeComparisonUtils.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseLocalDate.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseLocalDate.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/LocalDateTimeExtractYearMonthDayIntegerValues.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/LocalDateTimeExtractYearMonthDayIntegerValues.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/OffsetDateTimeExtractYearMonthDayIntegerValues.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/OffsetDateTimeExtractYearMonthDayIntegerValues.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/LocalDateExtractYearMonthDayIntegerValues.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/LocalDateExtractYearMonthDayIntegerValues.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/AddHoursToDate.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/AddHoursToDate.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/DateExtractYearMonthDayIntegerValues.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/DateExtractYearMonthDayIntegerValues.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseDateTimeFormatter.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseDateTimeFormatter.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/date/DateWithoutTime.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/date/DateWithoutTime.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/date/AgeCalculator.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/date/AgeCalculator.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/ZonedDateTimeExtractYearMonthDayIntegerValues.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/ZonedDateTimeExtractYearMonthDayIntegerValues.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseLocalTime.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseLocalTime.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/date/comparison/LegacyDateComparisonUtils.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/date/comparison/LegacyDateComparisonUtils.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseToInstant.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseToInstant.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UsePeriod.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UsePeriod.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseOffsetDateTime.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseOffsetDateTime.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseZonedDateTime.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseZonedDateTime.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseLocalDateTime.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/UseLocalDateTime.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/gregorian/calendar/GregorianCalendarExample.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/gregorian/calendar/GregorianCalendarExample.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/java9/time/TimeApi.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/java9/time/TimeApi.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/temporaladjuster/CustomTemporalAdjuster.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/temporaladjuster/CustomTemporalAdjuster.java
/Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/modify/DateIncrementer.java: Error while processing /Users/martinvw/baeldung/tutorials/java-dates/src/main/java/com/baeldung/datetime/modify/DateIncrementer.java
[INFO] 
[INFO] <<< maven-pmd-plugin:3.8:check (default) < :pmd @ java-dates <<<
[INFO] 
[INFO] 
[INFO] --- maven-pmd-plugin:3.8:check (default) @ java-dates ---
[INFO] 
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ java-dates ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO] 
[INFO] --- maven-compiler-plugin:3.7.0:testCompile (default-testCompile) @ java-dates ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 34 source files to /Users/martinvw/baeldung/tutorials/java-dates/target/test-classes
[INFO] /Users/martinvw/baeldung/tutorials/java-dates/src/test/java/com/baeldung/java9/time/TimeApiUnitTest.java: /Users/martinvw/baeldung/tutorials/java-dates/src/test/java/com/baeldung/java9/time/TimeApiUnitTest.java uses or overrides a deprecated API.
[INFO] /Users/martinvw/baeldung/tutorials/java-dates/src/test/java/com/baeldung/java9/time/TimeApiUnitTest.java: Recompile with -Xlint:deprecation for details.
[INFO] 
[INFO] --- maven-surefire-plugin:2.21.0:test (default-test) @ java-dates ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.baeldung.date.comparison.LegacyDateComparisonUtilsUnitTest
[INFO] Running com.baeldung.date.AgeCalculatorUnitTest
[INFO] Running com.baeldung.date.comparison.DateTimeComparisonUtilsUnitTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.116 s - in com.baeldung.date.comparison.DateTimeComparisonUtilsUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.132 s - in com.baeldung.date.comparison.LegacyDateComparisonUtilsUnitTest
[INFO] Running com.baeldung.jodatime.JodaTimeUnitTest
[INFO] Running com.baeldung.temporaladjusters.CustomTemporalAdjusterUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.164 s - in com.baeldung.date.AgeCalculatorUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 s - in com.baeldung.temporaladjusters.CustomTemporalAdjusterUnitTest
[INFO] Running com.baeldung.dateapi.JavaUtilTimeUnitTest
1990-12-15
[INFO] Running com.baeldung.java9.time.TimeApiUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.072 s - in com.baeldung.java9.time.TimeApiUnitTest
[INFO] Running com.baeldung.dateapi.JavaDurationUnitTest
2019-10-23
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.15 s - in com.baeldung.dateapi.JavaUtilTimeUnitTest
[INFO] Running com.baeldung.datetime.UseLocalTimeUnitTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.baeldung.datetime.UseLocalTimeUnitTest
[INFO] Running com.baeldung.datetime.UseTimeZoneUnitTest
Java8: Time now in 'Asia/Singapore' is 'wo 2019-10-23 17:03:51 p.m.'
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.111 s - in com.baeldung.dateapi.JavaDurationUnitTest
[INFO] Running com.baeldung.datetime.LocalDateExtractYearMonthDayIntegerValuesUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in com.baeldung.datetime.LocalDateExtractYearMonthDayIntegerValuesUnitTest
[INFO] Running com.baeldung.datetime.OffsetDateTimeExtractYearMonthDayIntegerValuesUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in com.baeldung.datetime.OffsetDateTimeExtractYearMonthDayIntegerValuesUnitTest
[INFO] Running com.baeldung.datetime.ZonedDateTimeExtractYearMonthDayIntegerValuesUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.baeldung.datetime.ZonedDateTimeExtractYearMonthDayIntegerValuesUnitTest
[INFO] Running com.baeldung.datetime.UsePeriodUnitTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.baeldung.datetime.UsePeriodUnitTest
[INFO] Running com.baeldung.datetime.UseLocalDateTimeUnitTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s - in com.baeldung.datetime.UseLocalDateTimeUnitTest
[INFO] Running com.baeldung.date.comparison.Java8DateTimeApiGeneralComparisonsUnitTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.316 s - in com.baeldung.jodatime.JodaTimeUnitTest
[INFO] Running com.baeldung.temporaladjusters.TemporalAdjustersUnitTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.baeldung.temporaladjusters.TemporalAdjustersUnitTest
[INFO] Running com.baeldung.dateapi.JavaPeriodUnitTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s - in com.baeldung.date.comparison.Java8DateTimeApiGeneralComparisonsUnitTest
[INFO] Running com.baeldung.dst.DaylightSavingTimeJavaTimeExamplesUnitTest
2018-03-25T01:55
 ZonedDateTime = 2018-03-25T01:55+01:00[Europe/Rome]
       Zone ID = Europe/Rome (Europe/Rome)
     RawOffset = 60 minutes
  -----------------------------------------
 ZonedDateTime = 2018-03-25T03:05+02:00[Europe/Rome]
       Zone ID = Europe/Rome (Europe/Rome)
     RawOffset = 120 minutes
  -----------------------------------------
Total java.time.ZoneId      count : 600
Total java.util.TimeZone Id count : 628
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in com.baeldung.dst.DaylightSavingTimeJavaTimeExamplesUnitTest
log4j:WARN No appenders could be found for logger (com.baeldung.dateapi.JavaPeriodUnitTest).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Joda-time: Time now in 'Asia/Singapore' is 'wo 2019-10-23 17:03:51 p.m.'
Java7: Time now in 'Asia/Singapore' is 'wo 2019-10-23 17:03:51 p.m.'
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.219 s - in com.baeldung.datetime.UseTimeZoneUnitTest
[INFO] Running com.baeldung.datetime.modify.DateIncrementerUnitTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.067 s - in com.baeldung.datetime.modify.DateIncrementerUnitTest
[INFO] Running com.baeldung.datetime.UseLocalDateUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.183 s - in com.baeldung.dateapi.JavaPeriodUnitTest
[INFO] Running com.baeldung.datetime.DateExtractYearMonthDayIntegerValuesUnitTest
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in com.baeldung.datetime.UseLocalDateUnitTest
[INFO] Running com.baeldung.datetime.LocalDateTimeExtractYearMonthDayIntegerValuesUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in com.baeldung.datetime.DateExtractYearMonthDayIntegerValuesUnitTest
[INFO] Running com.baeldung.datetime.UseDateTimeFormatterUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.baeldung.datetime.LocalDateTimeExtractYearMonthDayIntegerValuesUnitTest
[INFO] Running com.baeldung.date.DateDiffUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.048 s - in com.baeldung.datetime.UseDateTimeFormatterUnitTest
[INFO] Running com.baeldung.datetime.UseToInstantUnitTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in com.baeldung.datetime.UseToInstantUnitTest
[INFO] Running com.baeldung.datetime.UseZonedDateTimeUnitTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.066 s - in com.baeldung.date.DateDiffUnitTest
[INFO] Running com.baeldung.dst.DaylightSavingTimeExamplesUnitTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.02 s - in com.baeldung.datetime.UseZonedDateTimeUnitTest
[INFO] Running com.baeldung.datetime.UseOffsetDateTimeUnitTest
    Zone ID = Europe/Rome (Midden-Europese standaardtijd)
  RawOffset = 60 minutes
        DST = 60 minutes
  -----------------------------------------
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.baeldung.datetime.UseOffsetDateTimeUnitTest
[INFO] Running com.baeldung.datetime.AddHoursToDateUnitTest
Before DST (00:55 UTC - 01:55 GMT+1) = Sun Mar 25 01:55:00 CET 2018
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 s - in com.baeldung.datetime.AddHoursToDateUnitTest
[INFO] Running com.baeldung.date.DateWithoutTimeUnitTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.baeldung.date.DateWithoutTimeUnitTest
[INFO] Running com.baeldung.time.ElapsedTimeUnitTest
With this Calendar 60 minutes must be added to UTC (GMT TimeZone) to get a correct date for this TimeZone

 After DST (01:05 UTC - 03:05 GMT+2) = Sun Mar 25 03:05:00 CEST 2018
With this Calendar 120 minutes must be added to UTC (GMT TimeZone) to get a correct date for this TimeZone

[WARNING] Tests run: 2, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.092 s - in com.baeldung.dst.DaylightSavingTimeExamplesUnitTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.017 s - in com.baeldung.time.ElapsedTimeUnitTest
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 133, Failures: 0, Errors: 0, Skipped: 1
[INFO] 
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ java-dates ---
[INFO] Building jar: /Users/martinvw/baeldung/tutorials/java-dates/target/java-dates.jar
[INFO] 
[INFO] --- maven-install-plugin:2.5.1:install (default-install) @ java-dates ---
[INFO] Installing /Users/martinvw/baeldung/tutorials/java-dates/target/java-dates.jar to /Users/martinvw/.m2/repository/com/baeldung/java-dates/0.1.0-SNAPSHOT/java-dates-0.1.0-SNAPSHOT.jar
[INFO] Installing /Users/martinvw/baeldung/tutorials/java-dates/pom.xml to /Users/martinvw/.m2/repository/com/baeldung/java-dates/0.1.0-SNAPSHOT/java-dates-0.1.0-SNAPSHOT.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18.818 s
[INFO] Finished at: 2019-10-23T11:04:02+02:00
[INFO] ------------------------------------------------------------------------
```