### PR TITLE
PostRepository - removing redundant interface

### DIFF
--- a/spring-boot-rest/src/main/java/com/baeldung/springpagination/repository/PostRepository.java
+++ b/spring-boot-rest/src/main/java/com/baeldung/springpagination/repository/PostRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 import com.baeldung.springpagination.model.Post;
 import com.baeldung.springpagination.model.User;
 
-public interface PostRepository extends JpaRepository<Post, Long>, PagingAndSortingRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("select u from Post u where u.userName=:userName")
     Page<Post> findByUser(@Param("userName") String userName, Pageable pageReq);


### PR DESCRIPTION
`JpaRepository` already extends `PagingAndSortingRepository` and the project uses `getOne()` from `JpaRepository`.