### PR TITLE
JAVA:8981: verify spring.mvc.pathmatch.matching-strategy property usage

### DIFF
--- a/spring-boot-modules/spring-boot-mvc/src/main/resources/application.properties
+++ b/spring-boot-modules/spring-boot-mvc/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.thymeleaf.view-names=thymeleaf/*
-spring.mvc.pathmatch.matching-strategy=ant_path_matcher
+spring.mvc.pathmatch.matching-strategy=ant-path-matcher

--- a/spring-boot-modules/spring-boot-springdoc/pom.xml
+++ b/spring-boot-modules/spring-boot-springdoc/pom.xml
@@ -206,7 +206,7 @@
     </profiles>
 
     <properties>
-        <springdoc.version>1.5.2</springdoc.version>
+        <springdoc.version>1.6.4</springdoc.version>
         <asciidoctor-plugin.version>1.5.6</asciidoctor-plugin.version>
         <kotlin.version>1.6.0</kotlin.version>
         <snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>

--- a/spring-boot-modules/spring-boot-springdoc/src/main/resources/application.properties
+++ b/spring-boot-modules/spring-boot-springdoc/src/main/resources/application.properties
@@ -11,6 +11,3 @@ spring.datasource.url=jdbc:h2:mem:springdoc
 ## for com.baeldung.restdocopenapi ##
 springdoc.version=@springdoc.version@
 spring.jpa.hibernate.ddl-auto=none
-######################################
-
-spring.mvc.pathmatch.matching-strategy=ant_path_matcher

--- a/spring-web-modules/spring-mvc-basics-5/src/main/java/com/baeldung/spring/web/config/WebConfig.java
+++ b/spring-web-modules/spring-mvc-basics-5/src/main/java/com/baeldung/spring/web/config/WebConfig.java
@@ -33,7 +33,7 @@ public class WebConfig implements WebMvcConfigurer {
     /** Static resource locations */
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/resources/**/*")
+        registry.addResourceHandler("/resources/**")
           .addResourceLocations("/", "/resources/")
           .setCachePeriod(3600)
           .resourceChain(true)

--- a/spring-web-modules/spring-mvc-basics-5/src/main/resources/application.properties
+++ b/spring-web-modules/spring-mvc-basics-5/src/main/resources/application.properties
@@ -1,3 +1,1 @@
 server.servlet.context-path=/spring-mvc-basics
-
-spring.mvc.pathmatch.matching-strategy=ant-path-matcher

--- a/spring-web-modules/spring-mvc-basics/src/main/java/com/baeldung/spring/web/config/WebConfig.java
+++ b/spring-web-modules/spring-mvc-basics/src/main/java/com/baeldung/spring/web/config/WebConfig.java
@@ -53,7 +53,7 @@ public class WebConfig implements WebMvcConfigurer {
     /** Static resource locations including themes*/
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/resources/**/*")
+        registry.addResourceHandler("/resources/**")
             .addResourceLocations("/", "/resources/")
             .setCachePeriod(3600)
             .resourceChain(true)
@@ -118,8 +118,7 @@ public class WebConfig implements WebMvcConfigurer {
      */
     @Override
     public void configureContentNegotiation(final ContentNegotiationConfigurer configurer) {
-        configurer.favorPathExtension(true)
-            .favorParameter(true)
+        configurer.favorParameter(true)
             .parameterName("mediaType")
             .ignoreAcceptHeader(false)
             .useRegisteredExtensionsOnly(false)

--- a/spring-web-modules/spring-mvc-basics/src/main/resources/application.properties
+++ b/spring-web-modules/spring-mvc-basics/src/main/resources/application.properties
@@ -1,8 +1,5 @@
 server.servlet.context-path=/spring-mvc-basics
 
 ### Content Negotiation (already defined programatically)
-#spring.mvc.contentnegotiation.favor-path-extension=true
 #spring.mvc.contentnegotiation.favor-parameter=true
 #spring.mvc.contentnegotiation.parameter-name=mediaType
-spring.mvc.pathmatch.use-suffix-pattern=true
-spring.mvc.pathmatch.matching-strategy=ant-path-matcher

--- a/spring-web-modules/spring-mvc-basics/src/test/java/com/baeldung/web/controller/EmployeeControllerContentNegotiationIntegrationTest.java
+++ b/spring-web-modules/spring-mvc-basics/src/test/java/com/baeldung/web/controller/EmployeeControllerContentNegotiationIntegrationTest.java
@@ -20,20 +20,6 @@ public class EmployeeControllerContentNegotiationIntegrationTest {
     private MockMvc mockMvc;
 
     @Test
-    public void whenEndpointUsingJsonSuffixCalled_thenJsonResponseObtained() throws Exception {
-        this.mockMvc.perform(get("/employee/1.json"))
-            .andExpect(status().isOk())
-            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
-    }
-
-    @Test
-    public void whenEndpointUsingXmlSuffixCalled_thenXmlResponseObtained() throws Exception {
-        this.mockMvc.perform(get("/employee/1.xml"))
-            .andExpect(status().isOk())
-            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML_VALUE));
-    }
-
-    @Test
     public void whenEndpointUsingJsonParameterCalled_thenJsonResponseObtained() throws Exception {
         this.mockMvc.perform(get("/employee/1?mediaType=json"))
             .andExpect(status().isOk())


### PR DESCRIPTION
**spring-boot-mvc**

- This module uses springfox which is not yet compatible with 2.6.1 PathPatternParser until this issue is resolved. https://github.com/springfox/springfox/issues/3462
- Also, I've modified ant_path_matcher to ant-path-matcher (dashes instead of underscores). That's what the release notes says and I've verified it as well.

**spring-boot-springdoc**

- Updated spring doc version to 1.6.4 which has the fix to make it compatible with the new matcher and removed the property. 
- Article update: http://staging37.baeldung.com/spring-rest-openapi-documentation

**spring-mvc-basics**

- Fixed the resource handler pattern in WebMvcConfig and removed the property.
- Removed the usage of ContentNegotiationConfigurer.favorPathExtension which is deprecated and not compatible with PathPatternParser.
- Removed the endpoint and tests which were using URL suffix strategy because it is deprecated and not supported with the new matcher.

**spring-mvc-basics5**

- Fixed the resource handler pattern in WebMvcConfig and removed the property.