### PR TITLE
Redundant Variable 'config'

### DIFF
--- a/persistence-modules/spring-data-neo4j/src/main/java/com/baeldung/spring/data/neo4j/config/MovieDatabaseNeo4jConfiguration.java
+++ b/persistence-modules/spring-data-neo4j/src/main/java/com/baeldung/spring/data/neo4j/config/MovieDatabaseNeo4jConfiguration.java
@@ -16,8 +16,7 @@ public class MovieDatabaseNeo4jConfiguration {
 
     @Bean
     public org.neo4j.ogm.config.Configuration getConfiguration() {
-    	org.neo4j.ogm.config.Configuration config = new Builder().uri(URL).build();
-        return config;
+    	return new Builder().uri(URL).build();
     }
 
     @Bean


### PR DESCRIPTION
Instead of initializing a local variable first and then return it, you could directly return a new Builder instance.

-> `return new Builder().uri(URL).build();`