### PR TITLE
BAEL-4487 remove padding that causes non-deterministic behaviour

### DIFF
--- a/core-java-modules/core-java-security-3/src/main/java/com/baeldung/crypto/exception/BadPaddingExamples.java
+++ b/core-java-modules/core-java-security-3/src/main/java/com/baeldung/crypto/exception/BadPaddingExamples.java
@@ -16,7 +16,7 @@ public class BadPaddingExamples {
         SecretKey encryptionKey = CryptoUtils.getKeyForText("BaeldungIsASuperCoolSite");
         SecretKey differentKey = CryptoUtils.getKeyForText("ThisGivesUsAnAlternative");
 
-        Cipher cipher = Cipher.getInstance("AES/ECB/ISO10126Padding");
+        Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
 
         cipher.init(Cipher.ENCRYPT_MODE, encryptionKey);
         byte[] cipherTextBytes = cipher.doFinal(plainTextBytes);
@@ -28,12 +28,12 @@ public class BadPaddingExamples {
 
     public static byte[] encryptAndDecryptUsingDifferentAlgorithms(SecretKey key, IvParameterSpec ivParameterSpec,
             byte[] plainTextBytes) throws InvalidKeyException, GeneralSecurityException {
-        Cipher cipher = Cipher.getInstance("AES/CBC/ISO10126Padding");
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
 
         cipher.init(Cipher.ENCRYPT_MODE, key, ivParameterSpec);
         byte[] cipherTextBytes = cipher.doFinal(plainTextBytes);
 
-        cipher = Cipher.getInstance("AES/ECB/ISO10126Padding");
+        cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
 
         cipher.init(Cipher.DECRYPT_MODE, key);
 


### PR DESCRIPTION
ISO10126Padding has an element of randomness, which means that the code can occasionally "fluke" a result that does not throw an exception (which causes the associated tests to fail).

I have therefore replaced it with PKCS5Padding, which will work every time.

Tested by running the tests in a loop 100000 times and it passes each time.