### PR TITLE
BAEL-3806 Fixed integration test

### DIFF
--- a/spring-5-reactive-2/src/test/java/com/baeldung/debugging/consumer/ConsumerFooServiceIntegrationTest.java
+++ b/spring-5-reactive-2/src/test/java/com/baeldung/debugging/consumer/ConsumerFooServiceIntegrationTest.java
@@ -52,14 +52,13 @@ public class ConsumerFooServiceIntegrationTest {
                     .map(Arrays::stream)
                     .orElse(Stream.empty());
             })
-            .map(IThrowableProxy::getMessage)
+            .map(IThrowableProxy::getClassName)
             .collect(Collectors.toList());
         assertThat(allLoggedEntries).anyMatch(entry -> entry.contains("The following error happened on processFoo method!"))
             .anyMatch(entry -> entry.contains("| onSubscribe"))
             .anyMatch(entry -> entry.contains("| cancel()"));
 
-        assertThat(allSuppressedEntries).anyMatch(entry -> entry.contains("Assembly trace from producer"))
-            .anyMatch(entry -> entry.contains("Error has been observed by the following operator(s)"));
+        assertThat(allSuppressedEntries)
+            .anyMatch(entry -> entry.contains("reactor.core.publisher.FluxOnAssembly$OnAssemblyException"));
     }
-
 }

--- a/spring-5-reactive-2/src/test/java/com/baeldung/debugging/consumer/ConsumerFooServiceLiveTest.java
+++ b/spring-5-reactive-2/src/test/java/com/baeldung/debugging/consumer/ConsumerFooServiceLiveTest.java
@@ -7,6 +7,11 @@ import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 
 import com.baeldung.debugging.consumer.service.FooService;
 
+/**
+ * In order to run this live test, start the following classes:
+ * - com.baeldung.debugging.server.ServerDebuggingApplication
+ * - com.baeldung.debugging.consumer.ConsumerDebuggingApplication
+ */
 public class ConsumerFooServiceLiveTest {
 
     FooService service = new FooService();


### PR DESCRIPTION
The previous test was making an assertion on Logback suppressed exceptions messages. I suspect with the upgrade to Spring Boot (and Logback), these are now empty messages. Im not sure of the utility of this assertion, but I kept it and compared the exception class instead of the message. 