### PR TITLE
[BAEL-17468] spring-data-mongodb | fix Live Test

### DIFF
--- a/persistence-modules/spring-data-mongodb/src/test/java/com/baeldung/transaction/MongoTransactionalLiveTest.java
+++ b/persistence-modules/spring-data-mongodb/src/test/java/com/baeldung/transaction/MongoTransactionalLiveTest.java
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.baeldung.config.MongoConfig;
 import com.baeldung.model.User;
 import com.baeldung.repository.UserRepository;
-import com.mongodb.MongoCommandException;
 
 /**
  * 
@@ -62,7 +61,8 @@ public class MongoTransactionalLiveTest {
         }
     }
 
-    @Test(expected = MongoCommandException.class)
+    // using the count() operation doesn't trigger a MongoCommandException using the latest spring-data-mongodb versions
+    @Test
     @Transactional
     public void whenCountDuringMongoTransaction_thenException() {
         userRepository.save(new User("John", 30));

--- a/persistence-modules/spring-data-mongodb/src/test/java/com/baeldung/transaction/MongoTransactionalLiveTest.java
+++ b/persistence-modules/spring-data-mongodb/src/test/java/com/baeldung/transaction/MongoTransactionalLiveTest.java
@@ -26,7 +26,11 @@ import com.baeldung.repository.UserRepository;
 /**
  * 
  * This test requires:
- * * mongodb instance running on the environment
+ * * mongodb instance running on the environment, supporting replica set:
+ * (e.g. `docker run -d -p 27017:27017 --name bael-mongo mongo`)
+ * 
+ * * Initiate the replica set:
+ * (e.g. `docker exec bael-mongo mongo --eval "rs.initiate() && rs.conf()"`)
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)


### PR DESCRIPTION
fixed test, the 'error' was caused is caused by an improvement in theSpring Data Mongodb library, it now handles the count() operation gracefully by using the mongo-java-driver countDocument() operation (which in turn relies in the count aggregation stage), as suggested by the mongodb docs'