### PR TITLE
Add discussion on shallow vs deep copy

### DIFF
--- a/core-java-modules/core-java/src/main/java/com/baeldung/copies/PersonDeep.java
+++ b/core-java-modules/core-java/src/main/java/com/baeldung/copies/PersonDeep.java
@@ -1,0 +1,28 @@
+package com.baeldung.copies;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PersonDeep {
+    private String name;
+    private List<String> hobbies;
+
+    public PersonDeep(String name, List<String> hobbies) {
+        this.name = name;
+        this.hobbies = hobbies;
+    }
+
+    // Copy constructor for deep copy
+    public PersonDeep(PersonDeep person) {
+        this.name = person.name;
+        // Creating a new ArrayList object with copied elements of the original List object
+        this.hobbies = new ArrayList<>(person.hobbies);
+    }
+
+    public String getName() {
+        return name;
+    }
+    public List<String> getHobbies() {
+        return hobbies;
+    }
+}

--- a/core-java-modules/core-java/src/main/java/com/baeldung/copies/PersonShallow.java
+++ b/core-java-modules/core-java/src/main/java/com/baeldung/copies/PersonShallow.java
@@ -1,0 +1,30 @@
+package com.baeldung.copies;
+
+import java.util.List;
+
+public class PersonShallow {
+    private String name;
+    private int age;
+    private List<String> hobbies;
+
+    public PersonShallow(String name, int age, List<String> hobbies) {
+        this.name = name;
+        this.age = age;
+        this.hobbies = hobbies;
+    }
+
+    public PersonShallow shallowCopy() { return new PersonShallow(this.name, this.age, this.hobbies); }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public List<String> getHobbies() {
+        return hobbies;
+    }
+
+}

--- a/core-java-modules/core-java/src/test/java/com/baeldung/copies/PersonDeepTest.java
+++ b/core-java-modules/core-java/src/test/java/com/baeldung/copies/PersonDeepTest.java
@@ -1,0 +1,24 @@
+package com.baeldung.copies;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PersonDeepTest {
+    @Test
+    void givenPersonWithHobbies_whenCreateDeepCopy_thenCopiedPersonHasSameNameButDifferentHobbiesList() {
+        List<String> originalHobbies = new ArrayList<>();
+        originalHobbies.add("reading");
+        originalHobbies.add("swimming");
+        PersonDeep originalPerson = new PersonDeep("John", originalHobbies);
+
+        PersonDeep copiedPerson = new PersonDeep(originalPerson);
+        copiedPerson.getHobbies().remove("reading");
+
+        assertFalse(originalPerson.getHobbies().equals(copiedPerson.getHobbies()));
+        assertTrue(originalPerson.getHobbies().contains("reading"));
+    }
+}

--- a/core-java-modules/core-java/src/test/java/com/baeldung/copies/PersonShallowTest.java
+++ b/core-java-modules/core-java/src/test/java/com/baeldung/copies/PersonShallowTest.java
@@ -1,0 +1,24 @@
+package com.baeldung.copies;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PersonShallowTest {
+    @Test
+    public void givenPersonWithHobbies_whenShallowCopyIsMade_thenBothShouldShareHobbiesListAndNewHobbyShouldBeAddedToOriginal() {
+        PersonShallow original = new PersonShallow("Alice", 30, new ArrayList<>(Arrays.asList("reading", "swimming")));
+
+        PersonShallow copy = original.shallowCopy();
+        copy.getHobbies().add("painting");
+
+         // The copy should share the same memory address for the hobbies list
+        assertSame(original.getHobbies(), copy.getHobbies());
+         // The new hobby should be added to the original object
+        assertTrue(original.getHobbies().contains("painting"));
+
+    }
+}


### PR DESCRIPTION
This commit adds a new section to the documentation discussing the difference between shallow and deep copying. It covers the concept of references in Java, and the implications of copying an object by value versus by reference. The section also includes examples of both shallow and deep copying, along with their respective advantages and disadvantages. This information will be useful for developers who need to make copies of objects in their code and want to understand the best approach to take.