### PR TITLE
Replace StringBuffer with StringBuilder and add initial capacity

### DIFF
--- a/core-java-modules/core-java-security-2/src/main/java/com/baeldung/hashing/SHACommonUtils.java
+++ b/core-java-modules/core-java-security-2/src/main/java/com/baeldung/hashing/SHACommonUtils.java
@@ -3,7 +3,7 @@ package com.baeldung.hashing;
 class SHACommonUtils {
 
     public static String bytesToHex(byte[] hash) {
-        StringBuffer hexString = new StringBuffer();
+        StringBuilder hexString = new StringBuilder(2 * hash.length);
         for (byte h : hash) {
             String hex = Integer.toHexString(0xff & h);
             if (hex.length() == 1)


### PR DESCRIPTION
Replace StringBuffer with StringBuilder and add initial  capacity.
StringBuilder is faster because it is not synchronized.