### PR TITLE
Could com.baeldung:apache-rocketmq:1.0-SNAPSHOT drop off redundant dependencies to loose weight?

### DIFF
--- a/apache-rocketmq/pom.xml
+++ b/apache-rocketmq/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         
     </dependencies>
-    
+
     <properties>
         <geode.core>1.6.0</geode.core>
         <rocketmq.version>2.0.4</rocketmq.version>

--- a/apache-rocketmq/pom.xml
+++ b/apache-rocketmq/pom.xml
@@ -33,8 +33,7 @@
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
         </exclusions>
-        </dependency>
-        
+        </dependency>   
     </dependencies>
 
     <properties>

--- a/apache-rocketmq/pom.xml
+++ b/apache-rocketmq/pom.xml
@@ -36,12 +36,10 @@
         </dependency>
         
     </dependencies>
-    
     <properties>
         <geode.core>1.6.0</geode.core>
         <rocketmq.version>2.0.4</rocketmq.version>
     </properties>
-    
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/apache-rocketmq/pom.xml
+++ b/apache-rocketmq/pom.xml
@@ -36,6 +36,7 @@
         </dependency>
         
     </dependencies>
+    
     <properties>
         <geode.core>1.6.0</geode.core>
         <rocketmq.version>2.0.4</rocketmq.version>

--- a/apache-rocketmq/pom.xml
+++ b/apache-rocketmq/pom.xml
@@ -19,11 +19,66 @@
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-spring-boot-starter</artifactId>
             <version>${rocketmq.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-validation</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+        </exclusions>
         </dependency>
+        
     </dependencies>
-
+    
     <properties>
         <geode.core>1.6.0</geode.core>
         <rocketmq.version>2.0.4</rocketmq.version>
     </properties>
+    
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.rocketmq</groupId>
+                <artifactId>rocketmq-spring-boot</artifactId>
+                <version>2.0.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot</artifactId>
+                <version>2.0.5.RELEASE</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-autoconfigure</artifactId>
+                <version>2.0.5.RELEASE</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>8.5.34</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>6.0.12.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>2.10.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>1.7.25</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/deeplearning4j/pom.xml
+++ b/deeplearning4j/pom.xml
@@ -26,11 +26,39 @@
             <groupId>org.nd4j</groupId>
             <artifactId>nd4j-native-platform</artifactId>
             <version>${dl4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.nd4j</groupId>
+                    <artifactId>nd4j-native</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bytedeco.javacpp-presets</groupId>
+                    <artifactId>openblas</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>
             <artifactId>deeplearning4j-core</artifactId>
             <version>${dl4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bytedeco.javacpp-presets</groupId>
+                    <artifactId>opencv-platform</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bytedeco.javacpp-presets</groupId>
+                    <artifactId>hdf5</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bytedeco.javacpp-presets</groupId>
+                    <artifactId>leptonica</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bytedeco.javacpp-presets</groupId>
+                    <artifactId>hdf5-platform</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>


### PR DESCRIPTION
@johnA1331 Hi, I am a user of project **_com.baeldung:apache-rocketmq:1.0-SNAPSHOT_**. I found that its pom file introduced **_60_** dependencies. However, among them, **_10_** libraries (**_16%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for this project. 
This PR helps **_com.baeldung:apache-rocketmq:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards