### PR TITLE
BAEL-4881 - Source code for 'Understanding the Pattern.quote method' article.

### DIFF
--- a/core-java-modules/core-java-regex/src/test/java/com/baeldung/ignore/pattern/metacharacters/IgnoringPatternMetacharactersUnitTest.java
+++ b/core-java-modules/core-java-regex/src/test/java/com/baeldung/ignore/pattern/metacharacters/IgnoringPatternMetacharactersUnitTest.java
@@ -8,13 +8,13 @@ import java.util.regex.Pattern;
 import org.junit.Test;
 
 public class IgnoringPatternMetacharactersUnitTest {
-    private static final String dollarValues = "$100.25, $100.50, $150.50, $100.50, $100.75";
+    private static final String dollarAmounts = "$100.25, $100.50, $150.50, $100.50, $100.75";
     private static final String patternStr = "$100.50";
 
     @Test
     public void givenPatternStringHasMetacharacters_whenPatternMatchedWithoutEscapingMetacharacters_thenNoMatchesFound() {
         Pattern pattern = Pattern.compile(patternStr);
-        Matcher matcher = pattern.matcher(dollarValues);
+        Matcher matcher = pattern.matcher(dollarAmounts);
 
         int matches = 0;
         while (matcher.find()) {
@@ -28,7 +28,7 @@ public class IgnoringPatternMetacharactersUnitTest {
     public void givenPatternStringHasMetacharacters_whenPatternCompiledUsingManuallyMetaEscapedPattern_thenMatchingSuccessful() {
         String metaEscapedPatternStr = "\\Q" + patternStr + "\\E";
         Pattern pattern = Pattern.compile(metaEscapedPatternStr);
-        Matcher matcher = pattern.matcher(dollarValues);
+        Matcher matcher = pattern.matcher(dollarAmounts);
 
         int matches = 0;
         while (matcher.find()) {
@@ -42,7 +42,7 @@ public class IgnoringPatternMetacharactersUnitTest {
     public void givenPatternStringHasMetacharacters_whenPatternCompiledUsingLiteralPatternFromQuote_thenMatchingSuccessful() {
         String literalPatternStr = Pattern.quote(patternStr);
         Pattern pattern = Pattern.compile(literalPatternStr);
-        Matcher matcher = pattern.matcher(dollarValues);
+        Matcher matcher = pattern.matcher(dollarAmounts);
 
         int matches = 0;
         while (matcher.find()) {

--- a/core-java-modules/core-java-regex/src/test/java/com/baeldung/ignore/pattern/metacharacters/IgnoringPatternMetacharactersUnitTest.java
+++ b/core-java-modules/core-java-regex/src/test/java/com/baeldung/ignore/pattern/metacharacters/IgnoringPatternMetacharactersUnitTest.java
@@ -1,0 +1,54 @@
+package com.baeldung.ignore.pattern.metacharacters;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+public class IgnoringPatternMetacharactersUnitTest {
+    private static final String dollarValues = "$100.25, $100.50, $150.50, $100.50, $100.75";
+    private static final String patternStr = "$100.50";
+
+    @Test
+    public void givenPatternStringHasMetacharacters_whenPatternMatchedWithoutEscapingMetacharacters_thenNoMatchesFound() {
+        Pattern pattern = Pattern.compile(patternStr);
+        Matcher matcher = pattern.matcher(dollarValues);
+
+        int matches = 0;
+        while (matcher.find()) {
+            matches++;
+        }
+
+        assertEquals(0, matches);
+    }
+
+    @Test
+    public void givenPatternStringHasMetacharacters_whenPatternCompiledUsingManuallyMetaEscapedPattern_thenMatchingSuccessful() {
+        String metaEscapedPatternStr = "\\Q" + patternStr + "\\E";
+        Pattern pattern = Pattern.compile(metaEscapedPatternStr);
+        Matcher matcher = pattern.matcher(dollarValues);
+
+        int matches = 0;
+        while (matcher.find()) {
+            matches++;
+        }
+
+        assertEquals(2, matches);
+    }
+
+    @Test
+    public void givenPatternStringHasMetacharacters_whenPatternCompiledUsingLiteralPatternFromQuote_thenMatchingSuccessful() {
+        String literalPatternStr = Pattern.quote(patternStr);
+        Pattern pattern = Pattern.compile(literalPatternStr);
+        Matcher matcher = pattern.matcher(dollarValues);
+
+        int matches = 0;
+        while (matcher.find()) {
+            matches++;
+        }
+
+        assertEquals(2, matches);
+    }
+}


### PR DESCRIPTION
[BAEL-4881] Created a new IgnoringPatternMetacharactersUnitTest class inside a new com.baeldung.ignore.pattern.metacharacters package.