### PR TITLE
Add Namespace enum

### DIFF
--- a/core-java-modules/core-java-uuid/src/main/java/com/baeldung/uuid/UUIDGenerator.java
+++ b/core-java-modules/core-java-uuid/src/main/java/com/baeldung/uuid/UUIDGenerator.java
@@ -16,6 +16,24 @@ public final class UUIDGenerator {
 
     private UUIDGenerator() {}
 
+    // ref: https://datatracker.ietf.org/doc/html/rfc4122#appendix-C
+    public enum Namespace {
+        DNS("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+        URL("6ba7b811-9dad-11d1-80b4-00c04fd430c8"),
+        OID("6ba7b812-9dad-11d1-80b4-00c04fd430c8"),
+        X500("6ba7b814-9dad-11d1-80b4-00c04fd430c8");
+
+        public final String value;
+
+        Namespace(String value) {
+            this.value = value;
+        }
+
+        public UUID getUUID() {
+            return UUID.fromString(value);
+        }
+    }
+
     /**
      * Type 1 UUID Generation
      */

--- a/core-java-modules/core-java-uuid/src/main/java/com/baeldung/uuid/UUIDGenerator.java
+++ b/core-java-modules/core-java-uuid/src/main/java/com/baeldung/uuid/UUIDGenerator.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 public final class UUIDGenerator {
 
     private static final char[] hexArray = "0123456789ABCDEF".toCharArray();
+    private static final Random random = new Random();
 
     private UUIDGenerator() {}
 
@@ -27,7 +28,7 @@ public final class UUIDGenerator {
     }
 
     private static long get64LeastSignificantBitsForVersion1() {
-        final long random63BitLong = new Random().nextLong() & 0x3FFFFFFFFFFFFFFFL;
+        final long random63BitLong = random.nextLong() & 0x3FFFFFFFFFFFFFFFL;
         final long variant3BitFlag = 0x8000000000000000L;
         return random63BitLong + variant3BitFlag;
     }


### PR DESCRIPTION
## Description
- add `Namespace` enum in [RFC4122 docs](https://datatracker.ietf.org/doc/html/rfc4122)
  - a predefined namespace to the document as an enum
  - It is written so that the namespace value can be used even in the UUID used as a standard class in [other programming languages.](https://docs.python.org/3/library/uuid.html)
- use Random object as a class property