### PR TITLE
JAVA-31644 Update maven-compiler-plugin to 3.12.1

### DIFF
--- a/core-groovy-modules/core-groovy-2/pom.xml
+++ b/core-groovy-modules/core-groovy-2/pom.xml
@@ -157,7 +157,7 @@
     <properties>
         <groovy-wslite.version>1.1.3</groovy-wslite.version>
         <assembly.plugin.version>3.4.2</assembly.plugin.version>
-        <compiler.plugin.version>3.8.1</compiler.plugin.version>
+        <compiler.plugin.version>3.12.1</compiler.plugin.version>
         <groovy.compiler.version>3.9.0</groovy.compiler.version>
         <groovy-eclipse-batch.version>3.0.9-03</groovy-eclipse-batch.version>
     </properties>

--- a/core-java-modules/core-java-jpms/service-loader-api-pattern/pom.xml
+++ b/core-java-modules/core-java-jpms/service-loader-api-pattern/pom.xml
@@ -37,7 +37,7 @@
     </build>
 
     <properties>
-        <compiler.plugin.version>3.8.0</compiler.plugin.version>
+        <compiler.plugin.version>3.12.1</compiler.plugin.version>
         <source.version>11</source.version>
         <target.version>11</target.version>
     </properties>

--- a/core-java-modules/core-java-jpms/service-provider-factory-pattern/pom.xml
+++ b/core-java-modules/core-java-jpms/service-provider-factory-pattern/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <compiler.plugin.version>3.8.0</compiler.plugin.version>
+        <compiler.plugin.version>3.12.1</compiler.plugin.version>
         <source.version>11</source.version>
         <target.version>11</target.version>
     </properties>

--- a/ethereum/pom.xml
+++ b/ethereum/pom.xml
@@ -183,7 +183,7 @@
         <spring.boot.version>1.5.6.RELEASE</spring.boot.version>
         <jsonpath.version>2.8.0</jsonpath.version>
         <spring-boot-maven-plugin.version>2.0.4.RELEASE</spring-boot-maven-plugin.version>
-        <compiler.plugin.version>3.1</compiler.plugin.version>
+        <compiler.plugin.version>3.12.1</compiler.plugin.version>
     </properties>
 
 </project>

--- a/image-compressing/pom.xml
+++ b/image-compressing/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.12.1</version>
             </plugin>
         </plugins>
     </build>

--- a/java-panama/pom.xml
+++ b/java-panama/pom.xml
@@ -41,7 +41,7 @@
         <project.version>1.0</project.version>
         <maven.compiler.source>19</maven.compiler.source>
         <maven.compiler.target>19</maven.compiler.target>
-        <maven.compiler.version>3.10.1</maven.compiler.version>
+        <maven.compiler.version>3.12.1</maven.compiler.version>
         <junit.jupiter.version>5.9.0</junit.jupiter.version>
     </properties>
 

--- a/jhipster-modules/jhipster-uaa/gateway/pom.xml
+++ b/jhipster-modules/jhipster-uaa/gateway/pom.xml
@@ -1052,7 +1052,7 @@
 
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>

--- a/jhipster-modules/jhipster-uaa/quotes/pom.xml
+++ b/jhipster-modules/jhipster-uaa/quotes/pom.xml
@@ -872,7 +872,7 @@
 
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>

--- a/jhipster-modules/jhipster-uaa/uaa/pom.xml
+++ b/jhipster-modules/jhipster-uaa/uaa/pom.xml
@@ -873,7 +873,7 @@
 
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>

--- a/kubernetes-modules/k8s-intro/pom.xml
+++ b/kubernetes-modules/k8s-intro/pom.xml
@@ -24,7 +24,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.12.1</version>
                 <configuration>
                     <!-- http://maven.apache.org/plugins/maven-compiler-plugin/ -->
                     <source>1.8</source>

--- a/kubernetes-modules/k8s-java-heap-dump/pom.xml
+++ b/kubernetes-modules/k8s-java-heap-dump/pom.xml
@@ -16,7 +16,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.12.1</version>
                 <configuration>
                     <!-- http://maven.apache.org/plugins/maven-compiler-plugin/ -->
                     <source>1.8</source>

--- a/maven-modules/compiler-plugin-java-9/pom.xml
+++ b/maven-modules/compiler-plugin-java-9/pom.xml
@@ -22,7 +22,7 @@
     </build>
 
     <properties>
-        <compiler.plugin.version>3.11.0</compiler.plugin.version>
+        <compiler.plugin.version>3.12.1</compiler.plugin.version>
         <source.version>9</source.version>
         <target.version>9</target.version>
     </properties>

--- a/maven-modules/multimodulemavenproject/pom.xml
+++ b/maven-modules/multimodulemavenproject/pom.xml
@@ -40,7 +40,7 @@
     </build>
 
     <properties>
-        <compiler.plugin.version>3.8.0</compiler.plugin.version>
+        <compiler.plugin.version>3.12.1</compiler.plugin.version>
         <source.version>1.9</source.version>
         <target.version>1.9</target.version>
     </properties>

--- a/microservices-modules/micronaut/pom.xml
+++ b/microservices-modules/micronaut/pom.xml
@@ -152,7 +152,7 @@
         <jdk.version>17</jdk.version>
         <release.version>17</release.version>
         <packaging>jar</packaging>
-        <compiler.plugin.version>3.7.0</compiler.plugin.version>
+        <compiler.plugin.version>3.12.1</compiler.plugin.version>
         <micronaut.runtime>netty</micronaut.runtime>
         <shade.plugin.version>3.2.0</shade.plugin.version>
     </properties>

--- a/patterns-modules/ddd-contexts/pom.xml
+++ b/patterns-modules/ddd-contexts/pom.xml
@@ -68,7 +68,7 @@
     <properties>
         <source.version>9</source.version>
         <target.version>9</target.version>
-        <compiler.plugin.version>3.8.1</compiler.plugin.version>
+        <compiler.plugin.version>3.12.1</compiler.plugin.version>
         <appmodules.version>1.0</appmodules.version>
     </properties>
 

--- a/performance-tests/pom.xml
+++ b/performance-tests/pom.xml
@@ -160,7 +160,7 @@
         <uberjar.name>benchmarks</uberjar.name>
         <clean.plugin.version>3.1.0</clean.plugin.version>
         <deploy.plugin.version>3.0.0-M1</deploy.plugin.version>
-        <compiler.plugin.version>3.8.1</compiler.plugin.version>
+        <compiler.plugin.version>3.12.1</compiler.plugin.version>
         <shade.plugin.version>3.2.4</shade.plugin.version>
         <install.version>3.0.0-M1</install.version>
         <jar.plugin.version>3.2.0</jar.plugin.version>

--- a/persistence-modules/jnosql/jnosql-artemis/pom.xml
+++ b/persistence-modules/jnosql/jnosql-artemis/pom.xml
@@ -92,7 +92,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <javaee-web-api.version>8.0.1</javaee-web-api.version>
         <maven.war-plugin.version>3.3.1</maven.war-plugin.version>
-        <maven.compiler-plugin.version>3.8.1</maven.compiler-plugin.version>
+        <maven.compiler-plugin.version>3.12.1</maven.compiler-plugin.version>
     </properties>
 
 </project>

--- a/persistence-modules/sirix/pom.xml
+++ b/persistence-modules/sirix/pom.xml
@@ -48,7 +48,7 @@
     <properties>
         <maven.release.version>11</maven.release.version>
         <sirix-core.version>0.9.3</sirix-core.version>
-        <compiler.plugin.version>3.8.0</compiler.plugin.version>
+        <compiler.plugin.version>3.12.1</compiler.plugin.version>
         <asm.version>6.1</asm.version>
     </properties>
 

--- a/persistence-modules/spring-data-cassandra-2/pom.xml
+++ b/persistence-modules/spring-data-cassandra-2/pom.xml
@@ -84,7 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.12.1</version>
                 <configuration>
                     <annotationProcessorPaths>
                         <path>

--- a/quarkus-modules/quarkus-funqy/pom.xml
+++ b/quarkus-modules/quarkus-funqy/pom.xml
@@ -128,7 +128,7 @@
     </profiles>
 
     <properties>
-        <compiler-plugin.version>3.10.1</compiler-plugin.version>
+        <compiler-plugin.version>3.12.1</compiler-plugin.version>
         <failsafe.useModulePath>false</failsafe.useModulePath>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/quarkus-modules/quarkus-virtual-threads/pom.xml
+++ b/quarkus-modules/quarkus-virtual-threads/pom.xml
@@ -27,7 +27,7 @@
     </dependencyManagement>
 
     <properties>
-        <compiler-plugin.version>3.11.0</compiler-plugin.version>
+        <compiler-plugin.version>3.12.1</compiler-plugin.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/quarkus-modules/quarkus-vs-springboot/quarkus-project/pom.xml
+++ b/quarkus-modules/quarkus-vs-springboot/quarkus-project/pom.xml
@@ -136,7 +136,7 @@
     </profiles>
 
     <properties>
-        <compiler-plugin.version>3.10.1</compiler-plugin.version>
+        <compiler-plugin.version>3.12.1</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/spring-roo/pom.xml
+++ b/spring-roo/pom.xml
@@ -440,7 +440,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.12.1</version>
                     <configuration>
                         <source>${java.version}</source>
                         <target>${java.version}</target>

--- a/spring-swagger-codegen/spring-openapi-generator-api-client/pom.xml
+++ b/spring-swagger-codegen/spring-openapi-generator-api-client/pom.xml
@@ -275,7 +275,7 @@
         <maven-surefire-plugin.version>2.12</maven-surefire-plugin.version>
         <maven-jar-plugin.version>2.2</maven-jar-plugin.version>
         <build-helper-maven-plugin.version>1.10</build-helper-maven-plugin.version>
-        <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
         <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
         <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>

--- a/testing-modules/testng-command-line/pom.xml
+++ b/testing-modules/testng-command-line/pom.xml
@@ -109,7 +109,7 @@
         <com.beust.jcommander.version>1.81</com.beust.jcommander.version>
         <org.webjars.jquery.version>3.5.1</org.webjars.jquery.version>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
-        <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.12.1</maven.compiler.plugin.version>
         <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>
     </properties>
 

--- a/web-modules/jooby/pom.xml
+++ b/web-modules/jooby/pom.xml
@@ -76,7 +76,7 @@
         <rest-assured.version>3.1.1</rest-assured.version>
         <application.class>com.baeldung.jooby.App</application.class>
         <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-        <maven-compiler.version>3.8.1</maven-compiler.version>
+        <maven-compiler.version>3.12.1</maven-compiler.version>
         <squareup.okhttp.version>4.12.0</squareup.okhttp.version>
     </properties>
 

--- a/web-modules/ninja/pom.xml
+++ b/web-modules/ninja/pom.xml
@@ -214,7 +214,7 @@
         <jetty.version>9.4.18.v20190429</jetty.version>
         <bootstrap.version>3.3.4</bootstrap.version>
         <jquery.version>2.1.3</jquery.version>
-        <compiler.plugin.version>3.2</compiler.plugin.version>
+        <compiler.plugin.version>3.12.1</compiler.plugin.version>
         <source.version>17</source.version>
         <target.version>17</target.version>
         <enforcer.plugin.version>1.3.1</enforcer.plugin.version>


### PR DESCRIPTION
Updates maven-compiler-plugin version for all modules specifying a version earlier than the latest (3.12.1 at time of PR).

