### PR TITLE
BAEL-3900 Fixed ApplicationLiveTest.

### DIFF
--- a/spring-security-modules/spring-security-mvc-boot-1/src/main/java/org/baeldung/custom/Application.java
+++ b/spring-security-modules/spring-security-mvc-boot-1/src/main/java/org/baeldung/custom/Application.java
@@ -3,9 +3,11 @@ package org.baeldung.custom;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication
+@ComponentScan("org.baeldung.custom")
 @PropertySource("classpath:application-defaults.properties")
 public class Application extends SpringBootServletInitializer {
     public static void main(String[] args) {

--- a/spring-security-modules/spring-security-mvc-boot-1/src/main/java/org/baeldung/custom/config/SecurityConfig.java
+++ b/spring-security-modules/spring-security-mvc-boot-1/src/main/java/org/baeldung/custom/config/SecurityConfig.java
@@ -2,12 +2,25 @@ package org.baeldung.custom.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
-public class SecurityConfig {
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
+    @Override
+    protected void configure(final HttpSecurity http) throws Exception {
+        http.csrf()
+            .disable()
+            .authorizeRequests().anyRequest().authenticated()
+            .and()
+            .formLogin().permitAll();
+    }
+    
     @Bean
     public PasswordEncoder encoder() {
         return new BCryptPasswordEncoder(11);

--- a/spring-security-modules/spring-security-mvc-boot-1/src/main/java/org/baeldung/custom/config/SecurityConfig.java
+++ b/spring-security-modules/spring-security-mvc-boot-1/src/main/java/org/baeldung/custom/config/SecurityConfig.java
@@ -16,11 +16,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(final HttpSecurity http) throws Exception {
         http.csrf()
             .disable()
-            .authorizeRequests().anyRequest().authenticated()
+            .authorizeRequests()
+            .anyRequest()
+            .authenticated()
             .and()
-            .formLogin().permitAll();
+            .formLogin()
+            .permitAll();
     }
-    
+
     @Bean
     public PasswordEncoder encoder() {
         return new BCryptPasswordEncoder(11);

--- a/spring-security-modules/spring-security-mvc-boot-1/src/main/java/org/baeldung/ip/IpApplication.java
+++ b/spring-security-modules/spring-security-mvc-boot-1/src/main/java/org/baeldung/ip/IpApplication.java
@@ -3,9 +3,11 @@ package org.baeldung.ip;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication
+@ComponentScan("org.baeldung.ip")
 @PropertySource("classpath:application-defaults.properties")
 public class IpApplication extends SpringBootServletInitializer {
     public static void main(String[] args) {

--- a/spring-security-modules/spring-security-mvc-boot-1/src/test/java/org/baeldung/web/ApplicationLiveTest.java
+++ b/spring-security-modules/spring-security-mvc-boot-1/src/test/java/org/baeldung/web/ApplicationLiveTest.java
@@ -13,7 +13,7 @@ import io.restassured.specification.RequestSpecification;
 import org.junit.Test;
 import org.springframework.http.MediaType;
 
-
+// In order to execute these tests, org.baeldung.custom.Application needs to be running.
 public class ApplicationLiveTest {
     
     @Test

--- a/spring-security-modules/spring-security-mvc-boot-1/src/test/java/org/baeldung/web/IpLiveTest.java
+++ b/spring-security-modules/spring-security-mvc-boot-1/src/test/java/org/baeldung/web/IpLiveTest.java
@@ -8,6 +8,7 @@ import io.restassured.response.Response;
 import org.junit.Test;
 
 
+// In order to execute these tests, org.baeldung.ip.IpApplication needs to be running.
 public class IpLiveTest {
 
     @Test


### PR DESCRIPTION
CSRF was messing the test, and security config for that component was missing. Added csrf().disable() (as this was set for other components in the same module). I assume there is nothing to change in the related article.