### PR TITLE
fixing missing parameter

### DIFF
--- a/libraries-io/src/main/java/com/baeldung/java/io/zip4j/ZipSingleFile.java
+++ b/libraries-io/src/main/java/com/baeldung/java/io/zip4j/ZipSingleFile.java
@@ -21,7 +21,7 @@ public class ZipSingleFile {
         if (!fileToAdd.exists()) {
             fileToAdd.createNewFile();
         }
-        zipFile.addFile(fileToAdd);
+        zipFile.addFile(fileToAdd, zipParameters);
         zipFile.close();
     }
 }


### PR DESCRIPTION
Fixed not working example - Added missing zipParameters to .addFile() function