### PR TITLE
JAVA-20405 Remove 'modules' from spring-thymeleaf-attributes

### DIFF
--- a/spring-web-modules/spring-thymeleaf-attributes/accessing-session-attributes/pom.xml
+++ b/spring-web-modules/spring-thymeleaf-attributes/accessing-session-attributes/pom.xml
@@ -12,7 +12,7 @@
 
   <parent>
     <groupId>com.baeldung.spring-thymeleaf-attributes</groupId>
-    <artifactId>spring-thymeleaf-attributes-modules</artifactId>
+    <artifactId>spring-thymeleaf-attributes</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/spring-web-modules/spring-thymeleaf-attributes/pom.xml
+++ b/spring-web-modules/spring-thymeleaf-attributes/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.baeldung.spring-thymeleaf-attributes</groupId>
-    <artifactId>spring-thymeleaf-attributes-modules</artifactId>
+    <artifactId>spring-thymeleaf-attributes</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Remove 'modules' from spring-thymeleaf-attributes article in the context of aligning modules name.