### PR TITLE
Move code to core-java-arrays-guides module and add tests for null and empty arrays

### DIFF
--- a/core-java-modules/core-java-arrays-guides/src/test/java/com/baeldung/nullandemptyarray/NullAndEmptyArrayTests.java
+++ b/core-java-modules/core-java-arrays-guides/src/test/java/com/baeldung/nullandemptyarray/NullAndEmptyArrayTests.java
@@ -1,0 +1,23 @@
+package com.baeldung.nullandemptyarray;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class NullAndEmptyArrayTests {
+
+    @Test
+    public void givenNullArray_whenAccessLength_thenThrowsNullPointerException() {
+        int[] nullArray = null;
+        assertThrows(NullPointerException.class, () -> {
+            int length = nullArray.length;
+        });
+    }
+
+    @Test
+    public void givenEmptyArray_whenCheckLength_thenReturnsZero() {
+        int[] emptyArray = new int[0];
+        assertEquals(0, emptyArray.length);
+    }
+}

--- a/core-java-modules/core-java-arrays-guides/src/test/java/com/baeldung/nullandemptyarray/NullAndEmptyArrayUnitTests.java
+++ b/core-java-modules/core-java-arrays-guides/src/test/java/com/baeldung/nullandemptyarray/NullAndEmptyArrayUnitTests.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-public class NullAndEmptyArrayTests {
+public class NullAndEmptyArrayUnitTests {
 
     @Test
     public void givenNullArray_whenAccessLength_thenThrowsNullPointerException() {


### PR DESCRIPTION
Hey David Martinez,

I have created a new pull request due to some difficulties with the previous one. The previous PR had issues that were compounded by my current computer's performance, so I decided to start fresh. Here are the key changes and updates:

Moved the code from the `core-java-numbers-8` module to the `core-java-arrays-guides` module as per your feedback.

Reverted the `pom.xml` file to its original state to remove any unnecessary modifications.

Removed the `EmptyArray` and `NullArray` classes which were not needed. 

Added a new test file in the `core-java-arrays-guides` module.

Please review the changes and let me know if there is anything else that needs to be updated.

Thanks,
Philip Nyankena
