### PR TITLE
Fix loop iterating in Ant Colony Optimization

### DIFF
--- a/algorithms-genetic/src/main/java/com/baeldung/algorithms/ga/ant_colony/AntColonyOptimization.java
+++ b/algorithms-genetic/src/main/java/com/baeldung/algorithms/ga/ant_colony/AntColonyOptimization.java
@@ -69,10 +69,10 @@ public class AntColonyOptimization {
      * Use this method to run the main logic
      */
     public int[] solve() {
-        setupAnts();
         clearTrails();
         IntStream.range(0, maxIterations)
             .forEach(i -> {
+                setupAnts();
                 moveAnts();
                 updateTrails();
                 updateBest();


### PR DESCRIPTION
Currently, there is a bug and ants move only at the first iteration of the loop. After that `currentIndex` will have the value of `numberOfCities - 1` and the presented code will not be executed after the first iteration.

```java
private void moveAnts() {
    IntStream.range(currentIndex, numberOfCities - 1)
        .forEach(i -> {
            ants.forEach(ant -> ant.visitCity(currentIndex, selectNextCity(ant)));
            currentIndex++;
        });
    }
```

To fix this bug `currentIndex` should be set to 0 after each iteration. Also, ants should be set up again to clear the previous tour. Invoking `setupAnts()` method in each iteration will solve these problems. 

