### PR TITLE
Update Graph.java

### DIFF
--- a/algorithms-searching/src/main/java/com/baeldung/algorithms/dfs/Graph.java
+++ b/algorithms-searching/src/main/java/com/baeldung/algorithms/dfs/Graph.java
@@ -29,11 +29,13 @@ public class Graph {
         stack.push(start);
         while (!stack.isEmpty()) {
             int current = stack.pop();
-            isVisited[current] = true;
-            visit(current);
-            for (int dest : adjVertices.get(current)) {
-                if (!isVisited[dest])
-                    stack.push(dest);
+            if(!isVisited[current]){
+                isVisited[current] = true;
+                visit(current);
+                for (int dest : adjVertices.get(current)) {
+                    if (!isVisited[dest])
+                        stack.push(dest);
+                }
             }
         }
     }


### PR DESCRIPTION
for dfsWithoutRecursion, when a node popped from the stack it should be checked that the current node is visited or not. Since stack has duplicated nodes, some nodes is visired doubly.