### PR TITLE
Fix app in the load test tools comparison

### DIFF
--- a/testing-modules/load-testing-comparison/pom.xml
+++ b/testing-modules/load-testing-comparison/pom.xml
@@ -72,7 +72,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.0.5.RELEASE</version>
+                <version>2.3.4.RELEASE</version>
             </plugin>
             <!--<plugin>-->
             <!--<groupId>net.alchim31.maven</groupId>-->

--- a/testing-modules/load-testing-comparison/src/main/java/com/baeldung/loadtesting/RewardsController.java
+++ b/testing-modules/load-testing-comparison/src/main/java/com/baeldung/loadtesting/RewardsController.java
@@ -8,32 +8,32 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
 @RestController
 public class RewardsController {
 
-    @Autowired
-    private CustomerRewardsRepository customerRewardsRepository;
+    private CustomerRewardsRepository customerRewardsRepository = new CustomerRewardsRepository();
 
-    @Autowired
-    private TransactionRepository transactionRepository;
+    private TransactionRepository transactionRepository = new TransactionRepository();
 
     @PostMapping(path="/transactions/add")
     public @ResponseBody Transaction saveTransactions(@RequestBody Transaction trnsctn){
-        trnsctn.setTransactionDate(Calendar.getInstance().getTime());
-        Transaction result = transactionRepository.save(trnsctn);
-        return result;
+        if (trnsctn.getTransactionDate() == null) {
+            trnsctn.setTransactionDate(new Date());
+        }
+        return transactionRepository.save(trnsctn);
     }
 
     @GetMapping(path="/transactions/findAll/{rewardId}")
-    public @ResponseBody Iterable<Transaction> getTransactions(@PathVariable Integer rewardId){
+    public @ResponseBody List<Transaction> getTransactions(@PathVariable Integer rewardId){
         return transactionRepository.findByCustomerRewardsId(rewardId);
     }
 
     @PostMapping(path="/rewards/add")
-    public @ResponseBody CustomerRewardsAccount addRewardsAcount(@RequestBody CustomerRewardsAccount body) {
+    public @ResponseBody CustomerRewardsAccount addRewardsAccount(@RequestBody CustomerRewardsAccount body) {
         Optional<CustomerRewardsAccount> acct = customerRewardsRepository.findByCustomerId(body.getCustomerId());
         return !acct.isPresent() ? customerRewardsRepository.save(body) : acct.get();
     }
@@ -42,10 +42,5 @@ public class RewardsController {
     public @ResponseBody
     Optional<CustomerRewardsAccount> find(@PathVariable Integer customerId) {
         return customerRewardsRepository.findByCustomerId(customerId);
-    }
-
-    @GetMapping(path="/rewards/all")
-    public @ResponseBody List<CustomerRewardsAccount> findAll() {
-        return customerRewardsRepository.findAll();
     }
 }

--- a/testing-modules/load-testing-comparison/src/main/java/com/baeldung/loadtesting/model/CustomerRewardsAccount.java
+++ b/testing-modules/load-testing-comparison/src/main/java/com/baeldung/loadtesting/model/CustomerRewardsAccount.java
@@ -1,15 +1,7 @@
 package com.baeldung.loadtesting.model;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-
-@Entity
 public class CustomerRewardsAccount {
 
-    @Id
-    @GeneratedValue(strategy= GenerationType.AUTO)
     private Integer id;
     private Integer customerId;
 

--- a/testing-modules/load-testing-comparison/src/main/java/com/baeldung/loadtesting/model/Transaction.java
+++ b/testing-modules/load-testing-comparison/src/main/java/com/baeldung/loadtesting/model/Transaction.java
@@ -1,25 +1,13 @@
 package com.baeldung.loadtesting.model;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import java.util.Date;
-import java.util.Calendar;
 
-@Entity
 public class Transaction {
 
-    @Id
-    @GeneratedValue(strategy= GenerationType.AUTO)
     private Integer id;
     private Integer customerRewardsId;
     private Integer customerId;
     private Date transactionDate;
-
-    public Transaction(){
-        transactionDate = Calendar.getInstance().getTime();
-    }
 
     public void setTransactionDate(Date transactionDate){
         this.transactionDate = transactionDate;

--- a/testing-modules/load-testing-comparison/src/main/java/com/baeldung/loadtesting/repository/CustomerRewardsRepository.java
+++ b/testing-modules/load-testing-comparison/src/main/java/com/baeldung/loadtesting/repository/CustomerRewardsRepository.java
@@ -1,11 +1,28 @@
 package com.baeldung.loadtesting.repository;
 
 import com.baeldung.loadtesting.model.CustomerRewardsAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
-public interface CustomerRewardsRepository extends JpaRepository<CustomerRewardsAccount, Integer> {
+public class CustomerRewardsRepository {
 
-    Optional<CustomerRewardsAccount> findByCustomerId(Integer customerId);
+  private AtomicInteger accountIds = new AtomicInteger();
+	private final Map<Integer, CustomerRewardsAccount> accountsByCustomerId = new ConcurrentHashMap<>();
+
+    public Optional<CustomerRewardsAccount> findByCustomerId(Integer customerId) {
+    	return Optional.ofNullable(accountsByCustomerId.get(customerId));
+    }
+
+  public CustomerRewardsAccount save(CustomerRewardsAccount account) {
+    if (account.getId() == null) {
+      account.setId(accountIds.getAndIncrement());
+    }
+    if (account.getCustomerId() != null) {
+      accountsByCustomerId.put(account.getCustomerId(), account);
+    }
+    return account;
+  }
 }

--- a/testing-modules/load-testing-comparison/src/main/java/com/baeldung/loadtesting/repository/TransactionRepository.java
+++ b/testing-modules/load-testing-comparison/src/main/java/com/baeldung/loadtesting/repository/TransactionRepository.java
@@ -1,11 +1,30 @@
 package com.baeldung.loadtesting.repository;
 
 import com.baeldung.loadtesting.model.Transaction;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
-public interface TransactionRepository extends JpaRepository<Transaction, Integer> {
+public class TransactionRepository {
 
-    List<Transaction> findByCustomerRewardsId(Integer rewardsId);
+    private AtomicInteger transactionIds = new AtomicInteger();
+    private final Map<Integer, ConcurrentLinkedDeque<Transaction>> transactionsByCustomerRewardsId = new ConcurrentHashMap<>();
+
+    public List<Transaction> findByCustomerRewardsId(Integer rewardsId) {
+        return transactionsByCustomerRewardsId.get(rewardsId).stream().collect(Collectors.toList());
+    }
+
+    public Transaction save(Transaction trnsctn) {
+        if (trnsctn.getId() == null) {
+            trnsctn.setId(transactionIds.getAndIncrement());
+        }
+        if (trnsctn.getCustomerRewardsId() != null) {
+            transactionsByCustomerRewardsId.computeIfAbsent(trnsctn.getCustomerRewardsId(), key -> new ConcurrentLinkedDeque<>()).offer(trnsctn);
+        }
+        return trnsctn;
+    }
 }

--- a/testing-modules/load-testing-comparison/src/main/resources/application.properties
+++ b/testing-modules/load-testing-comparison/src/main/resources/application.properties
@@ -1,7 +1,1 @@
-spring.h2.console.enabled=true
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=password
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-
+server.tomcat.max-threads=100


### PR DESCRIPTION
Motivation:

The current implementation has performance issues and throughput decreases over time. This is likely causes by the lack of indexes on the h2 database. See the `findByXXX` repository methods.

Modifications:

Go with in memory maps with direct access by key instead of an h2 database.

Result:

Way faster and stable application under test.

On my test environment, Gatling outperforms JMeter (didn't try The Grinder):

```
Simulation com.baeldung.RewardsScenario completed in 23 seconds
Parsing log file(s)...
Parsing log file(s) done
Generating reports...

================================================================================
---- Global Information --------------------------------------------------------
> request count                                     499997 (OK=499997 KO=0     )
> min response time                                      0 (OK=0      KO=-     )
> max response time                                    461 (OK=461    KO=-     )
> mean response time                                     5 (OK=5      KO=-     )
> std deviation                                          6 (OK=6      KO=-     )
> response time 50th percentile                          4 (OK=4      KO=-     )
> response time 75th percentile                          5 (OK=5      KO=-     )
> response time 95th percentile                          7 (OK=7      KO=-     )
> response time 99th percentile                         13 (OK=13     KO=-     )
> mean requests/sec                                20833.208 (OK=20833.208 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                        499997 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
```

```
$ apache-jmeter-5.3/bin/jmeter -Jjmeter.reportgenerator.overall_granularity=1000 -n -t TestPlan.jmx -l log.jtl -e -o ~/jmeter-reports
Creating summariser <summary>
Created the tree successfully using TestPlan.jmx
Starting standalone test @ Thu Oct 15 16:15:05 CEST 2020 (1602771305736)
Waiting for possible Shutdown/StopTestNow/HeapDump/ThreadDump message on port 4445
summary + 341050 in 00:00:24 = 14091.8/s Avg:     5 Min:     0 Max:   218 Err: 341050 (100.00%) Active: 100 Started: 100 Finished: 0
summary + 158950 in 00:00:08 = 20761.5/s Avg:     3 Min:     0 Max:   143 Err: 158950 (100.00%) Active: 0 Started: 100 Finished: 100
summary = 500000 in 00:00:32 = 15694.6/s Avg:     4 Min:     0 Max:   218 Err: 500000 (100.00%)
Tidying up ...    @ Thu Oct 15 16:15:37 CEST 2020 (1602771337657)
```