### PR TITLE
JAVA-31765: Upgrade gitflow-incremental-builder to version 4.5.3

### DIFF
--- a/gradle-modules/gradle-5/cmd-line-args/src/main/java/com/baeldung/cmd/MainClass.java
+++ b/gradle-modules/gradle-5/cmd-line-args/src/main/java/com/baeldung/cmd/MainClass.java
@@ -1,6 +1,7 @@
 package com.baeldung.cmd;
 
 public class MainClass {
+
     public static void main(String[] args) {
         System.out.println("Gradle command line arguments example");
         for (String arg : args) {

--- a/gradle-modules/gradle-5/cmd-line-args/src/main/java/com/baeldung/cmd/MainClass.java
+++ b/gradle-modules/gradle-5/cmd-line-args/src/main/java/com/baeldung/cmd/MainClass.java
@@ -1,7 +1,6 @@
 package com.baeldung.cmd;
 
 public class MainClass {
-
     public static void main(String[] args) {
         System.out.println("Gradle command line arguments example");
         for (String arg : args) {

--- a/pom.xml
+++ b/pom.xml
@@ -1142,6 +1142,7 @@
         <gib.failOnMissingGitDir>false</gib.failOnMissingGitDir>
         <gib.failOnError>false</gib.failOnError>
         <gib.disable>true</gib.disable>
+        <gib.excludePathsMatching>/gradle-modules</gib.excludePathsMatching>
 
         <!-- used only in dependency management to force this version, not included as a direct dependency -->
         <junit.version>4.13.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1142,7 +1142,7 @@
         <gib.failOnMissingGitDir>false</gib.failOnMissingGitDir>
         <gib.failOnError>false</gib.failOnError>
         <gib.disable>true</gib.disable>
-        <gib.excludePathsMatching>/gradle-modules</gib.excludePathsMatching>
+        <gib.excludePathsMatching>.*gradle-modules.*</gib.excludePathsMatching>
 
         <!-- used only in dependency management to force this version, not included as a direct dependency -->
         <junit.version>4.13.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1183,7 +1183,7 @@
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
         <custom-pmd.version>0.0.1</custom-pmd.version>
-        <gitflow-incremental-builder.version>3.15.0</gitflow-incremental-builder.version>
+        <gitflow-incremental-builder.version>4.5.3</gitflow-incremental-builder.version>
         <maven-jxr-plugin.version>3.3.0</maven-jxr-plugin.version>
         <maven-pmd-plugin.version>3.21.0</maven-pmd-plugin.version>
         <lombok.version>1.18.30</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1182,7 +1182,7 @@
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
         <custom-pmd.version>0.0.1</custom-pmd.version>
-        <gitflow-incremental-builder.version>3.12.2</gitflow-incremental-builder.version>
+        <gitflow-incremental-builder.version>3.15.0</gitflow-incremental-builder.version>
         <maven-jxr-plugin.version>3.3.0</maven-jxr-plugin.version>
         <maven-pmd-plugin.version>3.21.0</maven-pmd-plugin.version>
         <lombok.version>1.18.30</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
 
         <extensions>
             <extension>
-                <groupId>com.vackosar.gitflowincrementalbuilder</groupId>
+                <groupId>io.github.gitflow-incremental-builder</groupId>
                 <artifactId>gitflow-incremental-builder</artifactId>
                 <version>${gitflow-incremental-builder.version}</version>
             </extension>


### PR DESCRIPTION
This version is not the latest, but the last one that doesn't introduce breaking changes.