### PR TITLE
Could com.baeldung:ShippingFunction:1.0 drop off redundant dependencies?

### DIFF
--- a/aws-modules/aws-lambda/shipping-tracker/ShippingFunction/pom.xml
+++ b/aws-modules/aws-lambda/shipping-tracker/ShippingFunction/pom.xml
@@ -35,6 +35,32 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>${hibernate.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>txw2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.istack</groupId>
+                    <artifactId>istack-commons-runtime</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -45,6 +71,16 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${postgresql.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.staxex</groupId>
+            <artifactId>stax-ex</artifactId>
+            <version>1.8</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.fastinfoset</groupId>
+            <artifactId>FastInfoset</artifactId>
+            <version>1.2.15</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/78527112/170045417-0d53f0e8-f2c8-46bd-8d48-694197afc34f.png)

Hi! I found the pom file of project **_com.baeldung:ShippingFunction:1.0_** introduced **_30_** dependencies. However, among them, **_6_** libraries (**_20%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
com.sun.istack:istack-commons-runtime:jar:3.0.7:compile
javax.xml.bind:jaxb-api:jar:2.3.1:compile
org.glassfish.jaxb:txw2:jar:2.3.1:compile
org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:jar:1.1.1.Final:compile
org.glassfish.jaxb:jaxb-runtime:jar:2.3.1:compile
javax.activation:javax.activation-api:jar:1.2.0:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, As such, I suggest a refactoring operation for **_com.baeldung:ShippingFunction:1.0_**’s pom file.

As shown in the figure, it is noteworthy that, libraries **_org.jvnet.staxex:stax-ex::1.8:compile, com.sun.xml.fastinfoset:FastInfoset::1.2.15:compile_** are invoked by the projects. When we remove the redundant dependency **_org.glassfish.jaxb:jaxb-runtime::2.3.1:compile_**, the above **_org.jvnet.staxex:stax-ex::1.8:compile, com.sun.xml.fastinfoset:FastInfoset::1.2.15:compile_** should be declared as direct dependencies. The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.baeldung:ShippingFunction:1.0_**’s maven tests.

Best regards