### PR TITLE
Event Sourcing - Recreate user with id from the UserCreatedEvent instead of creating a new one

### DIFF
--- a/patterns-modules/cqrs-es/src/main/java/com/baeldung/patterns/es/service/UserUtility.java
+++ b/patterns-modules/cqrs-es/src/main/java/com/baeldung/patterns/es/service/UserUtility.java
@@ -23,8 +23,7 @@ public class UserUtility {
         for (Event event : events) {
             if (event instanceof UserCreatedEvent) {
                 UserCreatedEvent e = (UserCreatedEvent) event;
-                user = new User(UUID.randomUUID()
-                    .toString(), e.getFirstName(), e.getLastName());
+                user = new User(e.getUserId(), e.getFirstName(), e.getLastName());
             }
             if (event instanceof UserAddressAddedEvent) {
                 UserAddressAddedEvent e = (UserAddressAddedEvent) event;


### PR DESCRIPTION
As the events are geting replayed, it should recreate  the user with the ID as it is provided on the UserCreatedEvent, otherwise it will generate a new ID for each read request.