### PR TITLE
fix launch run command for windows

### DIFF
--- a/spring-jenkins-pipeline/scripted-pipeline-unix-nonunix
+++ b/spring-jenkins-pipeline/scripted-pipeline-unix-nonunix
@@ -72,7 +72,7 @@ node {
                     if (isUnix()) {
                         sh 'nohup ./mvnw spring-boot:run -Dserver.port=8989 &'
                     } else {
-                        bat 'start ./mvnw.cmd spring-boot:run -Dserver.port=8989'
+                        bat 'start mvnw.cmd spring-boot:run -Dserver.port=8989'
                     }
                 }
             }


### PR DESCRIPTION
In order to launch the application, is necessary to remove "./"