### PR TITLE
BAEL-322 - quick fix - echo server loop

### DIFF
--- a/core-java-modules/core-java-nio-2/src/main/java/com/baeldung/selector/EchoServer.java
+++ b/core-java-modules/core-java-nio-2/src/main/java/com/baeldung/selector/EchoServer.java
@@ -45,8 +45,9 @@ public class EchoServer {
 
     private static void answerWithEcho(ByteBuffer buffer, SelectionKey key) throws IOException {
         SocketChannel client = (SocketChannel) key.channel();
-        client.read(buffer);
-        if (new String(buffer.array()).trim().equals(POISON_PILL)) {
+        int r = client.read(buffer);
+        if (r == -1 || new String(buffer.array()).trim()
+            .equals(POISON_PILL)) {
             client.close();
             System.out.println("Not accepting client messages anymore");
         } else {


### PR DESCRIPTION
The scenario is reproducible by running `EchoServer` and `NioEchoLiveTest`. After the test finishes, `answerWithEcho()` will be continuously called in the loop.