### PR TITLE
Make sure that native sqlite4 dependencies are copied to expected path

### DIFF
--- a/persistence-modules/spring-data-dynamodb/pom.xml
+++ b/persistence-modules/spring-data-dynamodb/pom.xml
@@ -151,6 +151,25 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>test</includeScope>
+                            <includeTypes>so,dll,dylib</includeTypes>
+                            <outputDirectory>${project.basedir}/native-libs</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
We need to add this plugin to get native dependencies to specific folder.
In this example we set the `sqlite4java.library.path` to show native libraries.
So we make sure that the native dependencies are copied over to the `native-libs` folder.
Without this added I am seeing unreliable behavior on IDEs.

Reference : https://stackoverflow.com/questions/26901613/easier-dynamodb-local-testing