### PR TITLE
BAEL0-1814 - Guide to Spring 5 WebFlux - quick fix

### DIFF
--- a/spring-reactive-modules/spring-reactive/src/main/java/com/baeldung/reactive/webflux/annotation/EmployeeController.java
+++ b/spring-reactive-modules/spring-reactive/src/main/java/com/baeldung/reactive/webflux/annotation/EmployeeController.java
@@ -22,17 +22,17 @@ public class EmployeeController {
     }
 
     @GetMapping("/{id}")
-    private Mono<Employee> getEmployeeById(@PathVariable String id) {
+    public Mono<Employee> getEmployeeById(@PathVariable String id) {
         return employeeRepository.findEmployeeById(id);
     }
 
     @GetMapping
-    private Flux<Employee> getAllEmployees() {
+    public Flux<Employee> getAllEmployees() {
         return employeeRepository.findAllEmployees();
     }
 
     @PostMapping("/update")
-    private Mono<Employee> updateEmployee(@RequestBody Employee employee) {
+    public Mono<Employee> updateEmployee(@RequestBody Employee employee) {
         return employeeRepository.updateEmployee(employee);
     }
 


### PR DESCRIPTION
Changing endpoints visibility to `public`.

Based on email feedback:
```
I would like to point out a something interesting in the following article : https://www.baeldung.com/spring-webflux.

The access specifiers mentioned in the controller methods are private, by far the my understanding is the methods should be public instead unless there is a specific reason to. Though the example works well in normal use cases, there can be instances when the application can show unexpected behaviours. To be honest I have learned a lot of concepts from the website and I am sure this is profound name among Java developers, 

You comments are welcome in this regard, mentioning the sections and one of github file I've identified.

Sections :
https://www.baeldung.com/spring-webflux#1-single-resource
https://www.baeldung.com/spring-webflux#2-collection-resource
Source File :
https://github.com/eugenp/tutorials/blob/master/spring-reactive-modules/spring-reactive/src/main/java/com/baeldung/reactive/webclient/TweetsSlowServiceController.java
```
Example scenario: https://sebastian.marsching.com/blog/archives/149-Springs-RequestMapping-annotation-works-on-private-methods.html