### PR TITLE
JAVA-31110 : Upgrade to latest Hibernate version

### DIFF
--- a/persistence-modules/spring-boot-persistence-3/pom.xml
+++ b/persistence-modules/spring-boot-persistence-3/pom.xml
@@ -61,9 +61,10 @@
 
 
     <properties>
-        <spring.boot.dependencies>3.2.0</spring.boot.dependencies>
+        <spring.boot.dependencies>3.2.2</spring.boot.dependencies>
         <org.slf4j.version>2.0.9</org.slf4j.version>
         <logback.version>1.4.14</logback.version>
+        <hibernate-core.version>6.4.2.Final</hibernate-core.version>
     </properties>
 
 </project>

--- a/persistence-modules/spring-boot-persistence-4/pom.xml
+++ b/persistence-modules/spring-boot-persistence-4/pom.xml
@@ -69,7 +69,7 @@
     </build>
 
     <properties>
-        <spring.boot.dependencies>3.1.0</spring.boot.dependencies>
+        <spring.boot.dependencies>3.2.2</spring.boot.dependencies>
         <junit-jupiter.version>5.9.3</junit-jupiter.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/persistence-modules/spring-hibernate-6/pom.xml
+++ b/persistence-modules/spring-hibernate-6/pom.xml
@@ -101,7 +101,7 @@
         <org.springframework.data.version>3.1.3</org.springframework.data.version>
         <org.springframework.security.version>6.1.3</org.springframework.security.version>
         <!-- persistence -->
-        <hibernate.version>6.2.8.Final</hibernate.version>
+        <hibernate.version>6.4.2.Final</hibernate.version>
         <mysql-connector-java.version>8.2.0</mysql-connector-java.version>
         <tomcat-dbcp.version>9.0.80</tomcat-dbcp.version>
     </properties>


### PR DESCRIPTION
Upgraded to latest hibernate for spring-hibernate-6.

Upgarded the following to transitively bring in the latest dependencies :- 

        spring-boot-persistence-3/pom.xml
        modified:   spring-boot-persistence-4/pom.xml

Didn't upgrade :- 

tutorials\persistence-modules\spring-hibernate-5\
tutorials\persistence-modules\spring-hibernate-3\

As both of them have articles dealing with specific hibernate versions (The articles deals with features in 5 and 3 respectively)
and hence it will be wrong to upgrade them to the latest versions.

