### PR TITLE
Fix Spring Spring security Voter sample code bug in MvcConfig path

### DIFF
--- a/spring-security-modules/spring-security-mvc-boot-1/src/main/java/org/baeldung/voter/VoterMvcConfig.java
+++ b/spring-security-modules/spring-security-mvc-boot-1/src/main/java/org/baeldung/voter/VoterMvcConfig.java
@@ -14,6 +14,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 public class VoterMvcConfig implements WebMvcConfigurer {
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
-        registry.addViewController("/").setViewName("private");
+        registry.addViewController("/private").setViewName("private");
     }
 }


### PR DESCRIPTION
There is a slight bug in the source code for this tutorial: https://www.baeldung.com/spring-security-acl