### PR TITLE
Updated README.md on spring-boot-testing and spring-boot-testing-2

### DIFF
--- a/spring-boot-modules/spring-boot-testing-2/README.md
+++ b/spring-boot-modules/spring-boot-testing-2/README.md
@@ -9,4 +9,5 @@ The "REST With Spring" Classes: http://bit.ly/restwithspring
 ### Relevant Articles:
 
 - [Setting the Log Level in Spring Boot when Testing](https://www.baeldung.com/spring-boot-testing-log-level)
+- [Failed to Load ApplicationContext for JUnit Test of Spring Controller](https://www.baeldung.com/spring-junit-failed-to-load-applicationcontext)
 - More articles: [[<-- prev]](../spring-boot-testing)

--- a/spring-boot-modules/spring-boot-testing/README.md
+++ b/spring-boot-modules/spring-boot-testing/README.md
@@ -15,5 +15,4 @@ The "REST With Spring" Classes: http://bit.ly/restwithspring
 - [Prevent ApplicationRunner or CommandLineRunner Beans From Executing During Junit Testing](https://www.baeldung.com/spring-junit-prevent-runner-beans-testing-execution)
 - [Testing in Spring Boot](https://www.baeldung.com/spring-boot-testing)
 - [Fixing the NoSuchMethodError JUnit Error](https://www.baeldung.com/junit-nosuchmethoderror)
-- [Failed to Load ApplicationContext for JUnit Test of Spring Controller](https://www.baeldung.com/spring-junit-failed-to-load-applicationcontext)
 - More articles: [[more -->]](../spring-boot-testing-2)


### PR DESCRIPTION
Moved https://www.baeldung.com/spring-junit-failed-to-load-applicationcontext to spring-boot-testing-2