### PR TITLE
[BAEL-19382] Upgrade parent-spring-5 to the latest version of Spring 5

### DIFF
--- a/httpclient-simple/src/main/java/com/baeldung/basic/MyBasicAuthenticationEntryPoint.java
+++ b/httpclient-simple/src/main/java/com/baeldung/basic/MyBasicAuthenticationEntryPoint.java
@@ -1,20 +1,20 @@
 package com.baeldung.basic;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.PrintWriter;
 
 @Component
 public class MyBasicAuthenticationEntryPoint extends BasicAuthenticationEntryPoint {
 
     @Override
-    public void commence(final HttpServletRequest request, final HttpServletResponse response, final AuthenticationException authException) throws IOException, ServletException {
+    public void commence(final HttpServletRequest request, final HttpServletResponse response, final AuthenticationException authException) throws IOException {
         response.addHeader("WWW-Authenticate", "Basic realm=\"" + getRealmName() + "\"");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         final PrintWriter writer = response.getWriter();
@@ -22,7 +22,7 @@ public class MyBasicAuthenticationEntryPoint extends BasicAuthenticationEntryPoi
     }
 
     @Override
-    public void afterPropertiesSet() throws Exception {
+    public void afterPropertiesSet() {
         setRealmName("Baeldung");
         super.afterPropertiesSet();
     }

--- a/parent-spring-5/pom.xml
+++ b/parent-spring-5/pom.xml
@@ -30,8 +30,8 @@
     </dependencies>
 
     <properties>
-        <spring.version>5.1.9.RELEASE</spring.version>
-        <spring-security.version>5.1.6.RELEASE</spring-security.version>
+        <spring.version>5.2.2.RELEASE</spring.version>
+        <spring-security.version>5.2.1.RELEASE</spring-security.version>
     </properties>
 
 </project>

--- a/spring-security-modules/spring-security-mvc-login/src/main/resources/RedirectionWebSecurityConfig.xml
+++ b/spring-security-modules/spring-security-mvc-login/src/main/resources/RedirectionWebSecurityConfig.xml
@@ -2,9 +2,9 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:beans="http://www.springframework.org/schema/beans"
              xsi:schemaLocation="
 		http://www.springframework.org/schema/security
-        http://www.springframework.org/schema/security/spring-security-4.2.xsd
+        https://www.springframework.org/schema/security/spring-security.xsd
 		http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd"
+        https://www.springframework.org/schema/beans/spring-beans.xsd"
 >
     <http use-expressions="true">
         <intercept-url pattern="/login*" access="permitAll"/>

--- a/spring-security-modules/spring-security-mvc-login/src/main/resources/channelWebSecurityConfig.xml
+++ b/spring-security-modules/spring-security-mvc-login/src/main/resources/channelWebSecurityConfig.xml
@@ -2,9 +2,9 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:beans="http://www.springframework.org/schema/beans"
     xsi:schemaLocation="
 		http://www.springframework.org/schema/security 
-        http://www.springframework.org/schema/security/spring-security-4.2.xsd
+        https://www.springframework.org/schema/security/spring-security.xsd
 		http://www.springframework.org/schema/beans 
-        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd"
+        https://www.springframework.org/schema/beans/spring-beans.xsd"
 >
 
     <http use-expressions="true">

--- a/spring-security-modules/spring-security-mvc-login/src/main/resources/webSecurityConfig.xml
+++ b/spring-security-modules/spring-security-mvc-login/src/main/resources/webSecurityConfig.xml
@@ -2,9 +2,9 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:beans="http://www.springframework.org/schema/beans"
     xsi:schemaLocation="
 		http://www.springframework.org/schema/security 
-        http://www.springframework.org/schema/security/spring-security-4.2.xsd
+        https://www.springframework.org/schema/security/spring-security.xsd
 		http://www.springframework.org/schema/beans 
-        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd"
+        https://www.springframework.org/schema/beans/spring-beans.xsd"
 >
 
     <http use-expressions="true">

--- a/spring-security-modules/spring-security-mvc-login/src/main/webapp/WEB-INF/mvc-servlet.xml
+++ b/spring-security-modules/spring-security-mvc-login/src/main/webapp/WEB-INF/mvc-servlet.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd" >
+  xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd" >
 
 </beans>

--- a/spring-security-modules/spring-security-mvc-login/src/test/resources/mvc-servlet.xml
+++ b/spring-security-modules/spring-security-mvc-login/src/test/resources/mvc-servlet.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:component-scan base-package="org.baeldung.controller" />
 

--- a/spring-security-modules/spring-security-rest-basic-auth/src/main/java/org/baeldung/basic/MyBasicAuthenticationEntryPoint.java
+++ b/spring-security-modules/spring-security-rest-basic-auth/src/main/java/org/baeldung/basic/MyBasicAuthenticationEntryPoint.java
@@ -14,7 +14,7 @@ import java.io.PrintWriter;
 public class MyBasicAuthenticationEntryPoint extends BasicAuthenticationEntryPoint {
 
     @Override
-    public void commence(final HttpServletRequest request, final HttpServletResponse response, final AuthenticationException authException) throws IOException, ServletException {
+    public void commence(final HttpServletRequest request, final HttpServletResponse response, final AuthenticationException authException) throws IOException {
         response.addHeader("WWW-Authenticate", "Basic realm=\"" + getRealmName() + "\"");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         final PrintWriter writer = response.getWriter();
@@ -22,7 +22,7 @@ public class MyBasicAuthenticationEntryPoint extends BasicAuthenticationEntryPoi
     }
 
     @Override
-    public void afterPropertiesSet() throws Exception {
+    public void afterPropertiesSet() {
         setRealmName("Baeldung");
         super.afterPropertiesSet();
     }


### PR DESCRIPTION
Jira: 
http://team.baeldung.com/browse/BAEL-19382

Notes: 
1- ethereum:
There is a LiveTest failing (and probably, an indication that the code for the article is not working as expected) due to the reason I pointed out in BAEL-9518 (we're using parent-spring-5, but we're declaring a spring-boot-starter dependency using 1.5.x version).

2- persistence-modules/spring-data-elasticsearch:
I could never get the ManualTests to pass even before updating the spring version. We could take more time to analyze how to get it running correctly and write down the indications in the Test.

3- spring-security-modules/spring-security-rest
Service is not starting:
Exception starting filter [springSecurityFilterChain]:
org.springframework.beans.factory.NoSuchBeanDefinitionException: No bean named 'springSecurityFilterChain' available

By uncommenting annotations in spring-security-rest/src/main/java/org/baeldung/spring/SecurityXmlConfig.java, the service starts but even with the change, LiveTests fails.

I'm not sure if we want to have a closer look at that.

4- httpclient-simple:

We're using deprecated classes in LiveTests and ManualTests (not due to this change, its classes that have been deprecated since version 4.3)