### PR TITLE
upgrade to springdoc-openapi v1.5.2

### DIFF
--- a/spring-boot-modules/spring-boot-springdoc/pom.xml
+++ b/spring-boot-modules/spring-boot-springdoc/pom.xml
@@ -171,7 +171,7 @@
     <properties>
         <java.version>1.8</java.version>
         <hibernate.version>5.2.10.Final</hibernate.version>
-        <springdoc.version>1.2.32</springdoc.version>
+        <springdoc.version>1.5.2</springdoc.version>
         <asciidoctor-plugin.version>1.5.6</asciidoctor-plugin.version>
         <kotlin.version>1.2.71</kotlin.version>
         <snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>

--- a/spring-boot-modules/spring-boot-springdoc/src/main/java/com/baeldung/springdoc/controller/BookController.java
+++ b/spring-boot-modules/spring-boot-springdoc/src/main/java/com/baeldung/springdoc/controller/BookController.java
@@ -5,6 +5,17 @@ import java.util.Collection;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import com.baeldung.springdoc.exception.BookNotFoundException;
+import com.baeldung.springdoc.model.Book;
+import com.baeldung.springdoc.repository.BookRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springdoc.api.annotations.ParameterObject;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,17 +31,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.baeldung.springdoc.exception.BookNotFoundException;
-import com.baeldung.springdoc.model.Book;
-import com.baeldung.springdoc.repository.BookRepository;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 @RestController
 @RequestMapping("/api/book")
@@ -58,7 +58,7 @@ public class BookController {
     }
 
     @GetMapping("/filter")
-    public Page<Book> filterBooks(Pageable pageable) {
+    public Page<Book> filterBooks(@ParameterObject Pageable pageable) {
         return repository.getBooks(pageable);
     }
 


### PR DESCRIPTION
Hi Team, 

 Could you please upgrade to springdoc-openapi version 1.5.2.

 For the [baeldung example](https://github.com/eugenp/tutorials/tree/master/spring-boot-modules/spring-boot-springdoc), there should be no breaking change by this upgrade.

 There has been a lot of enhancements since version 1.3.2 (8 months now), mainly:
 - The support of  spring-hateoas
 - The support of spring-data-rest
 - The support of Webflux and Webmvc.fn with a new functional DSL 
 - [New properties](https://springdoc.org/#properties) added to make the library more customizable.

 This PR, only covers the upgrade of the version and add the `@ParameterObject` annotation, which improves the support of Pageable in the swagger-ui.

You can let me know if you need any additional information.
