### PR TITLE
Could com.baeldung.deeplearning4j:deeplearning4j:1.0-SNAPSHOT drop off redundant dependencies to loose weight?

### DIFF
--- a/deeplearning4j/pom.xml
+++ b/deeplearning4j/pom.xml
@@ -26,11 +26,39 @@
             <groupId>org.nd4j</groupId>
             <artifactId>nd4j-native-platform</artifactId>
             <version>${dl4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>nd4j-native</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bytedeco.javacpp-presets</groupId>
+                    <artifactId>openblas</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>
             <artifactId>deeplearning4j-core</artifactId>
             <version>${dl4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bytedeco.javacpp-presets</groupId>
+                    <artifactId>opencv-platform</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bytedeco.javacpp-presets</groupId>
+                    <artifactId>hdf5</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bytedeco.javacpp-presets</groupId>
+                    <artifactId>leptonica</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bytedeco.javacpp-presets</groupId>
+                    <artifactId>hdf5-platform</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>


### PR DESCRIPTION
@psevestre Hi, I am a user of project **_com.baeldung.deeplearning4j:deeplearning4j:1.0-SNAPSHOT_**. I found that its pom file introduced **_132_** dependencies. However, among them, **_46_** libraries (**_34%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_com.baeldung.deeplearning4j:deeplearning4j:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.bytedeco.javacpp-presets:opencv:jar:android-x86:3.2.0-1.3:compile
org.nd4j:nd4j-native:jar:android-arm:0.9.1:compile
org.bytedeco.javacpp-presets:hdf5-platform:jar:1.10.0-patch1-1.3:compile
org.bytedeco.javacpp-presets:openblas:jar:0.2.19-1.3:compile
org.bytedeco.javacpp-presets:hdf5:jar:windows-x86:1.10.0-patch1-1.3:compile
org.bytedeco.javacpp-presets:opencv:jar:android-arm:3.2.0-1.3:compile
org.bytedeco.javacpp-presets:leptonica:jar:linux-ppc64le:1.73-1.3:compile
org.nd4j:nd4j-native:jar:android-x86:0.9.1:compile
org.bytedeco.javacpp-presets:openblas:jar:linux-armhf:0.2.19-1.3:compile
org.bytedeco.javacpp-presets:hdf5:jar:1.10.0-patch1-1.3:compile
org.bytedeco.javacpp-presets:hdf5:jar:windows-x86_64:1.10.0-patch1-1.3:compile
org.bytedeco.javacpp-presets:opencv:jar:linux-armhf:3.2.0-1.3:compile
org.bytedeco.javacpp-presets:leptonica:jar:macosx-x86_64:1.73-1.3:compile
org.nd4j:nd4j-native:jar:0.9.1:compile
org.bytedeco.javacpp-presets:leptonica:jar:linux-x86_64:1.73-1.3:compile
org.bytedeco.javacpp-presets:leptonica:jar:linux-x86:1.73-1.3:compile
org.bytedeco.javacpp-presets:openblas:jar:windows-x86_64:0.2.19-1.3:compile
org.bytedeco.javacpp-presets:opencv-platform:jar:3.2.0-1.3:compile
org.nd4j:nd4j-native:jar:macosx-x86_64:0.9.1:compile
org.bytedeco.javacpp-presets:opencv:jar:windows-x86:3.2.0-1.3:compile
org.bytedeco.javacpp-presets:leptonica:jar:1.73-1.3:compile
org.bytedeco.javacpp-presets:openblas:jar:windows-x86:0.2.19-1.3:compile
org.bytedeco.javacpp-presets:leptonica:jar:android-x86:1.73-1.3:compile
org.nd4j:nd4j-native:jar:linux-x86_64:0.9.1:compile
org.bytedeco.javacpp-presets:hdf5:jar:macosx-x86_64:1.10.0-patch1-1.3:compile
org.nd4j:nd4j-native:jar:linux-ppc64le:0.9.1:compile
org.bytedeco.javacpp-presets:leptonica-platform:jar:1.73-1.3:compile
org.bytedeco.javacpp-presets:hdf5:jar:linux-x86:1.10.0-patch1-1.3:compile
org.bytedeco.javacpp-presets:opencv:jar:linux-ppc64le:3.2.0-1.3:compile
org.bytedeco.javacpp-presets:hdf5:jar:linux-ppc64le:1.10.0-patch1-1.3:compile
org.bytedeco.javacpp-presets:leptonica:jar:android-arm:1.73-1.3:compile
org.bytedeco.javacpp-presets:leptonica:jar:windows-x86:1.73-1.3:compile
org.bytedeco.javacpp-presets:opencv:jar:windows-x86_64:3.2.0-1.3:compile
org.bytedeco.javacpp-presets:openblas:jar:android-x86:0.2.19-1.3:compile
org.bytedeco.javacpp-presets:openblas:jar:android-arm:0.2.19-1.3:compile
org.nd4j:nd4j-native:jar:windows-x86_64:0.9.1:compile
org.bytedeco.javacpp-presets:openblas:jar:linux-ppc64le:0.2.19-1.3:compile
org.bytedeco.javacpp-presets:openblas:jar:linux-x86_64:0.2.19-1.3:compile
org.bytedeco.javacpp-presets:opencv:jar:linux-x86:3.2.0-1.3:compile
org.bytedeco.javacpp-presets:opencv:jar:macosx-x86_64:3.2.0-1.3:compile
org.bytedeco.javacpp-presets:openblas:jar:linux-x86:0.2.19-1.3:compile
org.bytedeco.javacpp-presets:opencv:jar:linux-x86_64:3.2.0-1.3:compile
org.bytedeco.javacpp-presets:leptonica:jar:linux-armhf:1.73-1.3:compile
org.bytedeco.javacpp-presets:leptonica:jar:windows-x86_64:1.73-1.3:compile
org.bytedeco.javacpp-presets:openblas:jar:macosx-x86_64:0.2.19-1.3:compile
org.nd4j:nd4j-native-api:jar:0.9.1:compile
</code></pre>