### PR TITLE
Use shouldNotFilter to exclude URLs for a Filter

### DIFF
--- a/spring-web-modules/spring-mvc-basics-3/src/main/java/com/baeldung/exclude_urls_filter/filter/HeaderValidatorFilter.java
+++ b/spring-web-modules/spring-mvc-basics-3/src/main/java/com/baeldung/exclude_urls_filter/filter/HeaderValidatorFilter.java
@@ -11,20 +11,23 @@ import java.io.IOException;
 
 @Order(1)
 public class HeaderValidatorFilter extends OncePerRequestFilter {
-	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-	        throws ServletException, IOException {
-	    String path = request.getRequestURI();
-	    if ("/health".equals(path)) {
-	    	filterChain.doFilter(request, response);
-	    	return;
-	    }
-	    String countryCode = request.getHeader("X-Country-Code");
-	    if (!"US".equals(countryCode)) {
-	        response.sendError(HttpStatus.BAD_REQUEST.value(), "Invalid Locale");
-	        return;
-	    }
-	
-	    filterChain.doFilter(request, response);
-	}
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain)
+      throws ServletException,
+      IOException {
+        String countryCode = request.getHeader("X-Country-Code");
+        if (!"US".equals(countryCode)) {
+            response.sendError(HttpStatus.BAD_REQUEST.value(), "Invalid Locale");
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+        return "/health".equals(path);
+    }
 }


### PR DESCRIPTION
Jira ticket:
[BAEL-4703](http://jira.baeldung.com/browse/BAEL-4703)

Summary:
The existing article uses an out-dated way is used to excluded filtering
for certain URLs, instead, `shouldNotFilter` should be used.