### PR TITLE
JAVA-22499 | Using Hibernate Validator 8.0.0.Final

### DIFF
--- a/javaxval-2/pom.xml
+++ b/javaxval-2/pom.xml
@@ -15,26 +15,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate-validator.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
-            <version>${javax.el.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>${org.springframework.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>${org.springframework.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
             <version>${spring.boot.version}</version>
@@ -58,11 +38,7 @@
     <!--</plugin> </plugins> </build> -->
 
     <properties>
-        <hibernate-validator.version>6.2.3.Final</hibernate-validator.version>
-        <hibernate-validator.ap.version>6.2.0.Final</hibernate-validator.ap.version>
-        <javax.el.version>3.0.0</javax.el.version>
-        <org.springframework.version>5.3.21</org.springframework.version>
-        <spring.boot.version>2.7.1</spring.boot.version>
+        <spring.boot.version>3.0.4</spring.boot.version>
     </properties>
 
 </project>

--- a/javaxval-2/src/main/java/com/baeldung/javaxval/hibernate/validator/ap/Message.java
+++ b/javaxval-2/src/main/java/com/baeldung/javaxval/hibernate/validator/ap/Message.java
@@ -1,11 +1,13 @@
 package com.baeldung.javaxval.hibernate.validator.ap;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+
 import java.util.List;
 import java.util.Optional;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Past;
+
 
 public class Message {
 

--- a/javaxval-2/src/main/java/com/baeldung/javaxval/messageinterpolator/Person.java
+++ b/javaxval-2/src/main/java/com/baeldung/javaxval/messageinterpolator/Person.java
@@ -1,8 +1,8 @@
 package com.baeldung.javaxval.messageinterpolator;
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 
 public class Person {
 

--- a/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/constraints/ConsistentDateParameterValidator.java
+++ b/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/constraints/ConsistentDateParameterValidator.java
@@ -2,10 +2,10 @@ package com.baeldung.javaxval.methodvalidation.constraints;
 
 import java.time.LocalDate;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.constraintvalidation.SupportedValidationTarget;
-import javax.validation.constraintvalidation.ValidationTarget;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.constraintvalidation.SupportedValidationTarget;
+import jakarta.validation.constraintvalidation.ValidationTarget;
 
 @SupportedValidationTarget(ValidationTarget.PARAMETERS)
 public class ConsistentDateParameterValidator implements ConstraintValidator<ConsistentDateParameters, Object[]> {

--- a/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/constraints/ConsistentDateParameters.java
+++ b/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/constraints/ConsistentDateParameters.java
@@ -8,8 +8,8 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 @Constraint(validatedBy = ConsistentDateParameterValidator.class)
 @Target({ METHOD, CONSTRUCTOR })

--- a/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/constraints/ValidReservation.java
+++ b/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/constraints/ValidReservation.java
@@ -8,8 +8,8 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 @Constraint(validatedBy = ValidReservationValidator.class)
 @Target({ METHOD, CONSTRUCTOR })

--- a/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/constraints/ValidReservationValidator.java
+++ b/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/constraints/ValidReservationValidator.java
@@ -2,8 +2,8 @@ package com.baeldung.javaxval.methodvalidation.constraints;
 
 import java.time.LocalDate;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 import com.baeldung.javaxval.methodvalidation.model.Reservation;
 

--- a/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/model/Customer.java
+++ b/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/model/Customer.java
@@ -1,7 +1,7 @@
 package com.baeldung.javaxval.methodvalidation.model;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import org.springframework.validation.annotation.Validated;
 

--- a/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/model/Reservation.java
+++ b/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/model/Reservation.java
@@ -2,8 +2,8 @@ package com.baeldung.javaxval.methodvalidation.model;
 
 import java.time.LocalDate;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Positive;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 
 import org.springframework.validation.annotation.Validated;
 

--- a/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/model/ReservationManagement.java
+++ b/javaxval-2/src/main/java/com/baeldung/javaxval/methodvalidation/model/ReservationManagement.java
@@ -3,11 +3,11 @@ package com.baeldung.javaxval.methodvalidation.model;
 import java.time.LocalDate;
 import java.util.List;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Future;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;

--- a/javaxval-2/src/main/java/com/baeldung/javaxval/notnull/NotNullMethodParameter.java
+++ b/javaxval-2/src/main/java/com/baeldung/javaxval/notnull/NotNullMethodParameter.java
@@ -1,9 +1,9 @@
 package com.baeldung.javaxval.notnull;
 
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotNull;
 
 public class NotNullMethodParameter {
 

--- a/javaxval-2/src/main/java/com/baeldung/javaxval/notnull/ValidatingComponent.java
+++ b/javaxval-2/src/main/java/com/baeldung/javaxval/notnull/ValidatingComponent.java
@@ -1,6 +1,6 @@
 package com.baeldung.javaxval.notnull;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;

--- a/javaxval-2/src/test/java/com/baeldung/javaxval/messageinterpolator/ParameterMessageInterpolaterIntegrationTest.java
+++ b/javaxval-2/src/test/java/com/baeldung/javaxval/messageinterpolator/ParameterMessageInterpolaterIntegrationTest.java
@@ -4,10 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.junit.BeforeClass;

--- a/javaxval-2/src/test/java/com/baeldung/javaxval/methodvalidation/ContainerValidationIntegrationTest.java
+++ b/javaxval-2/src/test/java/com/baeldung/javaxval/methodvalidation/ContainerValidationIntegrationTest.java
@@ -3,7 +3,7 @@ package com.baeldung.javaxval.methodvalidation;
 import java.time.LocalDate;
 import java.util.List;
 
-import javax.validation.ConstraintViolationException;
+import jakarta.validation.ConstraintViolationException;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/javaxval-2/src/test/java/com/baeldung/javaxval/methodvalidation/ValidationIntegrationTest.java
+++ b/javaxval-2/src/test/java/com/baeldung/javaxval/methodvalidation/ValidationIntegrationTest.java
@@ -8,10 +8,10 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.ValidatorFactory;
-import javax.validation.executable.ExecutableValidator;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.executable.ExecutableValidator;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/javaxval-2/src/test/java/com/baeldung/javaxval/notnull/ValidatingComponentIntegrationTest.java
+++ b/javaxval-2/src/test/java/com/baeldung/javaxval/notnull/ValidatingComponentIntegrationTest.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.constraints.NotNull;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
Upgraded spring-boot and removed hybernate-validator explicit dependency to use 8.0.0.Final version of the spring-boot 3 transitive dependency. Changed javax with jakarta.