### PR TITLE
JAVA-16946: comment spring-jooq module from persistence-modules.

### DIFF
--- a/persistence-modules/pom.xml
+++ b/persistence-modules/pom.xml
@@ -107,7 +107,7 @@
         <!-- <module>spring-jpa</module>
         <module>spring-jpa-2</module> FAILED -->
         <module>spring-jdbc</module>
-        <module>spring-jooq</module>
+<!--        <module>spring-jooq</module>--> <!-- parent-boot-2 is its parent. -->
         <module>spring-mybatis</module>
         <module>spring-persistence-simple</module>
     </modules>


### PR DESCRIPTION
This pull request removes the spring-jooq module from persistence-modules. parent-boot-2 is the parent of the spring-jooq module, which uses the JDK 8.