### PR TITLE
Prevent NPE when trying to create a deep copy

### DIFF
--- a/persistence-modules/hibernate-mapping/src/main/java/com/baeldung/hibernate/arraymapping/CustomIntegerArrayType.java
+++ b/persistence-modules/hibernate-mapping/src/main/java/com/baeldung/hibernate/arraymapping/CustomIntegerArrayType.java
@@ -59,7 +59,7 @@ public class CustomIntegerArrayType implements UserType {
     @Override
     public Object deepCopy(Object value) throws HibernateException {
         Integer[] a = (Integer[])value;
-        return Arrays.copyOf(a, a.length);
+        return a != null ? Arrays.copyOf(a, a.length) : null;
     }
 
     @Override

--- a/persistence-modules/hibernate-mapping/src/main/java/com/baeldung/hibernate/arraymapping/CustomStringArrayType.java
+++ b/persistence-modules/hibernate-mapping/src/main/java/com/baeldung/hibernate/arraymapping/CustomStringArrayType.java
@@ -59,7 +59,7 @@ public class CustomStringArrayType implements UserType {
     @Override
     public Object deepCopy(Object value) throws HibernateException {
         String[] a = (String[])value;
-        return Arrays.copyOf(a, a.length);
+        return a != null ? Arrays.copyOf(a, a.length) : null;
     }
 
     @Override


### PR DESCRIPTION
`a.length` causes NPE when `null` is provided as a value