### PR TITLE
bug fix to avoid fallthrough

### DIFF
--- a/vavr-modules/vavr/src/test/java/com/baeldung/vavr/VavrUnitTest.java
+++ b/vavr-modules/vavr/src/test/java/com/baeldung/vavr/VavrUnitTest.java
@@ -323,13 +323,13 @@ public class VavrUnitTest {
         if (input == 0) {
             output = "zero";
         }
-        if (input == 1) {
+        else if (input == 1) {
             output = "one";
         }
-        if (input == 2) {
+        else if (input == 2) {
             output = "two";
         }
-        if (input == 3) {
+        else if (input == 3) {
             output = "three";
         } else {
             output = "unknown";


### PR DESCRIPTION
Fixing bug where any value other than `3` will result in "unknown" being assigned to `output`.

https://www.baeldung.com/vavr-pattern-matching should also be updated with the same changes.