### PR TITLE
BAEL-3410: Moved the User Model to its Package

### DIFF
--- a/spring-boot/src/main/java/org/baeldung/model/User.java
+++ b/spring-boot/src/main/java/org/baeldung/model/User.java
@@ -1,4 +1,4 @@
-package org.baeldung.caching.model;
+package org.baeldung.model;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;

--- a/spring-boot/src/main/java/org/baeldung/repository/UserRepository.java
+++ b/spring-boot/src/main/java/org/baeldung/repository/UserRepository.java
@@ -1,6 +1,6 @@
 package org.baeldung.repository;
 
-import org.baeldung.caching.model.User;
+import org.baeldung.model.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -15,7 +15,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
 
 @Repository("userRepository")
 public interface UserRepository extends JpaRepository<User, Integer> {

--- a/spring-boot/src/test/java/org/baeldung/repository/UserRepositoryIntegrationTest.java
+++ b/spring-boot/src/test/java/org/baeldung/repository/UserRepositoryIntegrationTest.java
@@ -1,19 +1,17 @@
 package org.baeldung.repository;
 
 import org.baeldung.boot.config.H2JpaConfig;
-import org.baeldung.caching.model.User;
+import org.baeldung.model.User;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
All these integration tests are failing because of a very weird mistake. Based on the directory structure, the User model should be in the `package org.baeldung.model` package, but instead it was in the `package org.baeldung.caching.model;` package.