### PR TITLE
Add java interface single implementation examples

### DIFF
--- a/core-java-modules/core-java-lang-oop-patterns/src/main/java/com/baeldung/interfacesingleimpl/Animal.java
+++ b/core-java-modules/core-java-lang-oop-patterns/src/main/java/com/baeldung/interfacesingleimpl/Animal.java
@@ -1,0 +1,5 @@
+package com.baeldung.interfacesingleimpl;
+
+public interface Animal {
+    String makeSound();
+}

--- a/core-java-modules/core-java-lang-oop-patterns/src/main/java/com/baeldung/interfacesingleimpl/AnimalCare.java
+++ b/core-java-modules/core-java-lang-oop-patterns/src/main/java/com/baeldung/interfacesingleimpl/AnimalCare.java
@@ -1,0 +1,13 @@
+package com.baeldung.interfacesingleimpl;
+
+public class AnimalCare {
+    private Animal animal;
+
+    public AnimalCare(Animal animal) {
+        this.animal = animal;
+    }
+
+    public String animalSound() {
+        return animal.makeSound();
+    }
+}

--- a/core-java-modules/core-java-lang-oop-patterns/src/main/java/com/baeldung/interfacesingleimpl/Cat.java
+++ b/core-java-modules/core-java-lang-oop-patterns/src/main/java/com/baeldung/interfacesingleimpl/Cat.java
@@ -1,0 +1,21 @@
+package com.baeldung.interfacesingleimpl;
+
+public class Cat {
+    private String name;
+
+    public Cat(String name) {
+        this.name = name;
+    }
+
+    public String makeSound() {
+        return "Meow! My name is " + name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/core-java-modules/core-java-lang-oop-patterns/src/main/java/com/baeldung/interfacesingleimpl/Dog.java
+++ b/core-java-modules/core-java-lang-oop-patterns/src/main/java/com/baeldung/interfacesingleimpl/Dog.java
@@ -1,0 +1,22 @@
+package com.baeldung.interfacesingleimpl;
+
+public class Dog implements Animal {
+    private String name;
+
+    public Dog(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String makeSound() {
+        return "Woof! My name is " + name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/core-java-modules/core-java-lang-oop-patterns/src/test/java/com/baeldung/interfacesingleimpl/InterfaceSingleImplUnitTest.java
+++ b/core-java-modules/core-java-lang-oop-patterns/src/test/java/com/baeldung/interfacesingleimpl/InterfaceSingleImplUnitTest.java
@@ -1,0 +1,51 @@
+package com.baeldung.interfacesingleimpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class InterfaceSingleImplUnitTest {
+    @Test
+    public void whenUsingMockAnimal_thenAnimalSoundIsCorrect() {
+        MockAnimal mockAnimal = new MockAnimal();
+        String expected = "Mock animal sound!";
+        AnimalCare animalCare = new AnimalCare(mockAnimal);
+        assertThat(animalCare.animalSound()).isEqualTo(expected);
+    }
+
+    @Test
+    public void whenCreatingDog_thenDogMakesWoofSound() {
+        Dog dog = new Dog("Buddy");
+        String expected = "Woof! My name is Buddy";
+        assertThat(dog.makeSound()).isEqualTo(expected);
+    }
+
+    @Test
+    public void whenCreatingCat_thenCatMakesMeowSound() {
+        Cat cat = new Cat("FuzzBall");
+        String expected = "Meow! My name is FuzzBall";
+        assertThat(cat.makeSound()).isEqualTo(expected);
+    }
+
+    @Test
+    public void whenCreatingAnimalCareWithDog_thenDogMakesWoofSound() {
+        Animal dog = new Dog("Ham");
+        AnimalCare animalCare = new AnimalCare(dog);
+        String expected = "Woof! My name is Ham";
+        assertThat(animalCare.animalSound()).isEqualTo(expected);
+    }
+
+    @Test
+    public void whenCreatingCatCareWithCat_thenCatMakesMeowSound() {
+        Cat cat = new Cat("Grumpy");
+        String expected = "Meow! My name is Grumpy";
+        assertThat(cat.makeSound()).isEqualTo(expected);
+    }
+
+    @Test
+    public void whenCreatingMockAnimal_thenMockAnimalMakesMockAnimalSound() {
+        MockAnimal mockAnimal = new MockAnimal();
+        String expected = "Mock animal sound!";
+        assertThat(mockAnimal.makeSound()).isEqualTo(expected);
+    }
+}

--- a/core-java-modules/core-java-lang-oop-patterns/src/test/java/com/baeldung/interfacesingleimpl/MockAnimal.java
+++ b/core-java-modules/core-java-lang-oop-patterns/src/test/java/com/baeldung/interfacesingleimpl/MockAnimal.java
@@ -1,0 +1,8 @@
+package com.baeldung.interfacesingleimpl;
+
+public class MockAnimal implements Animal {
+    @Override
+    public String makeSound() {
+        return "Mock animal sound!";
+    }
+}


### PR DESCRIPTION
## Description
This PR's main goal is to explore whether to create an interface for a single implementing class in Java. By providing examples and unit tests, we aim to demonstrate the advantages and disadvantages of using interfaces in different scenarios.

This pull request introduces an Animal interface along with its implementing class Dog, a non-interface class Cat, and classes AnimalCare and CatCare that work with the respective Animal and Cat classes. A MockAnimal class is also provided for testing purposes.

**Key changes:**
1. Add `Animal` interface, `Dog` and `MockAnimal` classes
2. Add `Cat`, `AnimalCare`, and `CatCare` classes
3. Include unit tests with AssertJ

This example helps developers understand when to use interfaces for single implementing classes in their projects.