### PR TITLE
Fixed typos in core-java-9-jigsaw module

### DIFF
--- a/core-java-modules/core-java-9-jigsaw/src/modules/com.baeldung.student.service.dbimpl/com/baeldung/student/service/dbimpl/StudentDbService.java
+++ b/core-java-modules/core-java-9-jigsaw/src/modules/com.baeldung.student.service.dbimpl/com/baeldung/student/service/dbimpl/StudentDbService.java
@@ -19,12 +19,12 @@ public class StudentDbService implements StudentService {
     }
 
     public Student update(Student student) {
-        logger.log(Level.INFO, "Updating sutdent in DB...");
+        logger.log(Level.INFO, "Updating student in DB...");
         return student;
     }
 
     public String delete(String registrationId) {
-        logger.log(Level.INFO, "Deleteing sutdent in DB...");
+        logger.log(Level.INFO, "Deleting student in DB...");
         return registrationId;
     }
 }


### PR DESCRIPTION
Fixed typos.
There are same typos in this article:
https://www.baeldung.com/project-jigsaw-java-modularity