### PR TITLE
[JAVA-3715] Update articles for 2.4.0 - spring-boot-modules/spring-boot-properties -- cleanup

### DIFF
--- a/spring-boot-modules/spring-boot-properties/pom.xml
+++ b/spring-boot-modules/spring-boot-properties/pom.xml
@@ -141,7 +141,6 @@
         <resource.delimiter>@</resource.delimiter>
         <!-- <start-class>com.baeldung.buildproperties.Application</start-class> -->
         <start-class>com.baeldung.yaml.MyApplication</start-class>
-        <spring-boot.version>2.4.0</spring-boot.version>
     </properties>
 
 </project>


### PR DESCRIPTION
JIRA: http://team.baeldung.com/browse/JAVA-3715
cleaned up boot version override in spring-boot-properties, since the parent-boot-2 module has been updated