### PR TITLE
Jcenter URL update

### DIFF
--- a/parent-kotlin/pom.xml
+++ b/parent-kotlin/pom.xml
@@ -16,7 +16,7 @@
     <repositories>
         <repository>
             <id>jcenter</id>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
         <repository>
             <id>kotlin-ktor</id>


### PR DESCRIPTION
- Updating the JCenter repository url as it has now moved from http to https