### PR TITLE
BAEL-3938: Add new section on Java 10 Collectors.toUnmodifiableList()

### DIFF
--- a/core-java-modules/core-java-10/README.md
+++ b/core-java-modules/core-java-10/README.md
@@ -11,3 +11,4 @@ This module contains articles about Java 10 core features
 - [Copying Sets in Java](https://www.baeldung.com/java-copy-sets)
 - [Converting between a List and a Set in Java](https://www.baeldung.com/convert-list-to-set-and-set-to-list)
 - [Java IndexOutOfBoundsException “Source Does Not Fit in Dest”](https://www.baeldung.com/java-indexoutofboundsexception)
+- [Collect a Java Stream to an Immutable Collection](https://www.baeldung.com/java-stream-immutable-collection)

--- a/core-java-modules/core-java-10/src/test/java/com/baeldung/java10/streams/StreamToImmutableJava10UnitTest.java
+++ b/core-java-modules/core-java-10/src/test/java/com/baeldung/java10/streams/StreamToImmutableJava10UnitTest.java
@@ -1,0 +1,32 @@
+package com.baeldung.java10.streams;
+
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public class StreamToImmutableJava10UnitTest {
+
+    @Test
+    public void whenUsingCollectorsToUnmodifiableList_thenSuccess() {
+        List<String> givenList = Arrays.asList("a", "b", "c");
+        List<String> result = givenList.stream()
+            .collect(toUnmodifiableList());
+
+        System.out.println(result.getClass());
+    }
+
+    @Test
+    public void whenUsingCollectingToJavaListCopyOf_thenSuccess() {
+        List<String> givenList = new ArrayList<>(Arrays.asList("a", "b", "c"));
+        List<String> result = givenList.stream()
+            .collect(collectingAndThen(toList(), List::copyOf));
+
+        System.out.println(result.getClass());
+    }
+}

--- a/core-java-modules/core-java-10/src/test/java/com/baeldung/java10/streams/StreamToImmutableJava10UnitTest.java
+++ b/core-java-modules/core-java-10/src/test/java/com/baeldung/java10/streams/StreamToImmutableJava10UnitTest.java
@@ -1,10 +1,7 @@
 package com.baeldung.java10.streams;
 
-import static java.util.stream.Collectors.collectingAndThen;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toUnmodifiableList;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -17,15 +14,6 @@ public class StreamToImmutableJava10UnitTest {
         List<String> givenList = Arrays.asList("a", "b", "c");
         List<String> result = givenList.stream()
             .collect(toUnmodifiableList());
-
-        System.out.println(result.getClass());
-    }
-
-    @Test
-    public void whenUsingCollectingToJavaListCopyOf_thenSuccess() {
-        List<String> givenList = new ArrayList<>(Arrays.asList("a", "b", "c"));
-        List<String> result = givenList.stream()
-            .collect(collectingAndThen(toList(), List::copyOf));
 
         System.out.println(result.getClass());
     }


### PR DESCRIPTION
I had to change the java version to 10 to support Collectors.toUnmodifiableList()

I also added an example of using Java 9's List.copyOf() which is not mentioned in the article. My intention with this was to follow the existing pattern, where there are more cases presented in the tests than in the article itself.

Besides these is the test that is included in the article, following the pattern of the existing tests.