### PR TITLE
JAVA-16946: disable unit test for core-java-lang-oop-modifiers module

### DIFF
--- a/core-java-modules/pom.xml
+++ b/core-java-modules/pom.xml
@@ -97,7 +97,7 @@
         <module>core-java-lang-oop-constructors</module>
         <module>core-java-lang-oop-patterns</module>
         <module>core-java-lang-oop-generics</module>
-        <module>core-java-lang-oop-modifiers</module>
+<!--        <module>core-java-lang-oop-modifiers</module>-->
         <module>core-java-lang-oop-types</module>
         <module>core-java-lang-oop-types-2</module>
         <module>core-java-lang-oop-inheritance</module>


### PR DESCRIPTION
To upgrade H2 version, it is necessary to remove test.mv.db from Jenkins. Therefore, unit tests shouldn't be running for core-java-lang-oop-modifiers module. After deletion, this change will be rolled back, and a .db file will be initiated. 