### PR TITLE
Fix link to the previous article in README.md

### DIFF
--- a/core-java-modules/core-java-collections-2/README.md
+++ b/core-java-modules/core-java-collections-2/README.md
@@ -13,4 +13,4 @@
 - [Getting the Size of an Iterable in Java](https://www.baeldung.com/java-iterable-size)
 - [Java Null-Safe Streams from Collections](https://www.baeldung.com/java-null-safe-streams-from-collections)
 - [Differences Between Iterator and Iterable and How to Use Them?](https://www.baeldung.com/java-iterator-vs-iterable)
-- More articles: [[<-- prev]](/core-java-modules/core-java-collections-1) [[next -->]](/core-java-modules/core-java-collections-3)
+- More articles: [[<-- prev]](/core-java-modules/core-java-collections) [[next -->]](/core-java-modules/core-java-collections-3)


### PR DESCRIPTION
Currently, "prev" points to "/core-java-modules/core-java-collections-1" which is not a valid relative directory in repository.