### PR TITLE
Update JavaDirectoryDeleteUnitTest.java 

### DIFF
--- a/libraries-io/src/test/java/com/baeldung/java/io/JavaDirectoryDeleteUnitTest.java
+++ b/libraries-io/src/test/java/com/baeldung/java/io/JavaDirectoryDeleteUnitTest.java
@@ -13,6 +13,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;

--- a/libraries-io/src/test/java/com/baeldung/java/io/JavaDirectoryDeleteUnitTest.java
+++ b/libraries-io/src/test/java/com/baeldung/java/io/JavaDirectoryDeleteUnitTest.java
@@ -110,7 +110,9 @@ public class JavaDirectoryDeleteUnitTest {
     public void givenDirectory_whenDeletedWithFilesWalk_thenIsGone() throws IOException {
         Path pathToBeDeleted = TEMP_DIRECTORY.resolve(DIRECTORY_NAME);
 
-        Files.walk(pathToBeDeleted).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+        try (Stream<Path> paths = Files.walk(pathToBeDeleted)) {
+            paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+        }
 
         assertFalse("Directory still exists", Files.exists(pathToBeDeleted));
     }


### PR DESCRIPTION
### Description

`File.walk` is a common source of memory leaks in my corporate job.  So much so that it has caused outages a few times now.

```
The returned stream encapsulates one or more DirectoryStreams. If timely disposal of file system resources is required, the try-with-resources construct should be used to ensure that the stream's close method is invoked after the stream operations are completed. Operating on a closed stream will result in an IllegalStateException.
```
[source](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#walk-java.nio.file.Path-java.nio.file.FileVisitOption...-)

Ideally you'd update your article too 😅 I suspect that is where most folks are going to grab this code.

I realize this is just a unit-test, so who cares but realistically your example will be used in critical sections that aren't just once-off unit tests.