### PR TITLE
simplify StandardCharsets use

### DIFF
--- a/core-java-modules/core-java-io-conversions-2/src/test/java/com/baeldung/inputstreamtostring/JavaInputStreamToXUnitTest.java
+++ b/core-java-modules/core-java-io-conversions-2/src/test/java/com/baeldung/inputstreamtostring/JavaInputStreamToXUnitTest.java
@@ -49,7 +49,7 @@ public class JavaInputStreamToXUnitTest {
         final InputStream inputStream = new ByteArrayInputStream(originalString.getBytes());
 
         final StringBuilder textBuilder = new StringBuilder();
-        try (Reader reader = new BufferedReader(new InputStreamReader(inputStream, Charset.forName(StandardCharsets.UTF_8.name())))) {
+        try (Reader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             int c;
             while ((c = reader.read()) != -1) {
                 textBuilder.append((char) c);
@@ -63,7 +63,7 @@ public class JavaInputStreamToXUnitTest {
         final String originalString = randomAlphabetic(DEFAULT_SIZE);
         final InputStream inputStream = new ByteArrayInputStream(originalString.getBytes());
 
-        final String text = new BufferedReader(new InputStreamReader(inputStream, Charset.forName(StandardCharsets.UTF_8.name())))
+        final String text = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
           .lines()
           .collect(Collectors.joining("\n"));
 


### PR DESCRIPTION
little point in taking the StandardCharset.UTF_8 and trying to build a new Charset instance from it