### PR TITLE
examples for BAEL-5153 - remove double quotes

### DIFF
--- a/core-java-modules/core-java-string-operations-3/src/main/java/com/baeldung/doublequotesremoval/DoubleQuotesRemovalUtils.java
+++ b/core-java-modules/core-java-string-operations-3/src/main/java/com/baeldung/doublequotesremoval/DoubleQuotesRemovalUtils.java
@@ -1,0 +1,37 @@
+package com.baeldung.doublequotesremoval;
+
+import com.google.common.base.CharMatcher;
+
+public class DoubleQuotesRemovalUtils {
+    
+    public static String removeWithSubString(String input) {
+        if (input != null && input.length() >= 2 && input.charAt(0) == '\"' 
+            && input.charAt(input.length() - 1) == '\"') {
+            return input.substring(1, input.length() - 1);
+        }
+
+        return input;
+    }
+
+    public static String removeWithReplaceAllSimple(String input) {
+        if (input == null || input.isEmpty())
+            return input;
+
+        return input.replaceAll("\"", "");
+    }
+    
+    public static String removeWithReplaceAllAdvanced(String input) {
+        if (input == null || input.isEmpty())
+            return input;
+
+        return input.replaceAll("^\"|\"$", "");
+    }
+    
+    public static String removeWithGuava(String input) {
+        if (input == null || input.isEmpty())
+            return input;
+        
+        return CharMatcher.is('\"').trimFrom(input);
+    }
+
+}

--- a/core-java-modules/core-java-string-operations-3/src/test/java/com/baeldung/doublequotesremoval/DoubleQuotesRemovalUtilsUnitTest.java
+++ b/core-java-modules/core-java-string-operations-3/src/test/java/com/baeldung/doublequotesremoval/DoubleQuotesRemovalUtilsUnitTest.java
@@ -1,0 +1,42 @@
+package com.baeldung.doublequotesremoval;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class DoubleQuotesRemovalUtilsUnitTest {
+    
+    @Test
+    public void given_EmptyString_ShouldReturn_EmptyString() {
+        String input = "";
+        
+        assertTrue(DoubleQuotesRemovalUtils.removeWithSubString(input).isEmpty());
+        assertTrue(DoubleQuotesRemovalUtils.removeWithReplaceAllSimple(input).isEmpty());
+        assertTrue(DoubleQuotesRemovalUtils.removeWithReplaceAllAdvanced(input).isEmpty());
+        assertTrue(DoubleQuotesRemovalUtils.removeWithGuava(input).isEmpty());
+    }
+    
+    @Test
+    public void given_DoubleQuotesOnly_ShouldReturn_EmptyString() {
+        String input = "\"\"";
+        
+        assertTrue(DoubleQuotesRemovalUtils.removeWithSubString(input).isEmpty());
+        assertTrue(DoubleQuotesRemovalUtils.removeWithReplaceAllSimple(input).isEmpty());
+        assertTrue(DoubleQuotesRemovalUtils.removeWithReplaceAllAdvanced(input).isEmpty());
+        assertTrue(DoubleQuotesRemovalUtils.removeWithGuava(input).isEmpty());
+    }
+    
+    @Test
+    public void given_TextWithDoubleQuotes_ShouldReturn_TextOnly() {
+        
+        String input = "\"Example of text for this test suit\"";
+        String expectedResult = "Example of text for this test suit";
+        
+        assertEquals(expectedResult, DoubleQuotesRemovalUtils.removeWithSubString(input));
+        assertEquals(expectedResult, DoubleQuotesRemovalUtils.removeWithReplaceAllSimple(input));
+        assertEquals(expectedResult, DoubleQuotesRemovalUtils.removeWithReplaceAllAdvanced(input));
+        assertEquals(expectedResult, DoubleQuotesRemovalUtils.removeWithGuava(input));
+    }
+
+}


### PR DESCRIPTION
Examples for the BAEL-5153 "How to Remove Beginning and Ending Double Quotes from a String in Java" tutorial.