### PR TITLE
 JAVA-9808 Fix integration test in spring-state-machine

### DIFF
--- a/spring-state-machine/pom.xml
+++ b/spring-state-machine/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <spring-statemachine-core.version>3.2.0</spring-statemachine-core.version>
         <spring-context.version>5.3.19</spring-context.version>
-        <spring-test.version>4.3.7.RELEASE</spring-test.version>
+        <spring-test.version>5.3.19</spring-test.version>
         <jayway.awaitility.version>1.7.0</jayway.awaitility.version>
     </properties>
 

--- a/spring-state-machine/src/main/java/com/baeldung/spring/statemachine/config/SimpleStateMachineConfiguration.java
+++ b/spring-state-machine/src/main/java/com/baeldung/spring/statemachine/config/SimpleStateMachineConfiguration.java
@@ -38,7 +38,7 @@ public class SimpleStateMachineConfiguration extends StateMachineConfigurerAdapt
           .stateEntry("S3", entryAction())
           .stateExit("S3", exitAction())
           .state("S4", executeAction(), errorAction())
-          .stateDo("S5", executeAction(), errorAction());
+          .state("S5", executeAction(), errorAction());
 
     }
 

--- a/spring-state-machine/src/main/java/com/baeldung/spring/statemachine/config/SimpleStateMachineConfiguration.java
+++ b/spring-state-machine/src/main/java/com/baeldung/spring/statemachine/config/SimpleStateMachineConfiguration.java
@@ -38,7 +38,7 @@ public class SimpleStateMachineConfiguration extends StateMachineConfigurerAdapt
           .stateEntry("S3", entryAction())
           .stateExit("S3", exitAction())
           .state("S4", executeAction(), errorAction())
-          .stateDo("S5", executeAction());
+          .stateDo("S5", executeAction(), errorAction());
 
     }
 

--- a/spring-state-machine/src/test/java/com/baeldung/spring/statemachine/StateMachineIntegrationTest.java
+++ b/spring-state-machine/src/test/java/com/baeldung/spring/statemachine/StateMachineIntegrationTest.java
@@ -1,32 +1,37 @@
 package com.baeldung.spring.statemachine;
 
-import com.baeldung.spring.statemachine.config.SimpleStateMachineConfiguration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.baeldung.spring.statemachine.config.SimpleStateMachineConfiguration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = SimpleStateMachineConfiguration.class)
+@TestMethodOrder(OrderAnnotation.class) 
 public class StateMachineIntegrationTest {
 
     @Autowired
     private StateMachine<String, String> stateMachine;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         stateMachine.start();
     }
 
     @Test
+    @Order(1)  
     public void whenSimpleStringStateMachineEvents_thenEndState() {
         assertEquals("SI", stateMachine.getState().getId());
 
@@ -37,8 +42,8 @@ public class StateMachineIntegrationTest {
         assertEquals("S2", stateMachine.getState().getId());
     }
 
-    @Ignore("Fixing in JAVA-9808")
     @Test
+    @Order(2) 
     public void whenSimpleStringMachineActionState_thenActionExecuted() {
 
         stateMachine.sendEvent("E3");
@@ -58,7 +63,7 @@ public class StateMachineIntegrationTest {
         assertEquals(2, stateMachine.getExtendedState().getVariables().get("approvalCount"));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         stateMachine.stop();
     }


### PR DESCRIPTION
I have upgraded the test to Junit5 in order to use the order functionality provided by Junit5. Also upgraded the spring-test.version as SpringExtension.class required by Junit5 is present in newer versions only.