### PR TITLE
[BAEL-6373] Why the Order of Maven Dependencies is Important

### DIFF
--- a/maven-modules/dependency-ordering/pom.xml
+++ b/maven-modules/dependency-ordering/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>dependency-ordering</artifactId>
+
+    <parent>
+        <artifactId>maven-modules</artifactId>
+        <groupId>com.baeldung</groupId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+            <version>5.3.0</version>
+        </dependency>
+        <!-- Change the order of dependencies to simulate the dependency ordering issue -->
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>4.2</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/maven-modules/dependency-ordering/src/test/java/com/baeldung/dependency/ordering/DependencyOrderingUnitTest.java
+++ b/maven-modules/dependency-ordering/src/test/java/com/baeldung/dependency/ordering/DependencyOrderingUnitTest.java
@@ -1,0 +1,16 @@
+package com.baeldung.dependency.ordering;
+
+import org.apache.commons.collections4.MapUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DependencyOrderingUnitTest {
+
+    @Test
+    void whenCorrectDependencyVersionIsUsed_thenShouldCompile() {
+        assertEquals(0, MapUtils.size(new HashMap<>()));
+    }
+}

--- a/maven-modules/pom.xml
+++ b/maven-modules/pom.xml
@@ -17,6 +17,7 @@
     <modules>
         <module>animal-sniffer-mvn-plugin</module>
         <module>compiler-plugin-java-9</module>
+        <module>dependency-ordering</module>
         <module>dependency-exclusion</module>
         <module>host-maven-repo-example</module>
         <module>jacoco-coverage-aggregation</module>


### PR DESCRIPTION
 - add module with Apache POI and OpenCSV dependencies that use different versions of Apache Commons Collections
 - add test that fails in case the order of those dependencies is changed