### PR TITLE
BAEL-7022 Why wait must be called in a synchronized block - quick fix

### DIFF
--- a/core-java-modules/core-java-concurrency-advanced-5/src/main/java/com/baeldung/wait_synchronization/ConditionChecker.java
+++ b/core-java-modules/core-java-concurrency-advanced-5/src/main/java/com/baeldung/wait_synchronization/ConditionChecker.java
@@ -2,7 +2,7 @@ package com.baeldung.wait_synchronization;
 
 public class ConditionChecker {
 
-    private volatile Boolean jobIsDone;
+    private volatile boolean jobIsDone;
     private final Object lock = new Object();
 
     public void ensureCondition() {


### PR DESCRIPTION
Changing `Boolean` to primitive.

Based on a comment.