### PR TITLE
Fix palindrome unit test

### DIFF
--- a/testing-modules/testing-libraries/src/test/java/com/baeldung/mutation/PalindromeUnitTest.java
+++ b/testing-modules/testing-libraries/src/test/java/com/baeldung/mutation/PalindromeUnitTest.java
@@ -11,13 +11,13 @@ public class PalindromeUnitTest {
     @Test
     public void whenEmptyString_thanAccept() {
         Palindrome palindromeTester = new Palindrome();
-        assertTrue(palindromeTester.isPalindrome("noon"));
+        assertTrue(palindromeTester.isPalindrome(""));
     }
 
     @Test
-	public void whenPalindrom_thanAccept() {
-	    Palindrome palindromeTester = new Palindrome();
-	    assertTrue(palindromeTester.isPalindrome("noon"));
+    public void whenPalindrom_thanAccept() {
+        Palindrome palindromeTester = new Palindrome();
+        assertTrue(palindromeTester.isPalindrome("noon"));
     }
     
     @Test


### PR DESCRIPTION
One of the test cases was not as described in the test method name.
Also corrected formatting in another test case.