### PR TITLE
Upgrade springdoc-openapi version to v1.2.32

### DIFF
--- a/spring-boot-modules/spring-boot-springdoc/pom.xml
+++ b/spring-boot-modules/spring-boot-springdoc/pom.xml
@@ -36,24 +36,8 @@
         <!-- SpringDoc -->
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-core</artifactId>
-            <version>1.1.49</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.github.classgraph</groupId>
-                    <artifactId>classgraph</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.1.49</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.classgraph</groupId>
-            <artifactId>classgraph</artifactId>
-            <version>4.8.44</version>
+            <version>1.2.32</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The objective is to make the configuration of springdoc-openapi simple for spring-boot projects.

Upgrading to 1.2.32, helps projects to use all the new springdoc-openapi properties:
 - https://springdoc.github.io/springdoc-openapi-demos/springdoc-properties.html

