### PR TITLE
Could com.baeldung.web: spring-boot-rest: 0.0.1-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/spring-boot-rest/pom.xml
+++ b/spring-boot-rest/pom.xml
@@ -159,5 +159,4 @@
         <xstream.version>1.4.11.1</xstream.version>
         <modelmapper.version>3.1.0</modelmapper.version>
     </properties>
-
 </project>

--- a/spring-boot-rest/pom.xml
+++ b/spring-boot-rest/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                  <artifactId>tomcat-embed-el</artifactId>
+                  <groupId>org.apache.tomcat.embed</groupId>
+                </exclusion>
+             </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -42,36 +48,100 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <exclusions>
+                <exclusion>
+                  <artifactId>jakarta.xml.bind-api</artifactId>
+                  <groupId>jakarta.xml.bind</groupId>
+                </exclusion>
+                <exclusion>
+                  <artifactId>txw2</artifactId>
+                  <groupId>org.glassfish.jaxb</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-rest</artifactId>
+            <exclusions>
+                <exclusion>
+                  <artifactId>spring-boot-starter-web</artifactId>
+                  <groupId>org.springframework.boot</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Spring HATEOAS -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-hateoas</artifactId>
+            <exclusions>
+                <exclusion>
+                  <artifactId>spring-boot-starter-web</artifactId>
+                  <groupId>org.springframework.boot</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- util -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+            <exclusions>
+                <exclusion>
+                  <artifactId>listenablefuture</artifactId>
+                  <groupId>com.google.guava</groupId>
+                </exclusion>
+                <exclusion>
+                  <artifactId>jsr305</artifactId>
+                  <groupId>com.google.code.findbugs</groupId>
+                </exclusion>
+                <exclusion>
+                  <artifactId>error_prone_annotations</artifactId>
+                  <groupId>com.google.errorprone</groupId>
+                </exclusion>
+                <exclusion>
+                  <artifactId>j2objc-annotations</artifactId>
+                  <groupId>com.google.j2objc</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                  <artifactId>jakarta.xml.bind-api</artifactId>
+                  <groupId>jakarta.xml.bind</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                  <artifactId>commons-logging</artifactId>
+                  <groupId>commons-logging</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
             <version>${modelmapper.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>io.rest-assured</groupId>
+          <artifactId>rest-assured</artifactId>
+          <version>3.3.0</version>
+          <scope>provided</scope>
+          <exclusions>
+            <exclusion>
+              <artifactId>hamcrest-library</artifactId>
+              <groupId>org.hamcrest</groupId>
+            </exclusion>
+          </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/78527112/222440972-223b5dc0-e452-4034-ac2d-0b511cf08349.png)
![2](https://user-images.githubusercontent.com/78527112/222441128-abdad98c-c025-42b0-b262-367c40c57050.png)
![3](https://user-images.githubusercontent.com/78527112/222441159-a7293370-dfeb-4ce4-a68f-515e98b504dd.png)
![4](https://user-images.githubusercontent.com/78527112/222441190-c2f23184-84d1-4aac-8cd5-e5f50b841b3f.png)


Hi, I found that **_com.baeldung.web: spring-boot-rest: 0.0.1-SNAPSHOT_**’s pom file introduced **_145_** dependencies. However, among them, **_8_** libraries (**_6%_** have not been used by this module), the redundant dependencies are listed below.

More importantly, **_5_** redundant  libraries have not been maintained by developers for more than **_3_** years (outdated dependencies).

Reducing these unused dependencies can help prevent introducing bugs/vulnerabilities from outdated dependencies. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code.

This PR **_com.baeldung.web: spring-boot-rest: 0.0.1-SNAPSHOT_** for removing the redundant dependencies have passed the tests.


Best regards

## Redundant dependencies
#### Redundant indirect dependencies:
    jakarta.xml.bind:jakarta.xml.bind-api:2.3.3:compile [112 KB]
    org.apache.tomcat.embed:tomcat-embed-el:9.0.71:compile [250 KB]
    org.glassfish.jaxb:txw2:2.3.7:compile [70 KB]
    com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava:compile [2 KB]
    com.google.code.findbugs:jsr305:3.0.2:compile [19 KB]
    com.google.errorprone:error_prone_annotations:2.11.0:compile [15 KB]
    com.google.j2objc:j2objc-annotations:1.3:compile [8 KB]
#### Redundant indirect dependencies inherited from parent pom:
    org.hamcrest:hamcrest-library:2.2:compile [1 KB]     


## Outdated libraries among the above redundant dependencies
1. org.hamcrest:hamcrest-library:2.2 (**_1232_** days without maintenance)
2. com.google.j2objc:j2objc-annotations:1.3  (**_2233_** days without maintenance)
3. jakarta.xml.bind:jakarta.xml.bind-api:2.3.3  (**_1130_** days without maintenance)
4. com.google.code.findbugs:jsr305:3.0.2  (**_2162_** days without maintenance)
5. com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (**_1632_** days without maintenance)
---
