### PR TITLE
Fix Gatling test used for https://www.baeldung.com/gatling-jmeter-grinder-comparison

### DIFF
--- a/testing-modules/load-testing-comparison/src/main/resources/scripts/Gatling/GatlingScenario.scala
+++ b/testing-modules/load-testing-comparison/src/main/resources/scripts/Gatling/GatlingScenario.scala
@@ -20,7 +20,7 @@ class RewardsScenario extends Simulation {
 	.repeat(10){
 		exec(http("transactions_add")
 		  .post("/transactions/add/")
-		  .body(StringBody("""{ "customerRewardsId":null,"customerId":""""+ randCustId() + """","transactionDate":null }""")).asJson
+		  .body(StringBody(_ => s"""{ "customerRewardsId":null,"customerId":"${randCustId()}","transactionDate":null }""")).asJson
 		.check(jsonPath("$.id").saveAs("txnId"))
 		.check(jsonPath("$.transactionDate").saveAs("txtDate"))
 		.check(jsonPath("$.customerId").saveAs("custId")))

--- a/testing-modules/load-testing-comparison/src/main/resources/scripts/Gatling/GatlingScenario.scala
+++ b/testing-modules/load-testing-comparison/src/main/resources/scripts/Gatling/GatlingScenario.scala
@@ -28,7 +28,7 @@ class RewardsScenario extends Simulation {
 		
 		.exec(http("get_reward")
 		  .get("/rewards/find/${custId}")
-		  .check(jsonPath("$.id").saveAs("rwdId")))
+		  .check(jsonPath("$.id").optional.saveAs("rwdId")))
 		.pause(1)
 		
 		.doIf("${rwdId.isUndefined()}"){

--- a/testing-modules/load-testing-comparison/src/main/resources/scripts/Gatling/GatlingScenario.scala
+++ b/testing-modules/load-testing-comparison/src/main/resources/scripts/Gatling/GatlingScenario.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 
 class RewardsScenario extends Simulation {
 
-  def randCustId() = Random.nextInt(99)
+  def randCustId() = Random.nextInt(100000)
   
   val httpProtocol = http.baseUrl("http://localhost:8080")
 					    .acceptHeader("text/html,application/json;q=0.9,*/*;q=0.8")

--- a/testing-modules/load-testing-comparison/src/main/resources/scripts/Gatling/GatlingScenario.scala
+++ b/testing-modules/load-testing-comparison/src/main/resources/scripts/Gatling/GatlingScenario.scala
@@ -24,12 +24,10 @@ class RewardsScenario extends Simulation {
 		.check(jsonPath("$.id").saveAs("txnId"))
 		.check(jsonPath("$.transactionDate").saveAs("txtDate"))
 		.check(jsonPath("$.customerId").saveAs("custId")))
-		.pause(1)
 		
 		.exec(http("get_reward")
 		  .get("/rewards/find/${custId}")
 		  .check(jsonPath("$.id").optional.saveAs("rwdId")))
-		.pause(1)
 		
 		.doIf("${rwdId.isUndefined()}"){
 			exec(http("rewards_add")
@@ -41,7 +39,6 @@ class RewardsScenario extends Simulation {
 		.exec(http("transactions_add")
 		  .post("/transactions/add/")
 		  .body(StringBody("""{ "customerRewardsId":"${rwdId}","customerId":"${custId}","transactionDate":"${txtDate}" }""")).asJson)
-		.pause(1)
 		
 		.exec(http("get_reward")
 		  .get("/transactions/findAll/${rwdId}"))

--- a/testing-modules/load-testing-comparison/src/main/resources/scripts/Gatling/GatlingScenario.scala
+++ b/testing-modules/load-testing-comparison/src/main/resources/scripts/Gatling/GatlingScenario.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 
 class RewardsScenario extends Simulation {
 
-  def randCustId() = Random.nextInt(100000)
+  def randCustId() = java.util.concurrent.ThreadLocalRandom.current().nextInt(1, 10000)
   
   val httpProtocol = http.baseUrl("http://localhost:8080")
 					    .acceptHeader("text/html,application/json;q=0.9,*/*;q=0.8")


### PR DESCRIPTION
The Gatling results in https://www.baeldung.com/gatling-jmeter-grinder-comparison are completely broken:

* dynamic parameter injection is incorrect, always the same value is injected, causing the application to actually crash because of the duplicates
* one of the response parameter capture (check) is incorrect and should be optional
* the test includes 1 second pauses between consecutive requests. The tests with the other tools don't have them. The result is that the Gatling throughput is artificially limited.

On my local machine, I get 4100 requests executed in ~3 seconds (instead of the 31s in your article), which give an average throughput of 1025 requests/second.

Generally speaking the performance figures in the article are very suspicious:

```
  | Successful Requests | Errors | Total Test Time (s) | Average Response Time (ms) | Peak Throughput
-- | -- | -- | -- | -- | --
Gatling | 4100 Requests | 100 (soft)* | 31 | 64.5 | 132 req/s
JMeter | 4135 Requests | 0 | 35 | 81 | 1080 req/s
The Grinder | 5000 Requests | 0 | 5.57 | 65.72 | 1284 req/s
```

* How come JMeter gets 4135 requests in 35s and get a throughput of 1080 req/s?!?!
* How do you measure "Peak Throughput"?
* Those tests are actually super short. With only 5,000 iterations, the JIT compiler hasn't kicked in yet. You should run longer tests to get meaningful results.