### PR TITLE
Bael 8138: Exclude Property from Lombok @Builder Annotation

### DIFF
--- a/lombok-modules/lombok/src/main/java/com/baeldung/lombok/builder/ClassWithExcludedFields.java
+++ b/lombok-modules/lombok/src/main/java/com/baeldung/lombok/builder/ClassWithExcludedFields.java
@@ -1,0 +1,31 @@
+package com.baeldung.lombok.builder;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClassWithExcludedFields {
+
+    private int id;
+    private String includedField;
+
+    @Builder.Default
+    private String excludedField = "Excluded Field using Default";
+
+    static String anotherExcludedField = "Excluded Field using static";
+
+    @Builder(builderMethodName = "customBuilder")
+    public static ClassWithExcludedFields of(int id, String includedField) {
+        ClassWithExcludedFields myObject = new ClassWithExcludedFields();
+        myObject.setId(id);
+        myObject.setIncludedField(includedField);
+
+        return myObject;
+    }
+
+}

--- a/lombok-modules/lombok/src/test/java/com/baeldung/lombok/builder/BuilderUnitTest.java
+++ b/lombok-modules/lombok/src/test/java/com/baeldung/lombok/builder/BuilderUnitTest.java
@@ -40,4 +40,29 @@ public class BuilderUnitTest {
         assertThat(testImmutableClient.getName()).isEqualTo("foo");
         assertThat(testImmutableClient.getId()).isEqualTo(1);
     }
+
+    @Test
+    public void whenUsingCustomBuilder_thenExcludeUnspecifiedFields() {
+        ClassWithExcludedFields myObject = ClassWithExcludedFields.customBuilder()
+            .id(3)
+            .includedField("Included Field")
+            // .excludedField() no method to set excludedField
+            .build();
+
+        assertThat(myObject.getId()).isEqualTo(3);
+        assertThat(myObject.getIncludedField()).isEqualTo("Included Field");
+    }
+
+    @Test
+    public void whenUsingBuilderDefaultAnnotation_thenExcludeField() {
+        ClassWithExcludedFields myObject = ClassWithExcludedFields.builder()
+            .id(3)
+            .includedField("Included Field")
+            .build();
+
+        assertThat(myObject.getId()).isEqualTo(3);
+        assertThat(myObject.getIncludedField()).isEqualTo("Included Field");
+        assertThat(myObject.getExcludedField()).isEqualTo("Excluded Field using Default");
+    }
+
 }


### PR DESCRIPTION
+ Add a new class _ClassWithExcludedFields_
+ Add test cases to showcase how to exclude fields from Lombok builder