### PR TITLE
This PR for the article BAEL-6748

### DIFF
--- a/core-java-modules/core-java-collections-maps-6/src/test/java/com/baeldung/map/mapclear/MapClearVsNewMapTest.java
+++ b/core-java-modules/core-java-collections-maps-6/src/test/java/com/baeldung/map/mapclear/MapClearVsNewMapTest.java
@@ -1,0 +1,41 @@
+package com.baeldung.map.mapclear;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MapClearVsNewMapTest {
+
+    @Test
+    public void given_EmptyMap_whenUsingMapClear_thenMapIsEmpty() {
+        Map<String, Integer> map = new HashMap<>();
+        map.put("A", 1);
+        map.put("B", 2);
+        map.put("C", 3);
+        map.clear();
+        Assertions.assertTrue(map.isEmpty());
+    }
+
+    @Test
+    public void given_NonEmptyMap_whenCreatingNewMapInstance_thenMapIsEmpty() {
+        Map<String, Integer> map = new HashMap<>();
+        map.put("A", 1);
+        map.put("B", 2);
+        map.put("C", 3);
+        map = new HashMap<>();
+        Assertions.assertTrue(map.isEmpty());
+    }
+
+    @Test
+    public void given_OriginalMap_whenUsingMapClear_thenOtherReferencesStillPointToClearedMap() {
+        Map<String, Integer> map = new HashMap<>();
+        map.put("A", 1);
+        map.put("B", 2);
+        map.put("C", 3);
+        Map<String, Integer> originalMap = map;
+        map.clear();
+        Assertions.assertTrue(originalMap.isEmpty());
+    }
+}


### PR DESCRIPTION
This PR aims to add a test class called MapClearVsNewMapTest to show the differences between Map.clear() and the new Map instance.