### PR TITLE
Refactored RenameFileUnitTest with Temporary Directory

### DIFF
--- a/core-java-modules/core-java-io/src/test/java/com/baeldung/rename/RenameFileUnitTest.java
+++ b/core-java-modules/core-java-io/src/test/java/com/baeldung/rename/RenameFileUnitTest.java
@@ -1,64 +1,59 @@
 package com.baeldung.rename;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class RenameFileUnitTest {
 
-    private final String FILE_TO_MOVE = "src/test/resources/originalFileToMove.txt";
-    private final String TARGET_FILE = "src/test/resources/targetFileToMove.txt";
+    private final String FILE_TO_MOVE = "originalFileToMove.txt";
+    private final String TARGET_FILE = "targetFileToMove.txt";
 
     @BeforeEach
-    public void createFileToMove() throws IOException {
-        File fileToMove = new File(FILE_TO_MOVE);
+    public void createFileToMove(@TempDir Path tempDir) throws IOException {
+        File fileToMove = tempDir.resolve(FILE_TO_MOVE).toFile();
         fileToMove.createNewFile();
     }
 
-    @AfterEach
-    public void cleanUpFiles() {
-        File targetFile = new File(TARGET_FILE);
-        targetFile.delete();
-    }
-
     @Test
-    public void givenUsingNio_whenMovingFile_thenCorrect() throws IOException {
-        Path fileToMovePath = Paths.get(FILE_TO_MOVE);
-        Path targetPath = Paths.get(TARGET_FILE);
+    public void givenUsingNio_whenMovingFile_thenCorrect(@TempDir Path tempDir) throws IOException {
+        Path fileToMovePath = tempDir.resolve(FILE_TO_MOVE);
+        Path targetPath = tempDir.resolve(TARGET_FILE);
+
         Files.move(fileToMovePath, targetPath);
     }
 
     @Test
-    public void givenUsingFileClass_whenMovingFile_thenCorrect() throws IOException {
-        File fileToMove = new File(FILE_TO_MOVE);
-        boolean isMoved = fileToMove.renameTo(new File(TARGET_FILE));
+    public void givenUsingFileClass_whenMovingFile_thenCorrect(@TempDir Path tempDir) throws IOException {
+        File fileToMove = tempDir.resolve(FILE_TO_MOVE).toFile();
+        File targetFile = tempDir.resolve(TARGET_FILE).toFile();
+
+        boolean isMoved = fileToMove.renameTo(targetFile);
         if (!isMoved) {
             throw new FileSystemException(TARGET_FILE);
         }
     }
 
     @Test
-    public void givenUsingGuava_whenMovingFile_thenCorrect()
-            throws IOException {
-        File fileToMove = new File(FILE_TO_MOVE);
-        File targetFile = new File(TARGET_FILE);
+    public void givenUsingGuava_whenMovingFile_thenCorrect(@TempDir Path tempDir) throws IOException {
+        File fileToMove = tempDir.resolve(FILE_TO_MOVE).toFile();
+        File targetFile = tempDir.resolve(TARGET_FILE).toFile();
 
         com.google.common.io.Files.move(fileToMove, targetFile);
     }
 
     @Test
-    public void givenUsingApache_whenMovingFile_thenCorrect() throws IOException {
+    public void givenUsingApache_whenMovingFile_thenCorrect(@TempDir Path tempDir) throws IOException {
         FileUtils.moveFile(
-                FileUtils.getFile(FILE_TO_MOVE),
-                FileUtils.getFile(TARGET_FILE));
+                FileUtils.getFile(tempDir.resolve(FILE_TO_MOVE).toString()),
+                FileUtils.getFile(tempDir.resolve(TARGET_FILE).toString()));
     }
 
 }


### PR DESCRIPTION
This is a test refactoring. No original assertion was changed nor the original code presented any failing steps.

Problem:
Tests that manipulate external file resources need to guarantee resource integrity and availability. Test suite design and maintainability may suffer from the addition of assurance steps to guarantee parallel execution scenarios and resource leakage from failed executions.

Solution:
The use of @TempDir annotation assures a temporary directory being created and cleaned up for every test method execution, thus simplifying test maintenance steps.