### PR TITLE
Update ThreadLocalRandom benchmark to show issues with contention

### DIFF
--- a/core-java-modules/core-java-concurrency-advanced-2/src/main/java/com/baeldung/threadlocalrandom/ThreadLocalRandomBenchMarkRunner.java
+++ b/core-java-modules/core-java-concurrency-advanced-2/src/main/java/com/baeldung/threadlocalrandom/ThreadLocalRandomBenchMarkRunner.java
@@ -1,22 +1,27 @@
 package com.baeldung.threadlocalrandom;
 
 import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import com.google.common.collect.ImmutableList;
 
 public class ThreadLocalRandomBenchMarkRunner {
 
     public static void main(String[] args) throws Exception {
 
-        Options options = new OptionsBuilder().include(ThreadLocalRandomBenchMarker.class.getSimpleName())
-            .threads(1)
+        ChainedOptionsBuilder options = new OptionsBuilder().include(ThreadLocalRandomBenchMarker.class.getSimpleName())
             .forks(1)
             .shouldFailOnError(true)
             .shouldDoGC(true)
-            .jvmArgs("-server")
-            .build();
+            .jvmArgs("-server");
 
-        new Runner(options).run();
-
+        for (Integer i : ImmutableList.of(1, 2, 8, 32)) {
+            new Runner(
+                    options
+                            .threads(i)
+                            .build())
+                    .run();
+        }
     }
 }

--- a/core-java-modules/core-java-concurrency-advanced-2/src/main/java/com/baeldung/threadlocalrandom/ThreadLocalRandomBenchMarker.java
+++ b/core-java-modules/core-java-concurrency-advanced-2/src/main/java/com/baeldung/threadlocalrandom/ThreadLocalRandomBenchMarker.java
@@ -1,64 +1,34 @@
 package com.baeldung.threadlocalrandom;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-@BenchmarkMode(Mode.AverageTime)
+@BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 1)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
 public class ThreadLocalRandomBenchMarker {
+    private final Random random = new Random();
 
-    List<Callable<Integer>> randomCallables = new ArrayList<>();
-    List<Callable<Integer>> threadLocalRandomCallables = new ArrayList<>();
-
-    @Setup(Level.Iteration)
-    public void init() {
-        Random random = new Random();
-        randomCallables = new ArrayList<>();
-        threadLocalRandomCallables = new ArrayList<>();
-        for (int i = 0; i < 1000; i++) {
-            randomCallables.add(() -> {
-                return random.nextInt();
-            });
-        }
-
-        for (int i = 0; i < 1000; i++) {
-            threadLocalRandomCallables.add(() -> {
-                return ThreadLocalRandom.current()
-                    .nextInt();
-            });
-        }
+    @Benchmark
+    public int randomValuesUsingRandom() {
+        return random.nextInt();
     }
 
     @Benchmark
-    public void randomValuesUsingRandom() throws InterruptedException {
-        ExecutorService executor = Executors.newWorkStealingPool();
-        executor.invokeAll(randomCallables);
-        executor.shutdown();
-    }
-
-    @Benchmark
-    public void randomValuesUsingThreadLocalRandom() throws InterruptedException {
-        ExecutorService executor = Executors.newWorkStealingPool();
-        executor.invokeAll(threadLocalRandomCallables);
-        executor.shutdown();
+    public int randomValuesUsingThreadLocalRandom() {
+        return ThreadLocalRandom
+                .current()
+                .nextInt();
     }
 
 }


### PR DESCRIPTION
Previous benchmark was measuring initialization of thread pools and
their shutdown, not really measuring Random.nextInt() with shared Random
instance and ThreadLocalRandom.current()

Example when run with 8 threads

```
Benchmark                                                         Mode  Cnt     Score     Error   Units
ThreadLocalRandomBenchMarker.randomValuesUsingRandom             thrpt   20     9.597 ±   0.475  ops/us
ThreadLocalRandomBenchMarker.randomValuesUsingThreadLocalRandom  thrpt   20  2195.178 ± 109.579  ops/us
```

This will require to change https://www.baeldung.com/java-thread-local-random#comparing-threadlocalrandom-and-random-using-jmh