### PR TITLE
Fixing Yet Another Date & Time Problem

### DIFF
--- a/core-java-modules/core-java-date-operations-2/src/test/java/com/baeldung/offsetdatetime/ConvertToOffsetDateTimeUnitTest.java
+++ b/core-java-modules/core-java-date-operations-2/src/test/java/com/baeldung/offsetdatetime/ConvertToOffsetDateTimeUnitTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.time.OffsetDateTime;
 import java.util.Date;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -18,12 +19,19 @@ public class ConvertToOffsetDateTimeUnitTest {
 
     @Test
     public void givenDate_whenHasOffset_thenConvertWithOffset() {
+        TimeZone prevTimezone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
         Date date = new Date();
         date.setHours(6);
         date.setMinutes(30);
+
         OffsetDateTime odt = ConvertToOffsetDateTime.convert(date, 3, 30);
         assertEquals(10, odt.getHour());
         assertEquals(0, odt.getMinute());
+
+        // Reset the timezone to its original value to prevent side effects
+        TimeZone.setDefault(prevTimezone);
     }
 
 }


### PR DESCRIPTION
_Dates are tricky!_ When someone writes something like:
 ```java
Date date = new Date();
```
This would assign the current date and time in _UTC_ to the current variable, despite what `toString` might say. When you write:
 ```java
date.setHours(6);
date.setMinutes(30);
```
Those modifications would happen based on the `TimeZone.getDefault()` timezone, not _UTC_.  As the `TimeZone.getDefault()` is usually equal to the local timezone, **observing unexpected results is expected!**
For example, In my local timezone (Which btw is `+03:30`), the date variable is representing `06:30+03:30`. Therefore, the date vairable is already adjusted to my local timezone! When converting it to `Instant`, you would get the `03:00Z`. The final offset adjustment would get us back to `06:30+03:30` again!
Based on Travis's runner server location and its default timezone configurations, you might get different results. Anyway, we have to just set the default timezone to UTC and the problem should be resolved.
_Fingers crossed, though, as the dates are still tricky!_