### PR TITLE
Also consider string interpolation

### DIFF
--- a/testing-modules/testing-assertions/src/test/java/com/baeldung/junit/log/MemoryAppender.java
+++ b/testing-modules/testing-assertions/src/test/java/com/baeldung/junit/log/MemoryAppender.java
@@ -19,7 +19,7 @@ public class MemoryAppender extends ListAppender<ILoggingEvent> {
 
     public boolean contains(String string, Level level) {
         return this.list.stream()
-          .anyMatch(event -> event.getMessage().toString().contains(string) 
+          .anyMatch(event -> event.toString().contains(string) 
             && event.getLevel().equals(level));
     }
 
@@ -30,13 +30,13 @@ public class MemoryAppender extends ListAppender<ILoggingEvent> {
 
     public List<ILoggingEvent> search(String string) {
         return this.list.stream()
-          .filter(event -> event.getMessage().toString().contains(string))
+          .filter(event -> event.toString().contains(string))
           .collect(Collectors.toList());
     }
 
     public List<ILoggingEvent> search(String string, Level level) {
         return this.list.stream()
-          .filter(event -> event.getMessage().toString().contains(string) 
+          .filter(event -> event.toString().contains(string) 
             && event.getLevel().equals(level))
           .collect(Collectors.toList());
     }


### PR DESCRIPTION
The above example only works when logging a string without using string interpolation. For example the following log statement: log.debug("This is a log from {}", "David"). This would result in event.getMessage() returning "This is a log from {}" while you would like to see the processed form "This is a log from David". The getMessage().toString() only returns the former while toString() on the event will return the latter. Furthermore the toString() method is redundant on getMessage() as it already is a string.