### PR TITLE
Add placeholder

### DIFF
--- a/spring-kafka/src/main/resources/application.properties
+++ b/spring-kafka/src/main/resources/application.properties
@@ -14,3 +14,4 @@ monitor.topic.name=baeldung
 monitor.producer.simulate=true
 monitor.consumer.simulate=true
 monitor.kafka.consumer.groupid.simulate=baeldungGrpSimulate
+test.topic=testtopic1


### PR DESCRIPTION
The placeholder is mentioned in the kafkaConsumer.java but didn't defined in the applications.prop. So we need to defined that.

Current exception is as follow.

org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'kafkaConsumer' defined in file [/Users/mac/Library/Mobile Documents/com~apple~CloudDocs/development/kafka-poc/producer/target/classes/com/ef/kafka/embedded/KafkaConsumer.class]: Initialization of bean failed; nested exception is java.lang.IllegalArgumentException: Could not resolve placeholder 'test.topic' in value "${test.topic}"