### PR TITLE
Implement Deep vs Shallow Copy Tutorial in Java

### DIFF
--- a/core-java-modules/core-java-lang-7/.gitignore.txt
+++ b/core-java-modules/core-java-lang-7/.gitignore.txt
@@ -1,0 +1,7 @@
+# Eclipse-specific files
+.classpath
+.project
+.settings/
+
+# Maven build folder
+target/

--- a/core-java-modules/core-java-lang-7/src/main/java/com/baeldung/deepshallowcopy/DeepCopyUser.java
+++ b/core-java-modules/core-java-lang-7/src/main/java/com/baeldung/deepshallowcopy/DeepCopyUser.java
@@ -1,0 +1,36 @@
+package com.baeldung.deepshallowcopy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeepCopyUser {
+    private String name;
+    private List<String> roles;
+
+    public DeepCopyUser(String name, List<String> roles) {
+        this.name = name;
+        this.roles = new ArrayList<>(roles);
+    }
+
+    // Copy constructor for deep copy
+    public DeepCopyUser(DeepCopyUser user) {
+        this.name = user.name;
+        this.roles = new ArrayList<>(user.roles);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+}

--- a/core-java-modules/core-java-lang-7/src/main/java/com/baeldung/deepshallowcopy/ShallowCopyUser.java
+++ b/core-java-modules/core-java-lang-7/src/main/java/com/baeldung/deepshallowcopy/ShallowCopyUser.java
@@ -1,0 +1,36 @@
+package com.baeldung.deepshallowcopy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ShallowCopyUser implements Cloneable {
+
+    private String name;
+    private List<String> roles;
+
+    public ShallowCopyUser(String name, List<String> roles) {
+        this.name = name;
+        this.roles = new ArrayList<>(roles);
+    }
+
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        return super.clone(); // Performs a shallow copy
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+}

--- a/core-java-modules/core-java-lang-7/src/test/java/com/baeldung/deepshallowcopy/DeepCopyUserUnitTest.java
+++ b/core-java-modules/core-java-lang-7/src/test/java/com/baeldung/deepshallowcopy/DeepCopyUserUnitTest.java
@@ -1,0 +1,27 @@
+package com.baeldung.deepshallowcopy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+public class DeepCopyUserUnitTest {
+
+    @Test
+    public void whenCloningUsingDeepCopy_thenObjectsShouldNotShareReferences() {
+        DeepCopyUser originalUser = new DeepCopyUser("Jack Madson", Arrays.asList("Admin", "User"));
+        DeepCopyUser copiedUser = new DeepCopyUser(originalUser);
+
+        assertNotSame(originalUser, copiedUser, "Copied user should be a different object.");
+        assertNotSame(originalUser.getRoles(), copiedUser.getRoles(), "Roles list should be a different object.");
+        assertEquals(originalUser.getRoles(), copiedUser.getRoles(), "Roles should be the same content.");
+        copiedUser.getRoles()
+            .add("Guest");
+        assertEquals(2, originalUser.getRoles()
+            .size(), "Original user roles should not be affected by changes to the copied user.");
+        assertEquals(3, copiedUser.getRoles()
+            .size(), "Copied user roles should reflect the new addition.");
+    }
+}

--- a/core-java-modules/core-java-lang-7/src/test/java/com/baeldung/deepshallowcopy/ShallowCopyUserUnitTest.java
+++ b/core-java-modules/core-java-lang-7/src/test/java/com/baeldung/deepshallowcopy/ShallowCopyUserUnitTest.java
@@ -1,0 +1,28 @@
+package com.baeldung.deepshallowcopy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+public class ShallowCopyUserUnitTest {
+
+    @Test
+    public void whenCloningUsingShallowCopy_thenObjectsShouldNotBeSameButFieldsShouldBe() {
+        ShallowCopyUser originalUser = new ShallowCopyUser("Jack Whiteman", Arrays.asList("Admin", "User"));
+        ShallowCopyUser clonedUser = null;
+        try {
+            clonedUser = (ShallowCopyUser) originalUser.clone();
+        } catch (CloneNotSupportedException e) {
+            e.printStackTrace();
+        }
+
+        assertNotSame(originalUser, clonedUser, "Cloned user should be a different object.");
+        assertEquals(originalUser.getRoles(), clonedUser.getRoles(), "Roles should be the same list (shallow copy).");
+        clonedUser.getRoles()
+            .add("Guest");
+        assertEquals(originalUser.getRoles(), clonedUser.getRoles(), "Changes to the roles list should affect both users.");
+    }
+}


### PR DESCRIPTION
**Introduction**
Following my recent application for the Java Author position at Baeldung, I'm thrilled to create this PR.

In addition to my application for the Java Author position at Baeldung, I am happy to submit this Pull Request. It provides a comprehensive exploration of the differences between deep and shallow copying in Java, complete with practical code examples to illustrate these concepts.

**Content Summary**
- **ShallowCopyUser Class**: Demonstrates shallow copying using the clone() method.
- **DeepCopyUser Class**: Illustrates deep copying using a copy constructor.

**Included Changes:**
- Added two new classes: `DeepCopyUser` and `ShallowCopyUser` and their unit test classes as well.
- Added unit tests in `DeepCopyUserUnitTest` and `ShallowCopyUserUnitTest` to validate the copying behavior.

**Tests Performed:**
- The shallow copy test confirms that the `clone()` method performs as expected.
- The deep copy test creates a new object with a separate reference.

**Discussion:**
The tutorial delineates key differences between deep and shallow copies, such as:
- Object References: Shallow copy shares references, while deep copy creates separate references.
- Use Cases: Shallow copying is favored for immutable objects, whereas deep copying is crucial for objects that require full independence.

Please check the article here [Creating a Deep vs Shallow Copy of an Object in Java](https://drafts.baeldung.com/?p=204787&preview=true). I would greatly appreciate your feedback.

Thank you for giving me this opportunity to demonstrate my technical writing skills!
