### PR TITLE
BAEL-3444: Fixed calculator unit tests due to incorrect Cucumber glue directory

### DIFF
--- a/testing-modules/testing-libraries/src/test/java/com/baeldung/calculator/CalculatorIntegrationTest.java
+++ b/testing-modules/testing-libraries/src/test/java/com/baeldung/calculator/CalculatorIntegrationTest.java
@@ -9,7 +9,6 @@ import io.cucumber.junit.CucumberOptions;
 @CucumberOptions(
   features = {"classpath:features/calculator.feature", "classpath:features/calculator-scenario-outline.feature"}
   , plugin = {"pretty", "json:target/reports/json/calculator.json"}
-  , glue = {"com.baeldung.cucumber.calculator"}
 )
 public class CalculatorIntegrationTest {
 }


### PR DESCRIPTION
The glue directory was incorrect in the Cucumber calculator tests. I have removed the explicit glue directory so that it defaults to the directory containing the integration tests (which is the correct directory in this case).

I have verified that the integration tests execute by running the following Maven command:

```
mvn clean install -P integration-heavy
```