### PR TITLE
Code added for ticket: BAEL-7621

### DIFF
--- a/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/struct/entities/StructDepartment.java
+++ b/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/struct/entities/StructDepartment.java
@@ -1,0 +1,51 @@
+package com.baeldung.hibernate.struct.entities;
+
+import jakarta.persistence.*;
+
+@Entity
+public class StructDepartment {
+    @Id
+    @GeneratedValue
+    private Integer id;
+
+    @Column
+    private String departmentName;
+
+    @Embedded
+    @Column
+    private StructManager manager;
+
+    @Override
+    public String toString() {
+        return "Department{" +
+                "id=" + id +
+                ", departmentName='" + departmentName + '\'' +
+                ", manager=" + manager +
+                '}';
+    }
+
+    public StructDepartment(String departmentName, StructManager manager) {
+        this.departmentName = departmentName;
+        this.manager = manager;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getDepartmentName() {
+        return departmentName;
+    }
+
+    public void setDepartmentName(String departmentName) {
+        this.departmentName = departmentName;
+    }
+
+    public StructManager getManager() {
+        return manager;
+    }
+
+    public void setManager(StructManager manager) {
+        this.manager = manager;
+    }
+}

--- a/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/struct/entities/StructManager.java
+++ b/persistence-modules/hibernate-jpa/src/main/java/com/baeldung/hibernate/struct/entities/StructManager.java
@@ -1,0 +1,52 @@
+package com.baeldung.hibernate.struct.entities;
+import jakarta.persistence.Embeddable;
+import org.hibernate.annotations.Struct;
+
+import java.io.Serializable;
+
+@Embeddable
+@Struct(name = "Department_Manager_Type", attributes = {"firstName", "lastName", "qualification"})
+public class StructManager implements Serializable {
+    private String firstName;
+    private String lastName;
+    private String qualification;
+
+    @Override
+    public String toString() {
+        return "Manager{" +
+                "firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", qualification='" + qualification + '\'' +
+                '}';
+    }
+
+    public StructManager(String firstName, String lastName, String qualification) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.qualification = qualification;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getQualification() {
+        return qualification;
+    }
+
+    public void setQualification(String qualification) {
+        this.qualification = qualification;
+    }
+}

--- a/persistence-modules/hibernate-jpa/src/test/java/com/baeldung/hibernate/struct/HibernateStructUnitTest.java
+++ b/persistence-modules/hibernate-jpa/src/test/java/com/baeldung/hibernate/struct/HibernateStructUnitTest.java
@@ -1,0 +1,101 @@
+package com.baeldung.hibernate.struct;
+
+import com.baeldung.hibernate.struct.entities.StructDepartment;
+import com.baeldung.hibernate.struct.entities.StructManager;
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.service.ServiceRegistry;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Properties;
+
+public class HibernateStructUnitTest {
+
+    private Session session;
+    private Transaction transaction;
+
+    public static SessionFactory getSessionFactoryByProperties(Properties properties) throws IOException {
+        ServiceRegistry serviceRegistry = configureServiceRegistry(properties);
+        return makeSessionFactory(serviceRegistry);
+    }
+
+    private static SessionFactory makeSessionFactory(ServiceRegistry serviceRegistry) {
+        MetadataSources metadataSources = new MetadataSources(serviceRegistry);
+        metadataSources.addPackage("com.baeldung.hibernate.struct.entities");
+        metadataSources.addAnnotatedClass(StructDepartment.class);
+        metadataSources.addAnnotatedClass(StructManager.class);
+
+        Metadata metadata = metadataSources.getMetadataBuilder()
+          .build();
+
+        return metadata.getSessionFactoryBuilder()
+          .build();
+
+    }
+    private static ServiceRegistry configureServiceRegistry(Properties properties) throws IOException {
+        return new StandardServiceRegistryBuilder().applySettings(properties)
+          .build();
+    }
+
+    public static Properties getProperties() throws IOException {
+        Properties properties = new Properties();
+        URL propertiesURL = Thread.currentThread()
+          .getContextClassLoader()
+          .getResource(StringUtils.defaultString(PROPERTY_FILE_NAME, "hibernate-derby.properties"));
+        try (FileInputStream inputStream = new FileInputStream(propertiesURL.getFile())) {
+            properties.load(inputStream);
+        }
+        return properties;
+    }
+
+    private static ServiceRegistry configureServiceRegistry() throws IOException {
+        return configureServiceRegistry(getProperties());
+    }
+    private static String PROPERTY_FILE_NAME;
+    public static SessionFactory getSessionFactory(String propertyFileName) throws IOException {
+        PROPERTY_FILE_NAME = propertyFileName;
+        ServiceRegistry serviceRegistry = configureServiceRegistry();
+        return makeSessionFactory(serviceRegistry);
+    }
+    @Before
+    public void setUp() throws IOException {
+        session = getSessionFactory("hibernate-derby.properties")
+                .openSession();
+        transaction = session.beginTransaction();
+
+        transaction.commit();
+        transaction = session.beginTransaction();
+    }
+
+    @After
+    public void tearDown() {
+        transaction.rollback();
+        session.close();
+    }
+
+
+
+/*  This unit test is for reference only because the Hibernate dialect for
+    Apache Derby database does not support @Struct annotation.
+
+    @Test
+    public void givenSaveDepartmentObject_ThenManagerUDTExists() {
+        StructDepartment d = new StructDepartment("Information Technology"
+                , new StructManager("Zeeshan", "Arif", "Qualified"));
+
+        session.persist(d);
+        session.flush();
+        session.clear();
+
+    }*/
+}

--- a/persistence-modules/hibernate-jpa/src/test/resources/hibernate-derby.properties
+++ b/persistence-modules/hibernate-jpa/src/test/resources/hibernate-derby.properties
@@ -1,0 +1,17 @@
+hibernate.connection.driver_class=org.apache.derby.jdbc.EmbeddedDriver
+hibernate.connection.url=jdbc:derby:db/derby.dbfile;create=true
+hibernate.connection.username=
+hibernate.connection.autocommit=true
+jdbc.password=
+
+hibernate.dialect=org.hibernate.dialect.DerbyDialect
+
+# enable to see Hibernate generated SQL
+hibernate.show_sql=false
+
+hibernate.hbm2ddl.auto=create-drop
+
+hibernate.c3p0.min_size=5
+hibernate.c3p0.max_size=20
+hibernate.c3p0.acquire_increment=5
+hibernate.c3p0.timeout=1800


### PR DESCRIPTION
StructDepartment.java
StructManager.java - (contains the @Struct annotation which is the annotation the ticket is about. HibernateStructUnitTest.java - Struct unit test class. No unit test present because the hibernate dialect: org.hibernate.dialect.DerbyDialect does not support the @Struct annotation despite the fact that Apache Derby has support for CREATE TYPE (https://db.apache.org/derby/docs/10.17/ref/rrefsqljcreatetype.html) ddls. hibernate-derby.properties - properties file, just for reference, not being used in unit tests.