### PR TITLE
Fix the Integrations Tests in spring-boot-testing

### DIFF
--- a/spring-boot-testing/src/test/java/com/baeldung/autoconfig/exclude/ExcludeAutoConfig1IntegrationTest.java
+++ b/spring-boot-testing/src/test/java/com/baeldung/autoconfig/exclude/ExcludeAutoConfig1IntegrationTest.java
@@ -1,26 +1,32 @@
 package com.baeldung.autoconfig.exclude;
 
-import static org.junit.Assert.assertEquals;
+import com.baeldung.boot.Application;
 import io.restassured.RestAssured;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.baeldung.boot.Application;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = Application.class, webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = Application.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration")
 public class ExcludeAutoConfig1IntegrationTest {
 
+    /**
+     * Encapsulates the random port the test server is listening on.
+     */
+    @LocalServerPort
+    private int port;
+
     @Test
     public void givenSecurityConfigExcluded_whenAccessHome_thenNoAuthenticationRequired() {
-        int statusCode = RestAssured.get("http://localhost:8080/").statusCode();
+        int statusCode = RestAssured.get("http://localhost:" + port).statusCode();
         assertEquals(HttpStatus.OK.value(), statusCode);
     }
 }

--- a/spring-boot-testing/src/test/java/com/baeldung/autoconfig/exclude/ExcludeAutoConfig2IntegrationTest.java
+++ b/spring-boot-testing/src/test/java/com/baeldung/autoconfig/exclude/ExcludeAutoConfig2IntegrationTest.java
@@ -1,26 +1,32 @@
 package com.baeldung.autoconfig.exclude;
 
-import static org.junit.Assert.assertEquals;
+import com.baeldung.boot.Application;
 import io.restassured.RestAssured;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.baeldung.boot.Application;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = Application.class, webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = Application.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 public class ExcludeAutoConfig2IntegrationTest {
 
+    /**
+     * Encapsulates the random port the test server is listening on.
+     */
+    @LocalServerPort
+    private int port;
+
     @Test
     public void givenSecurityConfigExcluded_whenAccessHome_thenNoAuthenticationRequired() {
-        int statusCode = RestAssured.get("http://localhost:8080/").statusCode();
+        int statusCode = RestAssured.get("http://localhost:" + port).statusCode();
         assertEquals(HttpStatus.OK.value(), statusCode);
     }
 }

--- a/spring-boot-testing/src/test/java/com/baeldung/autoconfig/exclude/ExcludeAutoConfig3IntegrationTest.java
+++ b/spring-boot-testing/src/test/java/com/baeldung/autoconfig/exclude/ExcludeAutoConfig3IntegrationTest.java
@@ -1,27 +1,33 @@
 package com.baeldung.autoconfig.exclude;
 
-import static org.junit.Assert.assertEquals;
+import com.baeldung.boot.Application;
 import io.restassured.RestAssured;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.baeldung.boot.Application;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = Application.class, webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = Application.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(exclude=SecurityAutoConfiguration.class)
 public class ExcludeAutoConfig3IntegrationTest {
 
+    /**
+     * Encapsulates the random port the test server is listening on.
+     */
+    @LocalServerPort
+    private int port;
+
     @Test
     public void givenSecurityConfigExcluded_whenAccessHome_thenNoAuthenticationRequired() {
-        int statusCode = RestAssured.get("http://localhost:8080/").statusCode();
+        int statusCode = RestAssured.get("http://localhost:" + port).statusCode();
         assertEquals(HttpStatus.OK.value(), statusCode);
     }
 }

--- a/spring-boot-testing/src/test/java/com/baeldung/autoconfig/exclude/ExcludeAutoConfig4IntegrationTest.java
+++ b/spring-boot-testing/src/test/java/com/baeldung/autoconfig/exclude/ExcludeAutoConfig4IntegrationTest.java
@@ -1,22 +1,29 @@
 package com.baeldung.autoconfig.exclude;
 
-import static org.junit.Assert.assertEquals;
 import io.restassured.RestAssured;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.junit.Assert.assertEquals;
+
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = TestApplication.class, webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = TestApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 public class ExcludeAutoConfig4IntegrationTest {
+
+    /**
+     * Encapsulates the random port the test server is listening on.
+     */
+    @LocalServerPort
+    private int port;
 
     @Test
     public void givenSecurityConfigExcluded_whenAccessHome_thenNoAuthenticationRequired() {
-        int statusCode = RestAssured.get("http://localhost:8080/").statusCode();
+        int statusCode = RestAssured.get("http://localhost:" + port).statusCode();
         assertEquals(HttpStatus.OK.value(), statusCode);
     }
 }

--- a/spring-boot-testing/src/test/java/com/baeldung/boot/autoconfig/AutoConfigIntegrationTest.java
+++ b/spring-boot-testing/src/test/java/com/baeldung/boot/autoconfig/AutoConfigIntegrationTest.java
@@ -1,30 +1,36 @@
 package com.baeldung.boot.autoconfig;
 
-import static org.junit.Assert.assertEquals;
+import com.baeldung.boot.Application;
 import io.restassured.RestAssured;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.baeldung.boot.Application;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = Application.class, webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = Application.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 public class AutoConfigIntegrationTest {
+
+    /**
+     * Encapsulates the random port the test server is listening on.
+     */
+    @LocalServerPort
+    private int port;
 
     @Test
     public void givenNoAuthentication_whenAccessHome_thenUnauthorized() {
-        int statusCode = RestAssured.get("http://localhost:8080/").statusCode();
+        int statusCode = RestAssured.get("http://localhost:" + port).statusCode();
         assertEquals(HttpStatus.UNAUTHORIZED.value(), statusCode);
     }
     
     @Test
     public void givenAuthentication_whenAccessHome_thenOK() {
-        int statusCode = RestAssured.given().auth().basic("john", "123").get("http://localhost:8080/").statusCode();
+        int statusCode = RestAssured.given().auth().basic("john", "123").get("http://localhost:" + port).statusCode();
         assertEquals(HttpStatus.OK.value(), statusCode);
     }
 }

--- a/spring-boot-testing/src/test/java/com/baeldung/testloglevel/LogbackMultiProfileTestLogLevelIntegrationTest.java
+++ b/spring-boot-testing/src/test/java/com/baeldung/testloglevel/LogbackMultiProfileTestLogLevelIntegrationTest.java
@@ -1,7 +1,5 @@
 package com.baeldung.testloglevel;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,9 +11,14 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_CLASS;
+
+@DirtiesContext(classMode = AFTER_CLASS)
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = TestLogLevelApplication.class)
 @EnableAutoConfiguration(exclude = SecurityAutoConfiguration.class)

--- a/spring-boot-testing/src/test/java/com/baeldung/testloglevel/LogbackTestLogLevelIntegrationTest.java
+++ b/spring-boot-testing/src/test/java/com/baeldung/testloglevel/LogbackTestLogLevelIntegrationTest.java
@@ -1,7 +1,5 @@
 package com.baeldung.testloglevel;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,9 +11,14 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_CLASS;
+
+@DirtiesContext(classMode = AFTER_CLASS)
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = TestLogLevelApplication.class)
 @EnableAutoConfiguration(exclude = SecurityAutoConfiguration.class)

--- a/spring-boot-testing/src/test/java/com/baeldung/testloglevel/TestLogLevelWithProfileIntegrationTest.java
+++ b/spring-boot-testing/src/test/java/com/baeldung/testloglevel/TestLogLevelWithProfileIntegrationTest.java
@@ -11,12 +11,15 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.rule.OutputCapture;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_CLASS;
 
 @RunWith(SpringRunner.class)
+@DirtiesContext(classMode = AFTER_CLASS)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = TestLogLevelApplication.class)
 @EnableAutoConfiguration(exclude = SecurityAutoConfiguration.class)
 @ActiveProfiles("logging-test")


### PR DESCRIPTION
These tests are failing due to two completely different reasons:

1. A few of them are failing because all of them are trying to listen to port 8080 simultaneously.  Using a random port would fix the problem.
2. Another set is failing because of sharing one TestContext between three different test classes.