### PR TITLE
Rename array variable name in DNF Partition method

### DIFF
--- a/algorithms-sorting-2/src/main/java/com/baeldung/algorithms/quicksort/DutchNationalFlagPartioning.java
+++ b/algorithms-sorting-2/src/main/java/com/baeldung/algorithms/quicksort/DutchNationalFlagPartioning.java
@@ -5,21 +5,21 @@ import static com.baeldung.algorithms.quicksort.SortingUtils.swap;
 
 public class DutchNationalFlagPartioning {
 
-    public static Partition partition(int[] a, int begin, int end) {
+    public static Partition partition(int[] input, int begin, int end) {
         int lt = begin, current = begin, gt = end;
-        int partitioningValue = a[begin];
+        int partitioningValue = input[begin];
 
         while (current <= gt) {
-            int compareCurrent = compare(a[current], partitioningValue);
+            int compareCurrent = compare(input[current], partitioningValue);
             switch (compareCurrent) {
                 case -1:
-                    swap(a, current++, lt++);
+                    swap(input, current++, lt++);
                     break;
                 case 0:
                     current++;
                     break;
                 case 1:
-                    swap(a, current, gt--);
+                    swap(input, current, gt--);
                     break;
             }
         }


### PR DESCRIPTION
### Why is this change required?
- There's an inconsistency in the variable name of the input-array
- While the code snippet in the [article's section-4.3](https://www.baeldung.com/java-sorting-arrays-with-repeated-entries#dijkstra-approach) use `input` as the variable name, on the other hand, the code present in the Github repo use `a` as the variable name
- The variable name `input` makes more sense

### References
- [BAEL-3484](http://jira.baeldung.com/browse/BAEL-3484)
- [Dutch National Flag Problem](https://www.baeldung.com/java-sorting-arrays-with-repeated-entries#dijkstra-approach)