### PR TITLE
BAEL-4844: Prevent building the pointcutadvice code with the ajc.

### DIFF
--- a/spring-aop/pom.xml
+++ b/spring-aop/pom.xml
@@ -53,6 +53,9 @@
                     <verbose>true</verbose>
                     <Xlint>ignore</Xlint>
                     <encoding>UTF-8</encoding>
+                    <excludes>
+                        <exclude>**/pointcutadvice/**</exclude>
+                    </excludes>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
This POM configuration change will resolve the integration test failures.