### PR TITLE
Assertions in JUnit 4 and JUnit 5 suggestions

### DIFF
--- a/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit4AssertionsUnitTest.java
+++ b/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit4AssertionsUnitTest.java
@@ -1,5 +1,6 @@
 package com.baeldung.junit5vsjunit4assertions;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -30,7 +31,7 @@ public class Junit4AssertionsUnitTest {
 
     @Test
     public void whenAssertingArraysEquality_thenEqual() {
-        char[] expected = { 'J', 'u', 'n', 'i', 't' };
+        char[] expected = {'J', 'u', 'n', 'i', 't'};
         char[] actual = "Junit".toCharArray();
 
         assertArrayEquals(expected, actual);
@@ -95,7 +96,7 @@ public class Junit4AssertionsUnitTest {
 
     @Test
     public void testAssertThatHasItems() {
-        assertThat(Arrays.asList("Java", "Kotlin", "Scala"), hasItems("Java", "Kotlin"));
+        MatcherAssert.assertThat(Arrays.asList("Java", "Kotlin", "Scala"), hasItems("Java", "Kotlin"));
     }
 
 }

--- a/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit5AssertionsUnitTest.java
+++ b/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit5AssertionsUnitTest.java
@@ -32,11 +32,11 @@ import org.junit.jupiter.api.Test;
  * Unit test that demonstrate the different assertions available within JUnit 4
  */
 @DisplayName("Test case for assertions")
-public class Junit5AssertionsUnitTest {
+class Junit5AssertionsUnitTest {
 
     @Test
     @DisplayName("Arrays should be equals")
-    public void whenAssertingArraysEquality_thenEqual() {
+    void whenAssertingArraysEquality_thenEqual() {
         char[] expected = {'J', 'u', 'p', 'i', 't', 'e', 'r'};
         char[] actual = "Jupiter".toCharArray();
 
@@ -45,7 +45,7 @@ public class Junit5AssertionsUnitTest {
 
     @Test
     @DisplayName("The area of two polygons should be equal")
-    public void whenAssertingEquality_thenEqual() {
+    void whenAssertingEquality_thenEqual() {
         float square = 2 * 2;
         float rectangle = 2 * 2;
 
@@ -53,7 +53,7 @@ public class Junit5AssertionsUnitTest {
     }
 
     @Test
-    public void whenAssertingEqualityWithDelta_thenEqual() {
+    void whenAssertingEqualityWithDelta_thenEqual() {
         float square = 2 * 2;
         float rectangle = 3 * 2;
         float delta = 2;
@@ -62,27 +62,27 @@ public class Junit5AssertionsUnitTest {
     }
 
     @Test
-    public void whenAssertingConditions_thenVerified() {
+    void whenAssertingConditions_thenVerified() {
         assertTrue(5 > 4, "5 is greater the 4");
         assertTrue(null == null, "null is equal to null");
     }
 
     @Test
-    public void whenAssertingNull_thenTrue() {
+    void whenAssertingNull_thenTrue() {
         Object cat = null;
 
         assertNull(cat, () -> "The cat should be null");
     }
 
     @Test
-    public void whenAssertingNotNull_thenTrue() {
+    void whenAssertingNotNull_thenTrue() {
         Object dog = new Object();
 
         assertNotNull(dog, () -> "The dog should not be null");
     }
 
     @Test
-    public void whenAssertingSameObject_thenSuccessfull() {
+    void whenAssertingSameObject_thenSuccessfull() {
         String language = "Java";
         Optional<String> optional = Optional.of(language);
 
@@ -90,7 +90,7 @@ public class Junit5AssertionsUnitTest {
     }
 
     @Test
-    public void givenBooleanSupplier_whenAssertingCondition_thenVerified() {
+    void givenBooleanSupplier_whenAssertingCondition_thenVerified() {
         BooleanSupplier condition = () -> 5 > 6;
 
         assertFalse(condition, "5 is not greater then 6");
@@ -98,13 +98,13 @@ public class Junit5AssertionsUnitTest {
 
     @Test
     @Disabled
-    public void whenFailingATest_thenFailed() {
+    void whenFailingATest_thenFailed() {
         // Test not completed
         fail("FAIL - test not completed");
     }
 
     @Test
-    public void givenMultipleAssertion_whenAssertingAll_thenOK() {
+    void givenMultipleAssertion_whenAssertingAll_thenOK() {
         Object obj = null;
         assertAll(
            "heading",
@@ -115,7 +115,7 @@ public class Junit5AssertionsUnitTest {
     }
 
     @Test
-    public void givenTwoLists_whenAssertingIterables_thenEquals() {
+    void givenTwoLists_whenAssertingIterables_thenEquals() {
         Iterable<String> al = new ArrayList<>(asList("Java", "Junit", "Test"));
         Iterable<String> ll = new LinkedList<>(asList("Java", "Junit", "Test"));
 
@@ -123,7 +123,7 @@ public class Junit5AssertionsUnitTest {
     }
 
     @Test
-    public void whenAssertingTimeout_thenNotExceeded() {
+    void whenAssertingTimeout_thenNotExceeded() {
         assertTimeout(
           ofSeconds(2),
           () -> {
@@ -134,7 +134,7 @@ public class Junit5AssertionsUnitTest {
     }
 
     @Test
-    public void whenAssertingTimeoutPreemptively_thenNotExceeded() {
+    void whenAssertingTimeoutPreemptively_thenNotExceeded() {
         assertTimeoutPreemptively(
           ofSeconds(2),
           () -> {
@@ -145,14 +145,14 @@ public class Junit5AssertionsUnitTest {
     }
 
     @Test
-    public void whenAssertingEquality_thenNotEqual() {
+    void whenAssertingEquality_thenNotEqual() {
         Integer value = 5; // result of an algorithm
 
         assertNotEquals(0, value, "The result cannot be 0");
     }
 
     @Test
-    public void whenAssertingEqualityListOfStrings_thenEqual() {
+    void whenAssertingEqualityListOfStrings_thenEqual() {
         List<String> expected = asList("Java", "\\d+", "JUnit");
         List<String> actual = asList("Java", "11", "JUnit");
 
@@ -171,7 +171,7 @@ public class Junit5AssertionsUnitTest {
     }
 
     @Test
-    public void testConvertToDoubleThrowException() {
+    void testConvertToDoubleThrowException() {
         String age = "eighteen";
         assertThrows(NumberFormatException.class, () -> {
             convertToInt(age);

--- a/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit5AssertionsUnitTest.java
+++ b/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit5AssertionsUnitTest.java
@@ -97,7 +97,7 @@ class Junit5AssertionsUnitTest {
                 "heading",
                 () -> assertEquals(4, 2 * 2, "4 is 2 times 2"),
                 () -> assertEquals("java", "JAVA".toLowerCase()),
-                () -> assertEquals(obj, null, "null is equal to null")
+                () -> assertNull(obj, "obj is null")
         );
     }
 

--- a/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit5AssertionsUnitTest.java
+++ b/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit5AssertionsUnitTest.java
@@ -70,7 +70,7 @@ class Junit5AssertionsUnitTest {
     }
 
     @Test
-    void whenAssertingSameObject_thenSuccessfull() {
+    void whenAssertingSameObject_thenSuccessful() {
         String language = "Java";
         Optional<String> optional = Optional.of(language);
 
@@ -115,7 +115,7 @@ class Junit5AssertionsUnitTest {
         assertTimeout(
                 ofSeconds(2),
                 () -> {
-                    // code that requires less then 2 minutes to execute
+                    // code that requires less than 2 minutes to execute
                     Thread.sleep(1000);
                 }
         );
@@ -126,7 +126,7 @@ class Junit5AssertionsUnitTest {
         assertTimeoutPreemptively(
                 ofSeconds(2),
                 () -> {
-                    // code that requires less then 2 minutes to execute
+                    // code that requires less than 2 minutes to execute
                     Thread.sleep(1000);
                 }
         );

--- a/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit5AssertionsUnitTest.java
+++ b/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit5AssertionsUnitTest.java
@@ -85,9 +85,8 @@ class Junit5AssertionsUnitTest {
     }
 
     @Test
-    @Disabled
+    @Disabled("Test not completed")
     void whenFailingATest_thenFailed() {
-        // Test not completed
         fail("FAIL - test not completed");
     }
 

--- a/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit5AssertionsUnitTest.java
+++ b/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit5AssertionsUnitTest.java
@@ -1,22 +1,8 @@
 package com.baeldung.junit5vsjunit4assertions;
 
-import static java.time.Duration.ofSeconds;
-import static java.util.Arrays.asList;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -24,9 +10,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static java.time.Duration.ofSeconds;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit test that demonstrate the different assertions available within JUnit 4
@@ -107,10 +93,10 @@ class Junit5AssertionsUnitTest {
     void givenMultipleAssertion_whenAssertingAll_thenOK() {
         Object obj = null;
         assertAll(
-           "heading",
-           () -> assertEquals(4, 2 * 2, "4 is 2 times 2"),
-           () -> assertEquals("java", "JAVA".toLowerCase()),
-           () -> assertEquals(obj, null, "null is equal to null")
+                "heading",
+                () -> assertEquals(4, 2 * 2, "4 is 2 times 2"),
+                () -> assertEquals("java", "JAVA".toLowerCase()),
+                () -> assertEquals(obj, null, "null is equal to null")
         );
     }
 
@@ -125,22 +111,22 @@ class Junit5AssertionsUnitTest {
     @Test
     void whenAssertingTimeout_thenNotExceeded() {
         assertTimeout(
-          ofSeconds(2),
-          () -> {
-            // code that requires less then 2 minutes to execute
-            Thread.sleep(1000);
-          }
+                ofSeconds(2),
+                () -> {
+                    // code that requires less then 2 minutes to execute
+                    Thread.sleep(1000);
+                }
         );
     }
 
     @Test
     void whenAssertingTimeoutPreemptively_thenNotExceeded() {
         assertTimeoutPreemptively(
-          ofSeconds(2),
-          () -> {
-            // code that requires less then 2 minutes to execute
-            Thread.sleep(1000);
-          }
+                ofSeconds(2),
+                () -> {
+                    // code that requires less then 2 minutes to execute
+                    Thread.sleep(1000);
+                }
         );
     }
 
@@ -162,10 +148,10 @@ class Junit5AssertionsUnitTest {
     @Test
     void whenAssertingException_thenThrown() {
         Throwable exception = assertThrows(
-          IllegalArgumentException.class,
-          () -> {
-            throw new IllegalArgumentException("Exception message");
-          }
+                IllegalArgumentException.class,
+                () -> {
+                    throw new IllegalArgumentException("Exception message");
+                }
         );
         assertEquals("Exception message", exception.getMessage());
     }

--- a/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit5AssertionsUnitTest.java
+++ b/testing-modules/junit5-migration/src/test/java/com/baeldung/junit5vsjunit4assertions/Junit5AssertionsUnitTest.java
@@ -9,6 +9,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 
 import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
@@ -57,7 +58,8 @@ class Junit5AssertionsUnitTest {
     void whenAssertingNull_thenTrue() {
         Object cat = null;
 
-        assertNull(cat, () -> "The cat should be null");
+        Supplier<String> messageSupplier = () -> "The cat should be null";
+        assertNull(cat, messageSupplier);
     }
 
     @Test


### PR DESCRIPTION
- [Let's start reviewing the assertions available also in JUnit 4](https://www.baeldung.com/junit-assertions#:~:text=Let%27s%20start%20reviewing%20the%20assertions%20available%20also%20in%20JUnit%204.). Its under Junit 5 thus should be Junit **5**
- [blacklisted exception](https://www.baeldung.com/junit-assertions#:~:text=blacklisted%20exception). Is marked [deprecated](https://junit.org/junit5/docs/current/user-guide/#:~:text=7.3.-,Deprecated%20APIs,-The%20following%20table) according to Junit5 docs
- [fast-forward marker](https://www.baeldung.com/junit-assertions#:~:text=expected%20line%20is%20a-,fast%2Dforward%20marker,-.%20If%20yes%20apply). Example should be given

A valid fast-forward marker is a string that starts and ends with >> and contains at least four characters. Any character between the fast-forward literals is discarded.
```
>>>>
>> stacktrace >>
>> single line, non Integer.parse()-able comment >>
```