### PR TITLE
Fix IT ItemIntegrationTest

### DIFF
--- a/persistence-modules/spring-boot-persistence-h2/src/main/resources/application-not-null-vs-nullable.properties
+++ b/persistence-modules/spring-boot-persistence-h2/src/main/resources/application-not-null-vs-nullable.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:mydb
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driverClassName=org.h2.Driver
+spring.sql.init.mode=never

--- a/persistence-modules/spring-boot-persistence-h2/src/test/java/com/baeldung/h2db/notnull/ItemIntegrationTest.java
+++ b/persistence-modules/spring-boot-persistence-h2/src/test/java/com/baeldung/h2db/notnull/ItemIntegrationTest.java
@@ -1,20 +1,22 @@
 package com.baeldung.h2db.notnull;
 
-import com.baeldung.h2db.notnull.daos.ItemRepository;
-import com.baeldung.h2db.notnull.models.Item;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import com.baeldung.h2db.notnull.daos.ItemRepository;
+import com.baeldung.h2db.notnull.models.Item;
 
 import jakarta.validation.ConstraintViolationException;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = NotNullVsNullableApplication.class)
+@ActiveProfiles("not-null-vs-nullable")
 public class ItemIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
+ Fix ItemIntegrationTest by adding a custom config to avoid init H2 using the default data.sql script