### PR TITLE
JAVA-16779 Removed kubernetes-spring from the kubernetes-modules

### DIFF
--- a/kubernetes-modules/pom.xml
+++ b/kubernetes-modules/pom.xml
@@ -15,7 +15,7 @@
     <modules>
         <module>k8s-intro</module>
         <module>k8s-admission-controller</module>
-        <module>kubernetes-spring</module>
+        <!-- <module>kubernetes-spring</module> --> <!-- JDK-11 Module -->
     </modules>
 
 </project>


### PR DESCRIPTION
- Removed kubernete-spring from the parent pom of kubernetes-modules since it is a JDK11 module