### PR TITLE
JAVA-20631 move Jetbrains module to *-jdk9-and-above profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,6 @@
                 <!-- <module>grails</module> --> <!-- Not a maven project -->
                 <!-- <module>guest</module> --> <!-- not to be built as its for guest articles  -->
 
-                <module>jetbrains</module>
                 <!-- <module>lagom</module> --> <!-- Not a maven project -->
                 <module>language-interop</module>
 
@@ -865,6 +864,7 @@
                 <module>javaxval</module>
                 <module>javaxval-2</module>
                 <module>javax-validation-advanced</module>
+                <module>jetbrains</module>
                 <module>jgit</module>
                 <module>jib</module>
 
@@ -1123,6 +1123,7 @@
                 <module>javaxval</module>
                 <module>javaxval-2</module>
                 <module>javax-validation-advanced</module>
+                <module>jetbrains</module>
                 <module>jgit</module>
                 <module>jib</module>
 

--- a/spring-reactive-modules/spring-reactor/pom.xml
+++ b/spring-reactive-modules/spring-reactor/pom.xml
@@ -10,10 +10,9 @@
     <url>http://maven.apache.org</url>
 
     <parent>
-        <groupId>com.baeldung</groupId>
-        <artifactId>parent-boot-2</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
-        <relativePath>../parent-boot-2</relativePath>
+        <groupId>com.baeldung.spring.reactive</groupId>
+        <artifactId>spring-reactive-modules</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/spring-reactive-modules/spring-webflux-amqp/pom.xml
+++ b/spring-reactive-modules/spring-webflux-amqp/pom.xml
@@ -11,10 +11,9 @@
     <description>Spring WebFlux AMQP Sample</description>
 
     <parent>
-        <groupId>com.baeldung</groupId>
-        <artifactId>parent-boot-2</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
-        <relativePath>../parent-boot-2</relativePath>
+        <groupId>com.baeldung.spring.reactive</groupId>
+        <artifactId>spring-reactive-modules</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencyManagement>


### PR DESCRIPTION
When I was trying to run the parent pom.xml file `mvn clean install -Pintegration-jdk9-and-above,default-jdk9-and-above
`, I realized that it was failing. It turned out two spring reactive modules had incorrect parents. Since it's small change (03a7952f93125ca9280ccf9f8106919793a80508), I fixed it in the scope of this work.