### PR TITLE
[JAVA-1659] Upgraded Maven Surefire Plugin and JUnit versions

### DIFF
--- a/ddd-modules/infrastructure/pom.xml
+++ b/ddd-modules/infrastructure/pom.xml
@@ -12,8 +12,9 @@
 
     <parent>
         <groupId>com.baeldung.dddmodules</groupId>
-        <artifactId>dddmodules</artifactId>
+        <artifactId>ddd-modules</artifactId>
         <version>1.0</version>
+        <relativePath>../</relativePath>
     </parent>
 
     <dependencies>

--- a/ddd-modules/mainapp/pom.xml
+++ b/ddd-modules/mainapp/pom.xml
@@ -11,8 +11,9 @@
 
     <parent>
         <groupId>com.baeldung.dddmodules</groupId>
-        <artifactId>dddmodules</artifactId>
+        <artifactId>ddd-modules</artifactId>
         <version>1.0</version>
+        <relativePath>../</relativePath>
     </parent>
 
     <dependencies>

--- a/ddd-modules/ordercontext/pom.xml
+++ b/ddd-modules/ordercontext/pom.xml
@@ -11,8 +11,9 @@
 
     <parent>
         <groupId>com.baeldung.dddmodules</groupId>
-        <artifactId>dddmodules</artifactId>
+        <artifactId>ddd-modules</artifactId>
         <version>1.0</version>
+        <relativePath>../</relativePath>
     </parent>
 
     <dependencies>

--- a/ddd-modules/pom.xml
+++ b/ddd-modules/pom.xml
@@ -28,9 +28,15 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit-jupiter.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -56,15 +62,31 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <forkCount>0</forkCount>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <properties>
-        <compiler.plugin.version>3.8.1</compiler.plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <source.version>9</source.version>
         <target.version>9</target.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <assertj-core.version>3.12.2</assertj-core.version>
+
+        <compiler.plugin.version>3.8.1</compiler.plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+
         <appmodules.version>1.0</appmodules.version>
+
+        <junit-jupiter.version>5.6.2</junit-jupiter.version>
+        <assertj-core.version>3.12.2</assertj-core.version>
     </properties>
 
 </project>

--- a/ddd-modules/sharedkernel/pom.xml
+++ b/ddd-modules/sharedkernel/pom.xml
@@ -11,8 +11,9 @@
 
     <parent>
         <groupId>com.baeldung.dddmodules</groupId>
-        <artifactId>dddmodules</artifactId>
+        <artifactId>ddd-modules</artifactId>
         <version>1.0</version>
+        <relativePath>../</relativePath>
     </parent>
 
     <build>

--- a/ddd-modules/shippingcontext/pom.xml
+++ b/ddd-modules/shippingcontext/pom.xml
@@ -11,8 +11,9 @@
 
     <parent>
         <groupId>com.baeldung.dddmodules</groupId>
-        <artifactId>dddmodules</artifactId>
+        <artifactId>ddd-modules</artifactId>
         <version>1.0</version>
+        <relativePath>../</relativePath>
     </parent>
 
     <dependencies>

--- a/ddd/pom.xml
+++ b/ddd/pom.xml
@@ -17,6 +17,35 @@
         <relativePath>../parent-boot-2</relativePath>
     </parent>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -25,24 +54,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-cassandra</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <!-- JUnit platform launcher -->
-        <!-- To be able to run tests from IDE directly -->
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <version>${junit-platform.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.joda</groupId>
@@ -95,7 +106,10 @@
     </dependencies>
 
     <properties>
-        <joda-money.version>1.0.1</joda-money.version>
-    </properties>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 
+        <joda-money.version>1.0.1</joda-money.version>
+
+        <junit-jupiter.version>5.6.2</junit-jupiter.version>
+    </properties>
 </project>


### PR DESCRIPTION
* Upgraded Maven Surefire Plugin version to 2.22.2

* Upgraded JUnit version to 5.6.2
  * Imported JUnit BOM before Spring Boot Dependencies BOM (as explained
  [here](https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/maven-plugin/reference/html/#using))