### PR TITLE
BAEL-5721: Configure Redis Container Using DynamicPropertySource Annotation

### DIFF
--- a/spring-boot-modules/spring-boot-testing-2/pom.xml
+++ b/spring-boot-modules/spring-boot-testing-2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-boot-testing-2</artifactId>
     <name>spring-boot-testing-2</name>
@@ -65,6 +65,18 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.redis.testcontainers</groupId>
+            <artifactId>testcontainers-redis-junit-jupiter</artifactId>
+            <version>1.4.6</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/spring-boot-modules/spring-boot-testing-2/src/test/java/com/baeldung/redistestcontainers/service/ProductServiceDynamicPropertyManualTest.java
+++ b/spring-boot-modules/spring-boot-testing-2/src/test/java/com/baeldung/redistestcontainers/service/ProductServiceDynamicPropertyManualTest.java
@@ -1,0 +1,89 @@
+package com.baeldung.redistestcontainers.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import com.baeldung.redistestcontainers.hash.Product;
+import com.redis.testcontainers.RedisContainer;
+
+@SpringBootTest
+@Testcontainers(disabledWithoutDocker = true)
+public class ProductServiceDynamicPropertyManualTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Container
+    private static final RedisContainer REDIS_CONTAINER = new RedisContainer(DockerImageName.parse("redis:5.0.3-alpine")).withExposedPorts(6379);
+
+    @DynamicPropertySource
+    private static void registerRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", REDIS_CONTAINER::getHost);
+        registry.add("spring.redis.port", () -> REDIS_CONTAINER.getMappedPort(6379)
+            .toString());
+    }
+
+    @Test
+    void givenRedisContainerConfiguredWithDynamicProperties_whenCheckingRunningStatus_thenStatusIsRunning() {
+        assertTrue(REDIS_CONTAINER.isRunning());
+    }
+
+    @Test
+    void givenProductCreated_whenGettingProductById_thenProductExistsAndHasSameProperties() {
+        Product product = new Product("1", "Test Product", 10.0);
+        productService.createProduct(product);
+        Product productFromDb = productService.getProduct("1");
+        assertEquals("1", productFromDb.getId());
+        assertEquals("Test Product", productFromDb.getName());
+        assertEquals(10.0, productFromDb.getPrice());
+    }
+
+    @Test
+    void givenProductCreatedAndUpdated_whenGettingTheProduct_thenUpdatedProductReturned() {
+        Product product = new Product("1", "Test Product", 10.0);
+        productService.createProduct(product);
+        Product productFromDb = productService.getProduct("1");
+        assertEquals("1", productFromDb.getId());
+        assertEquals("Test Product", productFromDb.getName());
+        assertEquals(10.0, productFromDb.getPrice());
+        productFromDb.setName("Updated Product");
+        productFromDb.setPrice(20.0);
+        productService.updateProduct(productFromDb);
+        Product updatedProductFromDb = productService.getProduct("1");
+        assertEquals("Updated Product", updatedProductFromDb.getName());
+        assertEquals(20.0, updatedProductFromDb.getPrice());
+    }
+
+    @Test
+    void givenProductCreatedAndDeleted_whenGettingTheProduct_thenNoProductReturned() {
+        Product product = new Product("1", "Test Product", 10.0);
+        productService.createProduct(product);
+        Product productFromDb = productService.getProduct("1");
+        assertEquals("1", productFromDb.getId());
+        assertEquals("Test Product", productFromDb.getName());
+        assertEquals(10.0, productFromDb.getPrice());
+        productService.deleteProduct("1");
+        Product deletedProductFromDb = productService.getProduct("1");
+        assertNull(deletedProductFromDb);
+    }
+
+    @Test
+    void givenProductCreated_whenGettingProductById_thenSameProductReturned() {
+        Product product = new Product("1", "Test Product", 10.0);
+        productService.createProduct(product);
+        Product productFromDb = productService.getProduct("1");
+        assertEquals("1", productFromDb.getId());
+        assertEquals("Test Product", productFromDb.getName());
+        assertEquals(10.0, productFromDb.getPrice());
+    }
+}


### PR DESCRIPTION
## Summary
- Add the [junit-jupiter](https://central.sonatype.com/artifact/org.testcontainers/junit-jupiter/1.17.6) and [testcontainers-redis-junit-jupiter](https://central.sonatype.com/artifact/com.redis.testcontainers/testcontainers-redis-junit-jupiter/1.4.6) dependencies in the project’s pom.xml
- Configure the Redis container using the `@DynamicPropertySource` annotation
- Add a test to validate that the container is running and available in the test methods
- Add the test methods from `ProductServiceManualTest` file in `ProductServiceDynamicPropertyManualTest` file

## Tests

- Tests are passing
<img width="1440" alt="Screenshot 2023-03-05 at 9 23 56 AM" src="https://user-images.githubusercontent.com/38013895/222940775-cdefcea2-35af-45b1-97f6-fb043b477940.png">


## Jira
[BAEL-5721](https://jira.baeldung.com/browse/BAEL-5721)