### PR TITLE
Java 29177 : Update Spring-AOP from Boot 2 to Boot 3

### DIFF
--- a/spring-aop/pom.xml
+++ b/spring-aop/pom.xml
@@ -9,9 +9,9 @@
 
     <parent>
         <groupId>com.baeldung</groupId>
-        <artifactId>parent-boot-2</artifactId>
+        <artifactId>parent-boot-3</artifactId>
         <version>0.0.1-SNAPSHOT</version>
-        <relativePath>../parent-boot-2</relativePath>
+        <relativePath>../parent-boot-3</relativePath>
     </parent>
 
     <dependencies>
@@ -26,6 +26,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-aop/src/main/java/com/baeldung/pointcutadvice/PerformanceAspect.java
+++ b/spring-aop/src/main/java/com/baeldung/pointcutadvice/PerformanceAspect.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
 @Component
 public class PerformanceAspect {
 
-    private static Logger logger = Logger.getLogger(PerformanceAspect.class.getName());
+    private static final Logger logger = Logger.getLogger(PerformanceAspect.class.getName());
 
     @Pointcut("within(com.baeldung..*) && execution(* com.baeldung.pointcutadvice.dao.FooDao.*(..))")
     public void repositoryClassMethods() {

--- a/spring-aop/src/test/java/com/baeldung/joinpoint/JoinPointAfterThrowingAspectIntegrationTest.java
+++ b/spring-aop/src/test/java/com/baeldung/joinpoint/JoinPointAfterThrowingAspectIntegrationTest.java
@@ -15,8 +15,8 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest

--- a/spring-aop/src/test/java/com/baeldung/joinpoint/JoinPointAroundExceptionAspectIntegrationTest.java
+++ b/spring-aop/src/test/java/com/baeldung/joinpoint/JoinPointAroundExceptionAspectIntegrationTest.java
@@ -15,8 +15,8 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest

--- a/spring-aop/src/test/java/com/baeldung/joinpoint/JoinPointBeforeAspectIntegrationTest.java
+++ b/spring-aop/src/test/java/com/baeldung/joinpoint/JoinPointBeforeAspectIntegrationTest.java
@@ -15,8 +15,8 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest

--- a/spring-aop/src/test/java/com/baeldung/pointcutadvice/AopLoggingIntegrationTest.java
+++ b/spring-aop/src/test/java/com/baeldung/pointcutadvice/AopLoggingIntegrationTest.java
@@ -69,7 +69,7 @@ public class AopLoggingIntegrationTest {
     @Test
     public void givenLoggingAspect_whenCallLoggableAnnotatedMethod_thenMethodIsLogged() {
         dao.create(42L, "baz");
-        assertThat(messages,  hasItem("Executing method: create"));
+        assertThat(messages, hasItem("Executing method: create"));
     }
 
     @Test

--- a/spring-aop/src/test/java/com/baeldung/pointcutadvice/AopLoggingIntegrationTest.java
+++ b/spring-aop/src/test/java/com/baeldung/pointcutadvice/AopLoggingIntegrationTest.java
@@ -17,10 +17,10 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.core. IsIterableContaining.hasItem;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {Application.class}, loader = AnnotationConfigContextLoader.class)
@@ -69,7 +69,7 @@ public class AopLoggingIntegrationTest {
     @Test
     public void givenLoggingAspect_whenCallLoggableAnnotatedMethod_thenMethodIsLogged() {
         dao.create(42L, "baz");
-        assertThat(messages, hasItem("Executing method: create"));
+        assertThat(messages,  hasItem("Executing method: create"));
     }
 
     @Test

--- a/spring-aop/src/test/java/com/baeldung/pointcutadvice/AopPerformanceIntegrationTest.java
+++ b/spring-aop/src/test/java/com/baeldung/pointcutadvice/AopPerformanceIntegrationTest.java
@@ -18,9 +18,9 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {Application.class}, loader = AnnotationConfigContextLoader.class)

--- a/spring-aop/src/test/java/com/baeldung/pointcutadvice/AopXmlConfigPerformanceIntegrationTest.java
+++ b/spring-aop/src/test/java/com/baeldung/pointcutadvice/AopXmlConfigPerformanceIntegrationTest.java
@@ -17,8 +17,8 @@ import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/pointcutadvice/beans.xml")


### PR DESCRIPTION
Added Commons-lang in pom and updated JUnits to use non deprecated methods.