### PR TITLE
JAVA-28831 :- Fix libraries data for JDK 21.

### DIFF
--- a/libraries-data/pom.xml
+++ b/libraries-data/pom.xml
@@ -207,13 +207,13 @@
     </build>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <assembly.plugin.version>2.3</assembly.plugin.version>
         <httpclient.version>3.1</httpclient.version>
         <storm.version>1.2.2</storm.version>
         <kafka.version>3.3.1</kafka.version>
-        <ignite.version>2.14.0</ignite.version>
+        <ignite.version>2.16.0</ignite.version>
         <ignite-spring-data.version>2.9.1</ignite-spring-data.version>
         <gson.version>2.10.1</gson.version>
         <cache.version>1.1.1</cache.version>

--- a/libraries-data/pom.xml
+++ b/libraries-data/pom.xml
@@ -207,8 +207,8 @@
     </build>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <assembly.plugin.version>2.3</assembly.plugin.version>
         <httpclient.version>3.1</httpclient.version>
         <storm.version>1.2.2</storm.version>


### PR DESCRIPTION
Have to upgrade Ignite to make it work with JDK 21. Checked by using JDK 21 SDK and setting maven version for JDK to 21. But for now set it to 17 to be compatible.