### PR TITLE
Add article comparing JPA List vs Set

### DIFF
--- a/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/onetomany/collection/CollectionContextDemoApplication.java
+++ b/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/onetomany/collection/CollectionContextDemoApplication.java
@@ -1,0 +1,11 @@
+package com.baeldung.hibernate.onetomany.collection;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages ="com.baeldung.hibernate.onetomany.collection")
+public class CollectionContextDemoApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(CollectionContextDemoApplication.class, args);
+    }
+}

--- a/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/onetomany/collection/listvsset/AddressEntity.java
+++ b/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/onetomany/collection/listvsset/AddressEntity.java
@@ -1,0 +1,52 @@
+package com.baeldung.hibernate.onetomany.collection.listvsset;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import java.util.Objects;
+
+@Entity
+public class AddressEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+    public AddressEntity() {
+    }
+
+    public AddressEntity(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AddressEntity order = (AddressEntity) o;
+        return Objects.equals(name, order.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/onetomany/collection/listvsset/CustomerEntity.java
+++ b/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/onetomany/collection/listvsset/CustomerEntity.java
@@ -1,0 +1,55 @@
+package com.baeldung.hibernate.onetomany.collection;
+
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Entity
+public class CustomerEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<OrderEntity> orderList = new ArrayList<>();
+
+    @OneToMany(cascade = CascadeType.ALL)
+    private Set<OrderEntity> orderSet = new HashSet<>();
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<OrderEntity> getOrderList() {
+        return orderList;
+    }
+
+    public void setOrderList(List<OrderEntity> orderList) {
+        this.orderList = orderList;
+    }
+
+    public Set<OrderEntity> getOrderSet() {
+        return orderSet;
+    }
+
+    public void setOrderSet(Set<OrderEntity> orderSet) {
+        this.orderSet = orderSet;
+    }
+}

--- a/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/onetomany/collection/listvsset/CustomerEntity.java
+++ b/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/onetomany/collection/listvsset/CustomerEntity.java
@@ -1,7 +1,6 @@
-package com.baeldung.hibernate.onetomany.collection;
+package com.baeldung.hibernate.onetomany.collection.listvsset;
 
 import jakarta.persistence.*;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -16,6 +15,8 @@ public class CustomerEntity {
 
     @OneToMany(cascade = CascadeType.ALL)
     private List<OrderEntity> orderList = new ArrayList<>();
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<AddressEntity> addressList = new ArrayList<>();
 
     @OneToMany(cascade = CascadeType.ALL)
     private Set<OrderEntity> orderSet = new HashSet<>();
@@ -39,6 +40,14 @@ public class CustomerEntity {
 
     public List<OrderEntity> getOrderList() {
         return orderList;
+    }
+
+    public List<AddressEntity> getAddressList() {
+        return addressList;
+    }
+
+    public void setAddressList(List<AddressEntity> addressList) {
+        this.addressList = addressList;
     }
 
     public void setOrderList(List<OrderEntity> orderList) {

--- a/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/onetomany/collection/listvsset/OrderEntity.java
+++ b/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/onetomany/collection/listvsset/OrderEntity.java
@@ -1,12 +1,21 @@
-package com.baeldung.hibernate.onetomany.collection;
+package com.baeldung.hibernate.onetomany.collection.listvsset;
 
 import jakarta.persistence.*;
+import java.util.Objects;
+
 @Entity
 public class OrderEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String item;
+
+    public OrderEntity() {
+    }
+
+    public OrderEntity(String item) {
+        this.item = item;
+    }
 
     public Long getId() {
         return id;
@@ -22,5 +31,18 @@ public class OrderEntity {
 
     public void setItem(String item) {
         this.item = item;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OrderEntity order = (OrderEntity) o;
+        return Objects.equals(item, order.item);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(item);
     }
 }

--- a/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/onetomany/collection/listvsset/OrderEntity.java
+++ b/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/onetomany/collection/listvsset/OrderEntity.java
@@ -1,0 +1,26 @@
+package com.baeldung.hibernate.onetomany.collection;
+
+import jakarta.persistence.*;
+@Entity
+public class OrderEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String item;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getItem() {
+        return item;
+    }
+
+    public void setItem(String item) {
+        this.item = item;
+    }
+}

--- a/persistence-modules/hibernate-jpa/src/test/java/com/baeldung/hibernate/onetomany/collection/listvsset/CustomerUnitTest.java
+++ b/persistence-modules/hibernate-jpa/src/test/java/com/baeldung/hibernate/onetomany/collection/listvsset/CustomerUnitTest.java
@@ -1,0 +1,38 @@
+package com.baeldung.hibernate.onetomany.collection;
+
+import java.util.*;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CustomerUnitTest {
+    @Test
+    public void givenCustomers_whenAddedOrders_thenCheckBehavior() {
+        OrderEntity order1 = new OrderEntity();
+        order1.setItem("item1");
+
+        OrderEntity order2 = new OrderEntity();
+        order2.setItem("item2");
+
+        OrderEntity order3 = new OrderEntity();
+        order3.setItem("item1"); // duplicate item
+
+        List<OrderEntity> orderList = Arrays.asList(order1, order2, order3);
+        Set<OrderEntity> orderSet = new HashSet<>(orderList);
+
+        CustomerEntity customerList = new CustomerEntity();
+        customerList.setOrderList(orderList);
+
+        CustomerEntity customerSet = new CustomerEntity();
+        customerSet.setOrderSet(orderSet);
+
+        assertAll("Customer with List vs Set",
+                () -> assertEquals(3, customerList.getOrderList().size(), "List allows duplicates and thus, size is 3"),
+                () -> assertEquals(2, customerSet.getOrderSet().size(), "Set doesn't allow duplicates and thus, size is 2"),
+                () -> assertTrue(customerList.getOrderList().contains(order3), "List maintains duplicates"),
+                () -> assertFalse(customerSet.getOrderSet().contains(order3), "Set removes duplicates"),
+                () -> assertNotEquals(customerList.getOrderList(), customerSet.getOrderSet(), "List and Set are not equal due to different rules on duplicates and order")
+        );
+    }
+}


### PR DESCRIPTION
This commit introduces an article discussing the differences between java.util.List and java.util.Set in the context of OneToMany relationships in the Java Persistence API (JPA). It covers the characteristics, benefits, and drawbacks of each type and provides practical code examples to highlight these differences. The code examples include a JPA entity model (CustomerEntity and OrderEntity) and JUnit5 tests illustrating how List and Set behave in one-to-many relationships. The article also provides guidelines to help developers decide when to use List or Set based on factors like ordering, duplicates, querying, and implementation complexity.