### PR TITLE
Use properly reactive endpoint

### DIFF
--- a/quarkus-modules/quarkus-vs-springboot/quarkus-project/src/main/java/com/baeldung/quarkus_project/ReactiveGreetingResource.java
+++ b/quarkus-modules/quarkus-vs-springboot/quarkus-project/src/main/java/com/baeldung/quarkus_project/ReactiveGreetingResource.java
@@ -4,12 +4,14 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import io.smallrye.common.annotation.NonBlocking;
 
 @Path("/hello")
 public class ReactiveGreetingResource {
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
+    @NonBlocking
     public String hello() {
         return "Hello RESTEasy Reactive";
     }


### PR DESCRIPTION
https://github.com/quarkusio/quarkus-quickstarts/commit/dadc5bc3ed6ec8cf58453501547affcb835f083d 

by default Quarkus run "non async types"  e.g. String in the blocking thread pool, behaving differently from its reactive ones .e.g. Uni<String> .

Adding this annotation is needed to making it behave correctly.