### PR TITLE
Replace old java-faker with kotlin-faker

### DIFF
--- a/spring-boot-modules/spring-boot-react/pom.xml
+++ b/spring-boot-modules/spring-boot-react/pom.xml
@@ -40,9 +40,9 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.javafaker</groupId>
-            <artifactId>javafaker</artifactId>
-            <version>${javafaker.version}</version>
+            <groupId>io.github.serpro69</groupId>
+            <artifactId>kotlin-faker</artifactId>
+            <version>${kotlin-faker.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -139,7 +139,7 @@
         <node.version>v14.18.0</node.version>
         <yarn.version>v1.12.1</yarn.version>
         <spring-boot.version>2.4.4</spring-boot.version>
-        <javafaker.version>1.0.2</javafaker.version>
+        <kotlin-faker.version>1.11.0</kotlin-faker.version>
         <log4j2.version>2.17.1</log4j2.version>
     </properties>
 

--- a/spring-boot-modules/spring-boot-react/src/main/java/com/baeldung/springbootreact/BoostrapInitialData.java
+++ b/spring-boot-modules/spring-boot-react/src/main/java/com/baeldung/springbootreact/BoostrapInitialData.java
@@ -2,9 +2,9 @@ package com.baeldung.springbootreact;
 
 import com.baeldung.springbootreact.domain.Client;
 import com.baeldung.springbootreact.repository.ClientRepository;
-import com.github.javafaker.Faker;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+import io.github.serpro69.kfaker.Faker;
 
 import java.util.Locale;
 
@@ -12,7 +12,7 @@ import java.util.Locale;
 public class BoostrapInitialData implements CommandLineRunner {
 
     private final ClientRepository clientRepository;
-    private final Faker faker = new Faker(Locale.getDefault());
+    private final Faker faker = new Faker();
 
     public BoostrapInitialData(ClientRepository clientRepository) {
         this.clientRepository = clientRepository;
@@ -21,7 +21,7 @@ public class BoostrapInitialData implements CommandLineRunner {
     @Override
     public void run(String... args) {
         for (int i = 0; i < 10; i++) {
-            clientRepository.save(new Client(faker.name().fullName(), faker.internet().emailAddress()));
+            clientRepository.save(new Client(faker.getName().name(), faker.getInternet().safeEmail()));
         }
     }
 }

--- a/spring-web-modules/spring-5-mvc/pom.xml
+++ b/spring-web-modules/spring-5-mvc/pom.xml
@@ -68,9 +68,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.javafaker</groupId>
-            <artifactId>javafaker</artifactId>
-            <version>${javafaker.version}</version>
+            <groupId>io.github.serpro69</groupId>
+            <artifactId>kotlin-faker</artifactId>
+            <version>${kotlin-faker.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -87,7 +87,7 @@
         <jayway-rest-assured.version>2.9.0</jayway-rest-assured.version>
         <httpclient.version>4.5.8</httpclient.version>
         <start-class>com.baeldung.Spring5Application</start-class>
-        <javafaker.version>0.18</javafaker.version>
+        <kotlin-faker.version>1.11.0</kotlin-faker.version>
     </properties>
 
 </project>

--- a/spring-web-modules/spring-5-mvc/src/main/java/com/baeldung/idc/BookRepository.java
+++ b/spring-web-modules/spring-5-mvc/src/main/java/com/baeldung/idc/BookRepository.java
@@ -10,13 +10,13 @@ import javax.annotation.PostConstruct;
 
 import org.springframework.stereotype.Component;
 
-import com.github.javafaker.Faker;
+import io.github.serpro69.kfaker.Faker;
 
 /**
  * Repository for storing the books.
- * 
+ *
  * It serves just for illustrative purposes and is completely in-memory. It uses Java Faker library in order to generate data.
- * 
+ *
  * @author A.Shcherbakov
  *
  */
@@ -27,9 +27,9 @@ public class BookRepository {
 
     @PostConstruct
     public void init() {
-        Faker faker = new Faker(Locale.ENGLISH);
-        final com.github.javafaker.Book book = faker.book();
-        this.items = IntStream.range(1, faker.random()
+        Faker faker = new Faker();
+        final io.github.serpro69.kfaker.provider.Book book = faker.getBook();
+        this.items = IntStream.range(1, faker.getRandom()
             .nextInt(10, 20))
             .mapToObj(i -> new Book(i, book.title(), book.author(), book.genre()))
             .collect(Collectors.toList());

--- a/spring-websockets/pom.xml
+++ b/spring-websockets/pom.xml
@@ -24,9 +24,9 @@
             <artifactId>reactor-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.javafaker</groupId>
-            <artifactId>javafaker</artifactId>
-            <version>1.0.2</version>
+            <groupId>io.github.serpro69</groupId>
+            <artifactId>kotlin-faker</artifactId>
+            <version>1.11.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/spring-websockets/src/main/java/com/baeldung/websockets/ReactiveScheduledPushMessages.java
+++ b/spring-websockets/src/main/java/com/baeldung/websockets/ReactiveScheduledPushMessages.java
@@ -1,6 +1,6 @@
 package com.baeldung.websockets;
 
-import com.github.javafaker.Faker;
+import io.github.serpro69.kfaker.Faker;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -25,7 +25,7 @@ public class ReactiveScheduledPushMessages implements InitializingBean {
     @Override
     public void afterPropertiesSet() throws Exception {
         Flux.interval(Duration.ofSeconds(4L))
-            .map((n) -> new OutputMessage(faker.backToTheFuture().character(), faker.backToTheFuture().quote(), 
+            .map((n) -> new OutputMessage(faker.getBackToTheFuture().characters(), faker.getBackToTheFuture().quotes(),
                                             new SimpleDateFormat("HH:mm").format(new Date())))
             .subscribe(message -> simpMessagingTemplate.convertAndSend("/topic/pushmessages", message));
     }

--- a/spring-websockets/src/main/java/com/baeldung/websockets/ScheduledPushMessages.java
+++ b/spring-websockets/src/main/java/com/baeldung/websockets/ScheduledPushMessages.java
@@ -1,7 +1,7 @@
 package com.baeldung.websockets;
 
 
-import com.github.javafaker.Faker;
+import io.github.serpro69.kfaker.Faker;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Controller;
@@ -14,9 +14,9 @@ import java.util.Date;
 public class ScheduledPushMessages {
 
     private final SimpMessagingTemplate simpMessagingTemplate;
-    
+
     private final Faker faker;
-    
+
     public ScheduledPushMessages(SimpMessagingTemplate simpMessagingTemplate) {
         this.simpMessagingTemplate = simpMessagingTemplate;
         faker = new Faker();
@@ -25,8 +25,8 @@ public class ScheduledPushMessages {
     @Scheduled(fixedRate = 5000)
     public void sendMessage() {
         final String time = new SimpleDateFormat("HH:mm").format(new Date());
-        simpMessagingTemplate.convertAndSend("/topic/pushmessages", 
-            new OutputMessage("Chuck Norris", faker.chuckNorris().fact(), time));
+        simpMessagingTemplate.convertAndSend("/topic/pushmessages",
+            new OutputMessage("Chuck Norris", faker.getChuckNorris().fact(), time));
     }
-    
+
 }


### PR DESCRIPTION
Was going through some of your code and saw that you're using an unmaintained and buggy java-faker, so decided to replace it with kotlin-faker. Hope this is a good change for you :) And thanks for your awesome tutorials :)

There's also a reference to java-faker in https://github.com/eugenp/tutorials/tree/master/testing-modules/mocks , which also has an article linked https://www.baeldung.com/java-faker. So I haven't replaced that since it's an article about java-faker itself. But maybe you'll be interested in updating that as well to reference kotlin-faker instead? Since java-faker has not been maintained for awhile now and also contains bugs and CVEs.
