### PR TITLE
fix: [ BAEL-5109 ] Environment Variable Prefixes in Spring Boot 2.5 

### DIFF
--- a/spring-boot-modules/spring-boot-environment/src/main/java/com/baeldung/prefix/PrefixController.java
+++ b/spring-boot-modules/spring-boot-environment/src/main/java/com/baeldung/prefix/PrefixController.java
@@ -1,6 +1,7 @@
 package com.baeldung.prefix;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,12 +9,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class PrefixController {
 
-    @Value(value = "${server.port}")
-    private int serverPort;
+    @Autowired
+    private Environment environment;
 
     @GetMapping("/prefix")
     public String getServerPortInfo(final Model model) {
-        model.addAttribute("serverPort", serverPort);
+        model.addAttribute("serverPort", environment.getProperty("server.port"));
         return "prefix";
     }
 }


### PR DESCRIPTION
use the environment to get properties to avoid exception in case property do not exists