### PR TITLE
BAEL 3275: Fix the Integrations Tests in spring-data-redis

### DIFF
--- a/persistence-modules/spring-data-redis/pom.xml
+++ b/persistence-modules/spring-data-redis/pom.xml
@@ -87,7 +87,8 @@
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <verbose>true</verbose>
-                    <fork>true</fork>
+                    <fork>false</fork>
+                    <forkCount>0</forkCount>
                     <argLine>-Xmx1024m</argLine>
                 </configuration>
             </plugin>

--- a/persistence-modules/spring-data-redis/src/test/java/com/baeldung/spring/data/reactive/redis/template/RedisKeyCommandsIntegrationTest.java
+++ b/persistence-modules/spring-data-redis/src/test/java/com/baeldung/spring/data/reactive/redis/template/RedisKeyCommandsIntegrationTest.java
@@ -38,7 +38,7 @@ public class RedisKeyCommandsIntegrationTest {
     
     @BeforeClass
     public static void startRedisServer() throws IOException {
-        redisServer = new RedisServerBuilder().port(6379).setting("maxheap 256M").build();
+        redisServer = new RedisServerBuilder().port(6379).setting("maxmemory 256M").build();
         redisServer.start();
     }
     

--- a/persistence-modules/spring-data-redis/src/test/java/com/baeldung/spring/data/reactive/redis/template/RedisTemplateListOpsIntegrationTest.java
+++ b/persistence-modules/spring-data-redis/src/test/java/com/baeldung/spring/data/reactive/redis/template/RedisTemplateListOpsIntegrationTest.java
@@ -36,7 +36,7 @@ public class RedisTemplateListOpsIntegrationTest {
     
     @BeforeClass
     public static void startRedisServer() throws IOException {
-        redisServer = new RedisServerBuilder().port(6379).setting("maxheap 128M").build();
+        redisServer = new RedisServerBuilder().port(6379).setting("maxmemory 128M").build();
         redisServer.start();
     }
     

--- a/persistence-modules/spring-data-redis/src/test/java/com/baeldung/spring/data/reactive/redis/template/RedisTemplateValueOpsIntegrationTest.java
+++ b/persistence-modules/spring-data-redis/src/test/java/com/baeldung/spring/data/reactive/redis/template/RedisTemplateValueOpsIntegrationTest.java
@@ -38,7 +38,7 @@ public class RedisTemplateValueOpsIntegrationTest {
     
     @BeforeClass
     public static void startRedisServer() throws IOException {
-        redisServer = new RedisServerBuilder().port(6379).setting("maxheap 256M").build();
+        redisServer = new RedisServerBuilder().port(6379).setting("maxmemory 256M").build();
         redisServer.start();
     }
     

--- a/persistence-modules/spring-data-redis/src/test/java/com/baeldung/spring/data/redis/RedisMessageListenerIntegrationTest.java
+++ b/persistence-modules/spring-data-redis/src/test/java/com/baeldung/spring/data/redis/RedisMessageListenerIntegrationTest.java
@@ -33,7 +33,7 @@ public class RedisMessageListenerIntegrationTest {
     
     @BeforeClass
     public static void startRedisServer() throws IOException {
-        redisServer = new RedisServerBuilder().port(6379).setting("maxheap 256M").build();
+        redisServer = new RedisServerBuilder().port(6379).setting("maxmemory 256M").build();
         redisServer.start();
     }
     

--- a/persistence-modules/spring-data-redis/src/test/java/com/baeldung/spring/data/redis/RedisMessageListenerIntegrationTest.java
+++ b/persistence-modules/spring-data-redis/src/test/java/com/baeldung/spring/data/redis/RedisMessageListenerIntegrationTest.java
@@ -46,7 +46,7 @@ public class RedisMessageListenerIntegrationTest {
     public void testOnMessage() throws Exception {
         String message = "Message " + UUID.randomUUID();
         redisMessagePublisher.publish(message);
-        Thread.sleep(100);
+        Thread.sleep(1000);
         assertTrue(RedisMessageSubscriber.messageList.get(0).contains(message));
     }
 }

--- a/persistence-modules/spring-data-redis/src/test/java/com/baeldung/spring/data/redis/repo/StudentRepositoryIntegrationTest.java
+++ b/persistence-modules/spring-data-redis/src/test/java/com/baeldung/spring/data/redis/repo/StudentRepositoryIntegrationTest.java
@@ -34,7 +34,7 @@ public class StudentRepositoryIntegrationTest {
     
     @BeforeClass
     public static void startRedisServer() throws IOException {
-        redisServer = new RedisServerBuilder().port(6379).setting("maxheap 128M").build();
+        redisServer = new RedisServerBuilder().port(6379).setting("maxmemory 128M").build();
         redisServer.start();
     }
     

--- a/persistence-modules/spring-data-redis/src/test/java/org/baeldung/SpringContextIntegrationTest.java
+++ b/persistence-modules/spring-data-redis/src/test/java/org/baeldung/SpringContextIntegrationTest.java
@@ -1,15 +1,34 @@
 package org.baeldung;
 
+import com.baeldung.spring.data.redis.config.RedisConfig;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import redis.embedded.RedisServerBuilder;
 
-import com.baeldung.spring.data.redis.config.RedisConfig;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
 
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = BEFORE_CLASS)
 @ContextConfiguration(classes = RedisConfig.class)
 public class SpringContextIntegrationTest {
+
+    private static redis.embedded.RedisServer redisServer;
+
+    @BeforeClass
+    public static void startRedisServer() {
+        redisServer = new RedisServerBuilder().port(6379).setting("maxmemory 256M").build();
+        redisServer.start();
+    }
+
+    @AfterClass
+    public static void stopRedisServer() {
+        redisServer.stop();
+    }
 
     @Test
     public void whenSpringContextIsBootstrapped_thenNoExceptions() {


### PR DESCRIPTION
Fixed the following issues:
 - There is no such configuration as `maxheap`.
 - Can't fork and parallel since we can't let 10 Redis servers to listen to the same port. 
 - The context test was failing to connect to the Redis server.
 - Fixed a flaky pub-sub test