### PR TITLE
BAEL-3409: Fixed the Broken Test

### DIFF
--- a/spring-mvc-simple-2/src/main/resources/application.properties
+++ b/spring-mvc-simple-2/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.main.allow-bean-definition-overriding=true
+spring.mail.host=localhost
+spring.mail.port=8025


### PR DESCRIPTION
Wiser was listening to port 8025 but we didn't configure the Spring Boot to use it. Anyway, adding the required `spring.mail.*` properties fixed the problem.