### PR TITLE
aws-lambda: todo-reminder: added cron trigger as stated in the article

### DIFF
--- a/aws-lambda/todo-reminder/template.yaml
+++ b/aws-lambda/todo-reminder/template.yaml
@@ -20,3 +20,9 @@ Resources:
         Variables:
           PARAM1: VALUE
           ENV_NAME: !Ref EnvironmentName
+      Events:
+        ScheduledEvent:
+          Type: Schedule
+          Properties:
+            Schedule: cron(0/10 * * * ? *)
+            Enabled: True


### PR DESCRIPTION
The corresponding article ( https://www.baeldung.com/java-enterprise-aws-lambda#2-example-problem ) says: "Let's create an app that runs every few minutes". However, it seems that a scheduled event trigger has been forgotten, so the function is never invoked.
I added a scheduled event that invokes the function every 10 minutes. Tested on AWS.