### PR TITLE
Fix naming of parameters in documentation

### DIFF
--- a/persistence-modules/java-cassandra/src/main/java/com/baeldung/cassandra/batch/repository/ProductRepository.java
+++ b/persistence-modules/java-cassandra/src/main/java/com/baeldung/cassandra/batch/repository/ProductRepository.java
@@ -62,12 +62,13 @@ public class ProductRepository {
 
         executeStatement(createTable.build(), keyspace);
 	}
-	
+
     /**
-     * Insert two variant Product into same table using a batch query.
-     *  
-	 * @param Product
-	 */
+     *  Insert two variant Product into same table using a batch query.
+     *
+     * @param productVariant1
+     * @param productVariant2
+     */
     public void insertProductVariantBatch(Product productVariant1,Product productVariant2) {
     	UUID productId = UUID.randomUUID();
         BoundStatement productBoundStatement1 = this.getProductVariantInsertStatement(productVariant1,productId);
@@ -83,7 +84,7 @@ public class ProductRepository {
      /**
      * Insert two same Product into related tables using a batch query.
 	 * 
-	 * @param book
+	 * @param product
 	 */
      public void insertProductBatch(Product product) {
         UUID productId = UUID.randomUUID();

--- a/persistence-modules/java-cassandra/src/main/java/com/baeldung/cassandra/java/client/repository/KeyspaceRepository.java
+++ b/persistence-modules/java-cassandra/src/main/java/com/baeldung/cassandra/java/client/repository/KeyspaceRepository.java
@@ -16,13 +16,13 @@ public class KeyspaceRepository {
     /**
      * Method used to create any keyspace - schema.
      * 
-     * @param schemaName the name of the schema.
-     * @param replicatioonStrategy the replication strategy.
+     * @param keyspaceName the name of the keyspaceName.
+     * @param replicationStrategy the replication strategy.
      * @param numberOfReplicas the number of replicas.
      * 
      */
-    public void createKeyspace(String keyspaceName, String replicatioonStrategy, int numberOfReplicas) {
-        StringBuilder sb = new StringBuilder("CREATE KEYSPACE IF NOT EXISTS ").append(keyspaceName).append(" WITH replication = {").append("'class':'").append(replicatioonStrategy).append("','replication_factor':").append(numberOfReplicas).append("};");
+    public void createKeyspace(String keyspaceName, String replicationStrategy, int numberOfReplicas) {
+        StringBuilder sb = new StringBuilder("CREATE KEYSPACE IF NOT EXISTS ").append(keyspaceName).append(" WITH replication = {").append("'class':'").append(replicationStrategy).append("','replication_factor':").append(numberOfReplicas).append("};");
 
         final String query = sb.toString();
 
@@ -37,7 +37,7 @@ public class KeyspaceRepository {
      * Method used to delete the specified schema.
      * It results in the immediate, irreversable removal of the keyspace, including all tables and data contained in the keyspace.
      * 
-     * @param schemaName the name of the keyspace to delete.
+     * @param keyspaceName the name of the keyspace to delete.
      */
     public void deleteKeyspace(String keyspaceName) {
         StringBuilder sb = new StringBuilder("DROP KEYSPACE ").append(keyspaceName);


### PR DESCRIPTION
* Fix naming mismatch in Javadocs and typo in `com.baeldung.cassandra.batch.repository.ProductRepository` and `com.baeldung.cassandra.java.client.repository.KeyspaceRepository` classes.