### PR TITLE
[BAEL-4875] 1. contains -> containsExactly, 2. get number strings as Java types, 3. Sci Not. and Hex

### DIFF
--- a/core-java-modules/core-java-regex/src/test/java/com/baeldung/regex/countdigits/CountDigitsUnitTest.java
+++ b/core-java-modules/core-java-regex/src/test/java/com/baeldung/regex/countdigits/CountDigitsUnitTest.java
@@ -1,0 +1,77 @@
+package com.baeldung.regex.countdigits;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.CharMatcher;
+
+/**
+ * Unit Test to count the number of digits in a String
+ */
+class CountDigitsUnitTest {
+
+    // Guava CharMatcher to match digits
+    private static final CharMatcher DIGIT_CHAR_MATCHER = CharMatcher.inRange('0', '9');
+    
+    private static final String STR_WITH_ALL_DIGITS = "970987678607608";
+    private static final String STR_WITH_SINGLE_DIGITS_SEP_BY_NON_DIGITS = "9kjl()4f*(&6~3dfd8&5dfd8a";
+    private static final String STR_WITH_SEQUENCES_OF_1_OR_MORE_DIGITS_SEP_BY_NON_DIGITS
+      = "64.6lk.l~453lkdsf9wg038.68*()(k;95786fsd7986";
+    
+    private static int countDigits(String stringToSearch) {
+        Matcher countEmailMatcher = Pattern.compile("\\d").matcher(stringToSearch);
+
+        int count = 0;
+        while (countEmailMatcher.find()) {
+            count++;
+        }
+
+        return count;
+    }
+
+    @Test
+    void givenStrOfAllDigits_whenRegexMatchByDigit_thenFifteenDigitsCounted() {
+        int count = countDigits(STR_WITH_ALL_DIGITS);
+
+        assertThat(count).isEqualTo(15);
+    }
+
+    @Test
+    void givenStrWithSingleDigitsSepByNonDigits_whenRegexMatchByDigit_thenSevenDigitsCounted() {
+        int count = countDigits(STR_WITH_SINGLE_DIGITS_SEP_BY_NON_DIGITS);
+
+        assertThat(count).isEqualTo(7);
+    }
+
+    @Test
+    void givenStrWithOneOrMoreDigitsSepByNonDigits_whenRegexMatchByDigit_thenTwentyOneDigitsCounted() {
+        int count = countDigits(STR_WITH_SEQUENCES_OF_1_OR_MORE_DIGITS_SEP_BY_NON_DIGITS);
+
+        assertThat(count).isEqualTo(21);
+    }
+    
+    @Test
+    void givenStrOfAllDigits_whenGuavaCharMatchByDigit_thenFifteenDigitsCounted() {
+        int count = DIGIT_CHAR_MATCHER.countIn(STR_WITH_ALL_DIGITS);
+
+        assertThat(count).isEqualTo(15);
+    }
+    
+    @Test
+    void givenStrWithSingleDigitsSepByNonDigits_whenGuavaCharMatchByDigit_thenSevenDigitsCounted() {
+        int count = DIGIT_CHAR_MATCHER.countIn(STR_WITH_SINGLE_DIGITS_SEP_BY_NON_DIGITS);
+
+        assertThat(count).isEqualTo(7);
+    }
+    
+    @Test
+    void givenStrWithOneOrMoreDigitsSepByNonDigits_whenGuavaCharMatchByDigit_thenTwentyOneDigitsCounted() {
+        int count = DIGIT_CHAR_MATCHER.countIn(STR_WITH_SEQUENCES_OF_1_OR_MORE_DIGITS_SEP_BY_NON_DIGITS);
+
+        assertThat(count).isEqualTo(21);
+    }
+}

--- a/core-java-modules/core-java-regex/src/test/java/com/baeldung/regex/findnumbers/FindNumbersUnitTest.java
+++ b/core-java-modules/core-java-regex/src/test/java/com/baeldung/regex/findnumbers/FindNumbersUnitTest.java
@@ -44,42 +44,42 @@ class FindNumbersUnitTest {
     void givenStrOfAllDigits_whenRegexMatchByInt_thenWholeStrMatchedAsOneInt() {     
         List<String> integersFound = findIntegers("970987678607608");
 
-        assertThat(integersFound).contains("970987678607608");
+        assertThat(integersFound).containsExactly("970987678607608");
     }
 
     @Test
     void givenStrWithIntegersSepByPeriods_whenRegexMatchByInt_thenExpectedIntsFound() {
         List<String> integersFound = findIntegers("3453..5.-23532...32432.-2363.3454......345.-34.");
 
-        assertThat(integersFound).contains("3453", "5", "-23532", "32432", "-2363", "3454", "345", "-34");
+        assertThat(integersFound).containsExactly("3453", "5", "-23532", "32432", "-2363", "3454", "345", "-34");
     }
 
     @Test
     void givenStrWithIntegersSepByNonDigits_whenRegexMatchByInt_thenExpectedIntsFound() {
         List<String> integersFound = findIntegers("646lkl~4-53l-k34.fdsf.-ds-35.45f9wg3868*()(k;-95786fsd79-86");
 
-        assertThat(integersFound).contains("646", "4", "-53", "34", "-35", "45", "9", "3868", "-95786", "79", "-86");
+        assertThat(integersFound).containsExactly("646", "4", "-53", "34", "-35", "45", "9", "3868", "-95786", "79", "-86");
     }
     
     @Test
     void givenStrOfAllDigits_whenRegexMatchByDecNum_thenWholeStrMatchedAsOneDecimalNumber() {
         List<String> decimalNumsFound = findDecimalNums("970987678607608");
         
-        assertThat(decimalNumsFound).contains("970987678607608");
+        assertThat(decimalNumsFound).containsExactly("970987678607608");
     }
     
     @Test
     void givenStrOfDecNumsSepByNonDigits_whenRegexMatchByDecNum_thenExpectedNumsFound() {
         List<String> decimalNumsFound = findDecimalNums(".7854.455wo.rdy(do.g)-3.-553.00.53;good^night%o3456sdcardR%3567.4%£cat");
         
-        assertThat(decimalNumsFound).contains("7854.455", "-3", "-553.00", "53", "3456", "3567.4");
+        assertThat(decimalNumsFound).containsExactly("7854.455", "-3", "-553.00", "53", "3456", "3567.4");
     }
     
     @Test
     void givenStrWithRandomDigitsDashesAndPeriods_whenRegexMatchByDecNum_thenExpectedNumsFound() {
         List<String> decimalNumsFound = findDecimalNums(".-..90834.345.--493-..-85.-875.345-.-.-355.345...345.-.636-5.6-3.");
         
-        assertThat(decimalNumsFound).contains("90834.345", "-493", "-85", "-875.345", "-355.345", "345", "636", "-5.6", "-3");
+        assertThat(decimalNumsFound).containsExactly("90834.345", "-493", "-85", "-875.345", "-355.345", "345", "636", "-5.6", "-3");
     }
     
     @Test
@@ -87,7 +87,7 @@ class FindNumbersUnitTest {
         LongStream integerValuesFound = findIntegers(".7854.455wo.rdy(do.g)-3.ght%o34.56")
           .stream().mapToLong(Long::valueOf);
         
-        assertThat(integerValuesFound).contains(7854L, 455L, -3L, 34L, 56L);
+        assertThat(integerValuesFound).containsExactly(7854L, 455L, -3L, 34L, 56L);
     }    
     
     @Test
@@ -95,7 +95,7 @@ class FindNumbersUnitTest {
         DoubleStream decimalNumValuesFound = findDecimalNums(".7854.455wo.rdy(do.g)-3.ght%o34.56")
           .stream().mapToDouble(Double::valueOf);
         
-        assertThat(decimalNumValuesFound).contains(7854.455, -3.0, 34.56);
+        assertThat(decimalNumValuesFound).containsExactly(7854.455, -3.0, 34.56);
     }
     
     @Test
@@ -109,7 +109,7 @@ class FindNumbersUnitTest {
             sciNotationNums.add(matcher.group());
         }
         
-        assertThat(sciNotationNums).contains("1.25E-3", "2e109", "-70.96E+105", "-8.7312E-102", "919.3822e+31");
+        assertThat(sciNotationNums).containsExactly("1.25E-3", "2e109", "-70.96E+105", "-8.7312E-102", "919.3822e+31");
     }
     
     @Test
@@ -123,6 +123,6 @@ class FindNumbersUnitTest {
             hexNums.add(matcher.group());
         }
         
-        assertThat(hexNums).contains("aF851B", "-3f6C", "-2Ad9eE", "70ae19");
+        assertThat(hexNums).containsExactly("aF851B", "-3f6C", "-2Ad9eE", "70ae19");
     }
 }

--- a/core-java-modules/core-java-regex/src/test/java/com/baeldung/regex/findnumbers/FindNumbersUnitTest.java
+++ b/core-java-modules/core-java-regex/src/test/java/com/baeldung/regex/findnumbers/FindNumbersUnitTest.java
@@ -1,0 +1,128 @@
+package com.baeldung.regex.findnumbers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.DoubleStream;
+import java.util.stream.LongStream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit Test to find Integers, Decimal Numbers, and Scientific Notation and Hexadecimal Numbers in a String
+ */
+class FindNumbersUnitTest {
+
+    private static List<String> findIntegers(String stringToSearch) {
+        Pattern integerPattern = Pattern.compile("-?\\d+");
+        Matcher matcher = integerPattern.matcher(stringToSearch);
+
+        List<String> integerList = new ArrayList<>();
+        while (matcher.find()) {
+            integerList.add(matcher.group());
+        }
+
+        return integerList;
+    }
+
+    private static List<String> findDecimalNums(String stringToSearch) {
+        Pattern decimalNumPattern = Pattern.compile("-?\\d+(\\.\\d+)?");
+        Matcher matcher = decimalNumPattern.matcher(stringToSearch);
+
+        List<String> decimalNumList = new ArrayList<>();
+        while (matcher.find()) {
+            decimalNumList.add(matcher.group());
+        }
+
+        return decimalNumList;
+    }
+
+    @Test
+    void givenStrOfAllDigits_whenRegexMatchByInt_thenWholeStrMatchedAsOneInt() {     
+        List<String> integersFound = findIntegers("970987678607608");
+
+        assertThat(integersFound).contains("970987678607608");
+    }
+
+    @Test
+    void givenStrWithIntegersSepByPeriods_whenRegexMatchByInt_thenExpectedIntsFound() {
+        List<String> integersFound = findIntegers("3453..5.-23532...32432.-2363.3454......345.-34.");
+
+        assertThat(integersFound).contains("3453", "5", "-23532", "32432", "-2363", "3454", "345", "-34");
+    }
+
+    @Test
+    void givenStrWithIntegersSepByNonDigits_whenRegexMatchByInt_thenExpectedIntsFound() {
+        List<String> integersFound = findIntegers("646lkl~4-53l-k34.fdsf.-ds-35.45f9wg3868*()(k;-95786fsd79-86");
+
+        assertThat(integersFound).contains("646", "4", "-53", "34", "-35", "45", "9", "3868", "-95786", "79", "-86");
+    }
+    
+    @Test
+    void givenStrOfAllDigits_whenRegexMatchByDecNum_thenWholeStrMatchedAsOneDecimalNumber() {
+        List<String> decimalNumsFound = findDecimalNums("970987678607608");
+        
+        assertThat(decimalNumsFound).contains("970987678607608");
+    }
+    
+    @Test
+    void givenStrOfDecNumsSepByNonDigits_whenRegexMatchByDecNum_thenExpectedNumsFound() {
+        List<String> decimalNumsFound = findDecimalNums(".7854.455wo.rdy(do.g)-3.-553.00.53;good^night%o3456sdcardR%3567.4%£cat");
+        
+        assertThat(decimalNumsFound).contains("7854.455", "-3", "-553.00", "53", "3456", "3567.4");
+    }
+    
+    @Test
+    void givenStrWithRandomDigitsDashesAndPeriods_whenRegexMatchByDecNum_thenExpectedNumsFound() {
+        List<String> decimalNumsFound = findDecimalNums(".-..90834.345.--493-..-85.-875.345-.-.-355.345...345.-.636-5.6-3.");
+        
+        assertThat(decimalNumsFound).contains("90834.345", "-493", "-85", "-875.345", "-355.345", "345", "636", "-5.6", "-3");
+    }
+    
+    @Test
+    void givenStrOfIntsSepByNonDigits_whenRegexMatchByInt_thenExpectedValuesFound() {
+        LongStream integerValuesFound = findIntegers(".7854.455wo.rdy(do.g)-3.ght%o34.56")
+          .stream().mapToLong(Long::valueOf);
+        
+        assertThat(integerValuesFound).contains(7854L, 455L, -3L, 34L, 56L);
+    }    
+    
+    @Test
+    void givenStrOfDecNumsSepByNonDigits_whenRegexMatchByDecNum_thenExpectedValuesFound() {
+        DoubleStream decimalNumValuesFound = findDecimalNums(".7854.455wo.rdy(do.g)-3.ght%o34.56")
+          .stream().mapToDouble(Double::valueOf);
+        
+        assertThat(decimalNumValuesFound).contains(7854.455, -3.0, 34.56);
+    }
+    
+    @Test
+    void givenStrOfSciNotationNumsSepByNonDigits_whenRegexMatchBySciNotNum_thenExpectedNumsFound() {
+        String strToSearch = "}s1.25E-3>,/@l2e109he-70.96E+105d£d_-8.7312E-102=#;,.d919.3822e+31e]";
+        
+        Matcher matcher = Pattern.compile("-?\\d+(\\.\\d+)?[eE][+-]?\\d+")
+          .matcher(strToSearch);
+        List<String> sciNotationNums = new ArrayList<>();
+        while (matcher.find()) {
+            sciNotationNums.add(matcher.group());
+        }
+        
+        assertThat(sciNotationNums).contains("1.25E-3", "2e109", "-70.96E+105", "-8.7312E-102", "919.3822e+31");
+    }
+    
+    @Test
+    void givenStrOfHexNumsSepByNonDigits_whenRegexMatchByHexNum_thenExpectedNumsFound() {
+        String strToSearch = "}saF851Bq-3f6Cm>,/@j-2Ad9eE>70ae19.>";
+        
+        Matcher matcher = Pattern.compile("-?[0-9a-fA-F]+")
+          .matcher(strToSearch);
+        List<String> hexNums = new ArrayList<>();
+        while (matcher.find()) {
+            hexNums.add(matcher.group());
+        }
+        
+        assertThat(hexNums).contains("aF851B", "-3f6C", "-2Ad9eE", "70ae19");
+    }
+}


### PR DESCRIPTION
Commits:
1. changed all instances of assertThat(...).contains(...) to containsExactly in FindingNumbersUnitTest
2. added tests for finding integers as Longs and decimal numbers as Doubles
3. added tests for finding Scientific Notation and Hexadecimal numbers

... these were added to previous code drafts for counting digits and finding numbers