### PR TITLE
JAVA-28947 Update Spring Activiti module to Spring Boot 3

### DIFF
--- a/spring-activiti/pom.xml
+++ b/spring-activiti/pom.xml
@@ -67,7 +67,7 @@
     </build>
 
     <properties>
-        <activiti.version>8.2.0</activiti.version>
+        <activiti.version>8.0.0</activiti.version>
     </properties>
 
 </project>

--- a/spring-activiti/pom.xml
+++ b/spring-activiti/pom.xml
@@ -10,10 +10,18 @@
 
     <parent>
         <groupId>com.baeldung</groupId>
-        <artifactId>parent-boot-2</artifactId>
+        <artifactId>parent-boot-3</artifactId>
         <version>0.0.1-SNAPSHOT</version>
-        <relativePath>../parent-boot-2</relativePath>
+        <relativePath>../parent-boot-3</relativePath>
     </parent>
+
+    <repositories>
+        <repository>
+            <id>alfresco</id>
+            <name>alfresco</name>
+            <url>https://artifacts.alfresco.com/nexus/content/repositories/public/</url>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>
@@ -59,7 +67,7 @@
     </build>
 
     <properties>
-        <activiti.version>7.1.0.M6</activiti.version>
+        <activiti.version>8.2.0</activiti.version>
     </properties>
 
 </project>

--- a/spring-activiti/src/main/java/com/baeldung/activiti/security/config/MvcConfig.java
+++ b/spring-activiti/src/main/java/com/baeldung/activiti/security/config/MvcConfig.java
@@ -3,11 +3,11 @@ package com.baeldung.activiti.security.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @EnableWebMvc
-public class MvcConfig extends WebMvcConfigurerAdapter {
+public class MvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {

--- a/spring-activiti/src/main/java/com/baeldung/activiti/security/withspring/SecurityConfig.java
+++ b/spring-activiti/src/main/java/com/baeldung/activiti/security/withspring/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.baeldung.activiti.security.withspring;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -14,28 +15,25 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.antMatcher("/**")
-            .authorizeRequests()
-            .antMatchers("/protected-process*")
-            .authenticated()
-            .anyRequest()
-            .permitAll()
-            .and()
-            .formLogin()
-            .loginPage("/login")
-            .defaultSuccessUrl("/homepage")
-            .failureUrl("/login?error=true")
-            .and()
-            .csrf()
-            .disable()
-            .logout()
-            .logoutSuccessUrl("/login");
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers("/protected-process*")
+                .authenticated()
+                .anyRequest()
+                .permitAll())
+            .formLogin(login -> login
+                .loginPage("/login")
+                .defaultSuccessUrl("/homepage")
+                .failureUrl("/login?error=true")
+                .permitAll())
+            .csrf(AbstractHttpConfigurer::disable)
+            .logout(logout -> logout.logoutSuccessUrl("/login"));
         return http.build();
     }
 
     @Bean
     public UserDetailsService userDetailsService() {
-        UserDetails user = User.withUsername("user")
+        User.UserBuilder users = User.withDefaultPasswordEncoder();
+        UserDetails user = users.username("user")
             .password("{noop}pass")
             .authorities("ROLE_ACTIVITI_USER")
             .build();

--- a/spring-activiti/src/main/resources/templates/homepage.html
+++ b/spring-activiti/src/main/resources/templates/homepage.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+<h1>Home page</h1>
+</body>
+</html>


### PR DESCRIPTION
Upgrades the module to Spring Boot 3 including updating now deprecated Spring Security code.
Also adds homepage.html so that the example security application takes you somewhere after logging in to improve the example.

Uses Activiti 8.0.0 as later versions seem incompatible with Java 17.