### PR TITLE
BAEL-6333: Avoiding the IndexOutOfBoundsException in subList in Java

### DIFF
--- a/core-java-modules/core-java-collections-list-6/src/main/java/com/baeldung/sublistindexoutofboundsexception/SubListUtils.java
+++ b/core-java-modules/core-java-collections-list-6/src/main/java/com/baeldung/sublistindexoutofboundsexception/SubListUtils.java
@@ -1,0 +1,16 @@
+package com.baeldung.sublistindexoutofboundsexception;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SubListUtils {
+
+    public static List<String> safeSubList(List<String> myList, int fromIndex, int toIndex) {
+        if (myList == null || fromIndex >= myList.size() || toIndex <= 0 || fromIndex >= toIndex) {
+            return Collections.emptyList();
+        }
+
+        return myList.subList(Math.max(0, fromIndex), Math.min(myList.size(), toIndex));
+    }
+
+}

--- a/core-java-modules/core-java-collections-list-6/src/test/java/com/baeldung/sublistindexoutofboundsexception/SubListIndexOutOfBoundsExceptionUnitTest.java
+++ b/core-java-modules/core-java-collections-list-6/src/test/java/com/baeldung/sublistindexoutofboundsexception/SubListIndexOutOfBoundsExceptionUnitTest.java
@@ -1,0 +1,28 @@
+package com.baeldung.sublistindexoutofboundsexception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class SubListIndexOutOfBoundsExceptionUnitTest {
+
+    @Test
+    void whenCallingSuListWithIncorrectIndexes_thenThrowIndexOutOfBoundsException() {
+        List<String> cities = List.of("Tokyo", "Tamassint", "Paris", "Madrid", "London");
+
+        assertThatThrownBy(() -> cities.subList(6, 10)).isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @Test
+    void whenCallingSafeSuList_thenReturnData() {
+        List<String> cities = List.of("Amsterdam", "Buenos Aires", "Dublin", "Brussels", "Prague");
+
+        assertThat(SubListUtils.safeSubList(cities, 6, 10)).isEmpty();
+        assertThat(SubListUtils.safeSubList(cities, -2, 3)).containsExactly("Amsterdam", "Buenos Aires", "Dublin");
+        assertThat(SubListUtils.safeSubList(cities, 3, 20)).containsExactly("Brussels", "Prague");
+    }
+
+}


### PR DESCRIPTION
+ Create a safe alternative of subList method to avoid IndexOutOfBoundsException