### PR TITLE
BAEL-5319 - Remove Basic Error Controller in Swagger

### DIFF
--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/SpringBootSwaggerConfApplication.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/SpringBootSwaggerConfApplication.java
@@ -1,0 +1,13 @@
+package com.baeldung.swaggerconf;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringBootSwaggerConfApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SpringBootSwaggerConfApplication.class, args);
+    }
+
+}

--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/configuration/SwaggerConfiguration.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/configuration/SwaggerConfiguration.java
@@ -21,7 +21,7 @@ public class SwaggerConfiguration {
 
     private ApiInfo apiInfo() {
         return new ApiInfo("My REST API", "Some custom description of API.", "API TOS", "Terms of service",
-                new Contact("Gaetano Piazzolla", "www.baeldung.com", "gae.piaz@gmail.com"),
+                new Contact("General UserName", "www.baeldung.com", "user-name@gmail.com"),
                 "License of API", "API license URL", Collections.emptyList());
     }
 
@@ -29,11 +29,8 @@ public class SwaggerConfiguration {
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2).apiInfo(apiInfo())
                 .select()
-                // excludes ErrorControllerExcludedForPackage
                 .apis(RequestHandlerSelectors.basePackage("com.baeldung.swaggerconf.controller"))
-                // excludes ErrorControllerExcludedForAnnotation
                 .apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
-                // excludes ErrorControllerExcludedForPath
                 .paths(regex("/good-path/.*"))
                 .build();
     }

--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/configuration/SwaggerConfiguration.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/configuration/SwaggerConfiguration.java
@@ -1,0 +1,41 @@
+package com.baeldung.swaggerconf.configuration;
+
+import java.util.Collections;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import static springfox.documentation.builders.PathSelectors.regex;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfiguration {
+
+    private ApiInfo apiInfo() {
+        return new ApiInfo("My REST API", "Some custom description of API.", "API TOS", "Terms of service",
+                new Contact("Gaetano Piazzolla", "www.baeldung.com", "gae.piaz@gmail.com"),
+                "License of API", "API license URL", Collections.emptyList());
+    }
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2).apiInfo(apiInfo())
+                .select()
+                // excludes ErrorControllerExcludedForPackage
+                .apis(RequestHandlerSelectors.basePackage("com.baeldung.swaggerconf.controller"))
+                // excludes ErrorControllerExcludedForAnnotation
+                .apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
+                // excludes ErrorControllerExcludedForPath
+                .paths(regex("/good-path/.*"))
+                .build();
+    }
+
+}

--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/configuration/SwaggerConfiguration.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/configuration/SwaggerConfiguration.java
@@ -1,10 +1,7 @@
 package com.baeldung.swaggerconf.configuration;
 
-import java.util.Collections;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
@@ -12,6 +9,8 @@ import springfox.documentation.service.Contact;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.Collections;
 
 import static springfox.documentation.builders.PathSelectors.regex;
 
@@ -21,18 +20,18 @@ public class SwaggerConfiguration {
 
     private ApiInfo apiInfo() {
         return new ApiInfo("My REST API", "Some custom description of API.", "API TOS", "Terms of service",
-                new Contact("General UserName", "www.baeldung.com", "user-name@gmail.com"),
-                "License of API", "API license URL", Collections.emptyList());
+          new Contact("General UserName", "www.baeldung.com", "user-name@gmail.com"),
+          "License of API", "API license URL", Collections.emptyList());
     }
 
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2).apiInfo(apiInfo())
-                .select()
-                .apis(RequestHandlerSelectors.basePackage("com.baeldung.swaggerconf.controller"))
-                .apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
-                .paths(regex("/good-path/.*"))
-                .build();
+          .select()
+          .apis(RequestHandlerSelectors.basePackage("com.baeldung.swaggerconf.controller"))
+          .apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
+          .paths(regex("/good-path/.*"))
+          .build();
     }
 
 }

--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/ErrorControllerExcludedForAnnotation.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/ErrorControllerExcludedForAnnotation.java
@@ -1,0 +1,18 @@
+package com.baeldung.swaggerconf.controller;
+
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Component
+@RequestMapping("good-path/error-excluded-annotation")
+public class ErrorControllerExcludedForAnnotation extends BasicErrorController {
+
+    public ErrorControllerExcludedForAnnotation(ErrorAttributes errorAttributes, ServerProperties serverProperties) {
+        super(errorAttributes, serverProperties.getError());
+    }
+
+}

--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/ErrorControllerExcludedForAnnotation.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/ErrorControllerExcludedForAnnotation.java
@@ -3,7 +3,6 @@ package com.baeldung.swaggerconf.controller;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
-
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestMapping;
 

--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/ErrorControllerExcludedForApiIgnore.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/ErrorControllerExcludedForApiIgnore.java
@@ -1,0 +1,21 @@
+package com.baeldung.swaggerconf.controller;
+
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+@Component
+@RequestMapping("good-path/error-excluded-apiignore")
+@RestController
+@ApiIgnore // exclude ErrorControllerExcludedForApiIgnore
+public class ErrorControllerExcludedForApiIgnore extends BasicErrorController {
+
+    public ErrorControllerExcludedForApiIgnore(ErrorAttributes errorAttributes, ServerProperties serverProperties) {
+        super(errorAttributes, serverProperties.getError());
+    }
+
+}

--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/ErrorControllerExcludedForApiIgnore.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/ErrorControllerExcludedForApiIgnore.java
@@ -11,7 +11,7 @@ import springfox.documentation.annotations.ApiIgnore;
 @Component
 @RequestMapping("good-path/error-excluded-apiignore")
 @RestController
-@ApiIgnore // exclude ErrorControllerExcludedForApiIgnore
+@ApiIgnore
 public class ErrorControllerExcludedForApiIgnore extends BasicErrorController {
 
     public ErrorControllerExcludedForApiIgnore(ErrorAttributes errorAttributes, ServerProperties serverProperties) {

--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/ErrorControllerExcludedForPath.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/ErrorControllerExcludedForPath.java
@@ -1,0 +1,19 @@
+package com.baeldung.swaggerconf.controller;
+
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Component
+@RequestMapping("wrong-path/error-excluded-path")
+@RestController
+public class ErrorControllerExcludedForPath extends BasicErrorController {
+
+    public ErrorControllerExcludedForPath(ErrorAttributes errorAttributes, ServerProperties serverProperties) {
+        super(errorAttributes, serverProperties.getError());
+    }
+
+}

--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/RegularRestController.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/RegularRestController.java
@@ -1,13 +1,12 @@
 package com.baeldung.swaggerconf.controller;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-
+import io.swagger.annotations.ApiOperation;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.swagger.annotations.ApiOperation;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 @RestController
 @RequestMapping("good-path")

--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/RegularRestController.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/RegularRestController.java
@@ -16,7 +16,7 @@ public class RegularRestController {
     @ApiOperation(value = "This method is used to get the author name.")
     @GetMapping("/getAuthor")
     public String getAuthor() {
-        return "Gaetano Piazzolla";
+        return "Name Surname";
     }
 
     @ApiOperation(value = "This method is used to get the current date.")

--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/RegularRestController.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/controller/RegularRestController.java
@@ -1,0 +1,34 @@
+package com.baeldung.swaggerconf.controller;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.ApiOperation;
+
+@RestController
+@RequestMapping("good-path")
+public class RegularRestController {
+
+    @ApiOperation(value = "This method is used to get the author name.")
+    @GetMapping("/getAuthor")
+    public String getAuthor() {
+        return "Gaetano Piazzolla";
+    }
+
+    @ApiOperation(value = "This method is used to get the current date.")
+    @GetMapping("/getDate")
+    public LocalDate getDate() {
+        return LocalDate.now();
+    }
+
+    @ApiOperation(value = "This method is used to get the current time.")
+    @GetMapping("/getTime")
+    public LocalTime getTime() {
+        return LocalTime.now();
+    }
+
+}

--- a/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/excluded/ErrorControllerExcludedForPackage.java
+++ b/spring-boot-modules/spring-boot-swagger/src/main/java/com/baeldung/swaggerconf/excluded/ErrorControllerExcludedForPackage.java
@@ -1,0 +1,17 @@
+package com.baeldung.swaggerconf.excluded;
+
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Component
+@RequestMapping("good-path/error-excluded-package")
+public class ErrorControllerExcludedForPackage extends BasicErrorController {
+
+    public ErrorControllerExcludedForPackage(ErrorAttributes errorAttributes, ServerProperties serverProperties) {
+        super(errorAttributes, serverProperties.getError());
+    }
+
+}

--- a/spring-boot-modules/spring-boot-swagger/src/main/resources/application.properties
+++ b/spring-boot-modules/spring-boot-swagger/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER

--- a/spring-boot-modules/spring-boot-swagger/src/test/java/com/baeldung/swaggerconf/SwaggerConfExcludeErrorControllerIntegrationTest.java
+++ b/spring-boot-modules/spring-boot-swagger/src/test/java/com/baeldung/swaggerconf/SwaggerConfExcludeErrorControllerIntegrationTest.java
@@ -17,7 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class SwaggerConfExcludeErrorControllerTest {
+public class SwaggerConfExcludeErrorControllerIntegrationTest {
 
     @Autowired
     private MockMvc mvc;

--- a/spring-boot-modules/spring-boot-swagger/src/test/java/com/baeldung/swaggerconf/SwaggerConfExcludeErrorControllerTest.java
+++ b/spring-boot-modules/spring-boot-swagger/src/test/java/com/baeldung/swaggerconf/SwaggerConfExcludeErrorControllerTest.java
@@ -1,0 +1,33 @@
+package com.baeldung.swaggerconf;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class SwaggerConfExcludeErrorControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    public void whenCallingSwaggerJSON_stringObjectDoesNotContainAnyErrorControllers() throws Exception {
+        ResultActions resultActions = mvc.perform(get("/v2/api-docs")).andExpect(status().isOk());
+        MvcResult result = resultActions.andReturn();
+        String content = result.getResponse().getContentAsString();
+        Assert.assertNotNull(content);
+        Assert.assertFalse(content.contains("error-controller"));
+    }
+}


### PR DESCRIPTION
Notes: 

I had to add inside the _application.properties_ this line:

`spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER`

Otherwise applications in the folder "spring-modules/spring-boot-swagger" couldn't start.
