### PR TITLE
BAEL-6481 - Remove `isInterrupted()` check

### DIFF
--- a/core-java-modules/core-java-lang-6/src/main/java/com/baeldung/stopexecution/InterruptThread.java
+++ b/core-java-modules/core-java-lang-6/src/main/java/com/baeldung/stopexecution/InterruptThread.java
@@ -4,9 +4,7 @@ public class InterruptThread extends Thread {
     @Override
     public void run() {
         while (!isInterrupted()) {
-            if (isInterrupted()) {
-                break;
-            }
+            break;
             // business logic
         }
     }


### PR DESCRIPTION
Based on a comment:

Section 6 should be headlined with “Using System.exit()” since that’s what stops code execution, not the boolean variable (this is just a means to decide that execution should be stopped, like the negative array element in section 4.

Also it’s unclear why we’d need the “if (isInterrupted())” statement in the while loop of the 8th section: how should isInterrupted() be true one line after we’ve checked in the while loop header that it’s false? Admittedly there’s a little chance that the interrupt status changed between these 2 lines, but this if statement would make much more sense somewhere in the business logic code where more time has passed since the evaluation of “while (!isInterrupted())”… and if that business code doesn’t have that complexity/length, one should omit this if statement altogether, since it creates more confusion than it helps for timely reaction on an interruption.