### PR TITLE
Update PostRestController.java

### DIFF
--- a/spring-boot-rest/src/main/java/com/baeldung/springpagination/controller/PostRestController.java
+++ b/spring-boot-rest/src/main/java/com/baeldung/springpagination/controller/PostRestController.java
@@ -63,7 +63,7 @@ public class PostRestController {
         return convertToDto(postService.getPostById(id));
     }
  
-    @PutMapping(value = "/{id}")
+    @PutMapping
     @ResponseStatus(HttpStatus.OK)
     public void updatePost(@RequestBody PostDto postDto) throws ParseException {
         Post post = convertToEntity(postDto);


### PR DESCRIPTION
The id is already part of the postDto in this case. And the controller method does not have a @PathVariable annotation to evaluate the /{id} parameter. Guess the id should be transmitted in the RequestBody in the PostDto Object? Otherwise, id would be redundant, once in the PathVariable and once in the PostDto.