### PR TITLE
(cmuramoto): Evaluation Article

### DIFF
--- a/core-java-modules/core-java-22/pom.xml
+++ b/core-java-modules/core-java-22/pom.xml
@@ -22,6 +22,13 @@
                     <compilerArgs>--enable-preview</compilerArgs>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+					<argLine>--enable-preview -XX:+EnableDynamicAgentLoading -Djdk.attach.allowAttachSelf=true</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/core-java-modules/core-java-22/pom.xml
+++ b/core-java-modules/core-java-22/pom.xml
@@ -26,7 +26,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-					<argLine>--enable-preview -XX:+EnableDynamicAgentLoading -Djdk.attach.allowAttachSelf=true</argLine>
+                    <argLine>--enable-preview -XX:+EnableDynamicAgentLoading -Djdk.attach.allowAttachSelf=true</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/core-java-modules/core-java-22/src/main/java/com/baeldung/javafeatures/classfile/ClassFileDriver.java
+++ b/core-java-modules/core-java-22/src/main/java/com/baeldung/javafeatures/classfile/ClassFileDriver.java
@@ -1,6 +1,7 @@
 package com.baeldung.javafeatures.classfile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.classfile.ClassElement;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
@@ -9,20 +10,29 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class ClassFileDriver {
+
     public Path updateClass() throws IOException {
         final String PREFIX = "test_";
+        byte[] original;
+
+        try (InputStream is = getClass().getClassLoader()
+            .getResourceAsStream("com/baeldung/javafeatures/classfile/ClassFileExample.class")) {
+            original = is.readAllBytes();
+        }
+
         final Path PATH = Path.of("src/main/java/com/baeldung/javafeatures/classfile/ClassFileExample.class");
         ClassFile cf = ClassFile.of();
-        ClassModel classModel = cf.parse(PATH);
-        byte[] newBytes = cf.build(classModel.thisClass().asSymbol(), classBuilder -> {
-            for (ClassElement ce : classModel) {
-                if (!(ce instanceof MethodModel mm && mm.methodName()
-                  .stringValue()
-                  .startsWith(PREFIX))) {
-                    classBuilder.with(ce);
+        ClassModel classModel = cf.parse(original);
+        byte[] newBytes = cf.build(classModel.thisClass()
+            .asSymbol(), classBuilder -> {
+                for (ClassElement ce : classModel) {
+                    if (!(ce instanceof MethodModel mm && mm.methodName()
+                        .stringValue()
+                        .startsWith(PREFIX))) {
+                        classBuilder.with(ce);
+                    }
                 }
-            }
-        });
+            });
         return Files.write(PATH, newBytes);
     }
 }

--- a/core-java-modules/core-java-22/src/main/java/com/baeldung/javafeatures/classfile/SerializableTransformer.java
+++ b/core-java-modules/core-java-22/src/main/java/com/baeldung/javafeatures/classfile/SerializableTransformer.java
@@ -1,0 +1,69 @@
+package com.baeldung.javafeatures.classfile;
+
+import java.io.Serializable;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassTransform;
+import java.lang.classfile.constantpool.ClassEntry;
+import java.lang.constant.ClassDesc;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.lang.reflect.AccessFlag;
+import java.security.ProtectionDomain;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SerializableTransformer implements ClassFileTransformer {
+
+    // skip core jdk classes
+    final Set<String> filtered;
+    final ClassDesc serializable;
+
+    public SerializableTransformer() {
+        filtered = ModuleLayer.boot()
+            .modules()
+            .stream()
+            .map(Module::getName)
+            .filter(name -> name != null && (name.startsWith("java") || name.startsWith("jdk")))
+            .collect(Collectors.toSet());
+
+        serializable = ClassDesc.of(Serializable.class.getName());
+    }
+
+    @Override
+    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+        var cf = ClassFile.of();
+
+        var model = cf.parse(classfileBuffer);
+
+        var flags = model.flags();
+
+        // No need to transform abstract classes/interfaces
+        if (flags.has(AccessFlag.ABSTRACT) || flags.has(AccessFlag.INTERFACE)) {
+            return classfileBuffer;
+        }
+
+        var interfaces = model.interfaces().stream().map(ClassEntry::asSymbol).collect(Collectors.toList());
+
+        // Already serializable
+        if (interfaces.contains(serializable)) {
+            return classfileBuffer;
+        } else {
+            interfaces.add(serializable);
+        }
+
+        var ct = ClassTransform.endHandler(cb -> cb.withInterfaceSymbols(interfaces));
+
+        return cf.transform(model, ct);
+    }
+
+    @Override
+    public byte[] transform(Module module, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+        String moduleName;
+
+        if (module != null && (moduleName = module.getName()) != null && filtered.contains(moduleName)) {
+            return classfileBuffer;
+        }
+
+        return transform(loader, className, classBeingRedefined, protectionDomain, classfileBuffer);
+    }
+}

--- a/core-java-modules/core-java-22/src/test/java/com/baeldung/foreign/api/Java22ForeignMemoryUnitTest.java
+++ b/core-java-modules/core-java-22/src/test/java/com/baeldung/foreign/api/Java22ForeignMemoryUnitTest.java
@@ -15,7 +15,7 @@ import java.nio.ByteBuffer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ForeignMemoryUnitTest {
+class ForeignMemoryUnitTest {
 
     @Test
     void whenGlobalArenaClosed_thenThrowsException() {

--- a/core-java-modules/core-java-22/src/test/java/com/baeldung/javafeatures/classfile/Data.java
+++ b/core-java-modules/core-java-22/src/test/java/com/baeldung/javafeatures/classfile/Data.java
@@ -1,0 +1,40 @@
+package com.baeldung.javafeatures.classfile;
+
+import java.util.Objects;
+
+class Data<T> {
+
+    String id;
+    long timestamp;
+    T payload;
+
+    public Data() {
+    }
+
+    public Data(String id, long timestamp, T payload) {
+        this.id = id;
+        this.timestamp = timestamp;
+        this.payload = payload;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Data<?> other = (Data<?>) obj;
+        return Objects.equals(id, other.id) && Objects.equals(payload, other.payload) && timestamp == other.timestamp;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, payload, timestamp);
+    }
+
+}

--- a/core-java-modules/core-java-22/src/test/java/com/baeldung/javafeatures/classfile/DeepCloneWithAgentTest.java
+++ b/core-java-modules/core-java-22/src/test/java/com/baeldung/javafeatures/classfile/DeepCloneWithAgentTest.java
@@ -1,0 +1,45 @@
+package com.baeldung.javafeatures.classfile;
+
+import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.util.Calendar;
+
+import org.junit.jupiter.api.Test;
+
+class DeepCloneWithAgentTest {
+
+    static final Exception INIT_EX;
+
+    static {
+        Exception ex;
+        try {
+            InstrumentationSupport.getInstrumentation()
+            .addTransformer(new SerializableTransformer());
+
+            ex = null;
+        } catch (Exception e) {
+            ex = e;
+        }
+        INIT_EX = ex;
+    }
+
+    @Test
+    void given_non_serializable_class_will_deep_clone() {
+        assumeTrue(InstrumentationSupport.REQUIRED_VM_ARGS, INIT_EX == null);
+
+        var original = new Data<>("id", System.currentTimeMillis(), Calendar.getInstance());
+
+        var cloned = DeepCloner.clone(original);
+
+        assertNotSame(original, cloned);
+        assertEquals(original, cloned);
+
+        cloned.payload.set(Calendar.YEAR, 1999);
+
+        assertNotEquals(original, cloned);
+    }
+
+}

--- a/core-java-modules/core-java-22/src/test/java/com/baeldung/javafeatures/classfile/DeepCloner.java
+++ b/core-java-modules/core-java-22/src/test/java/com/baeldung/javafeatures/classfile/DeepCloner.java
@@ -1,0 +1,41 @@
+package com.baeldung.javafeatures.classfile;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.UncheckedIOException;
+
+public final class DeepCloner {
+
+    public static <T> T clone(T o) {
+        if (o == null) {
+            return null;
+        }
+
+        return deserialize(serialize(o));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T deserialize(byte[] payload) {
+        try (var ois = new ObjectInputStream(new ByteArrayInputStream(payload))) {
+            return (T) ois.readObject();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] serialize(Object o) {
+        var baos = new ByteArrayOutputStream();
+        try (var oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(o);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return baos.toByteArray();
+    }
+
+}

--- a/core-java-modules/core-java-22/src/test/java/com/baeldung/javafeatures/classfile/InstrumentationSupport.java
+++ b/core-java-modules/core-java-22/src/test/java/com/baeldung/javafeatures/classfile/InstrumentationSupport.java
@@ -1,0 +1,90 @@
+package com.baeldung.javafeatures.classfile;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.lang.instrument.Instrumentation;
+import java.nio.file.Files;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.tools.attach.AttachNotSupportedException;
+import com.sun.tools.attach.VirtualMachine;
+
+public class InstrumentationSupport {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstrumentationSupport.class);
+
+    public static final String REQUIRED_VM_ARGS = "Dynamic Attachment in java 22+ requires VM initialization with -Djdk.attach.allowAttachSelf=true";
+
+    private static Instrumentation instrumentation;
+
+    public static void agentmain(final String args, final Instrumentation inst) {
+        instrumentation = inst;
+    }
+
+    static String createTempJar() throws IOException {
+        var path = Files.createTempFile("agent", ".jar");
+
+        try (var zout = new ZipOutputStream(Files.newOutputStream(path)); //
+            var writer = new PrintWriter(new OutputStreamWriter(zout))) {
+            zout.putNextEntry(new ZipEntry("META-INF/MANIFEST.MF"));
+
+            writer.print("Agent-Class: ");
+            writer.println(InstrumentationSupport.class.getName());
+            writer.print("Premain-Class: ");
+            writer.println(InstrumentationSupport.class.getName());
+            writer.println("Can-Redefine-Classes: true");
+            writer.println("Can-Retransform-Classes: true");
+        }
+
+        return path.toAbsolutePath().toString();
+    }
+
+    public static Instrumentation getInstrumentation() {
+        Instrumentation ret = instrumentation;
+        if (ret == null) {
+            try {
+                selfInstall();
+            } catch (final Exception e) {
+                throw e instanceof RuntimeException re ? re : new RuntimeException("Unable to install java-agent", e);
+            }
+            ret = instrumentation;
+        }
+        return ret;
+    }
+
+    static VirtualMachine getVM() throws Exception {
+        var pid = Long.toString(ProcessHandle.current().pid());
+
+        VirtualMachine vm;
+
+        try {
+            vm = VirtualMachine.attach(pid);
+        } catch (final AttachNotSupportedException | IOException e) {
+            LOGGER.warn("Attachment Failed: ({}). To avoid this, run with -Djdk.attach.allowAttachSelf=true.", e.getMessage());
+
+            throw e instanceof RuntimeException re ? re : new RuntimeException("Unable to attach", e);
+        }
+
+        return vm;
+    }
+
+    public static void premain(/* agent arg */ String ignore, final Instrumentation inst) {
+        instrumentation = inst;
+    }
+
+    static void selfInstall() throws Exception {
+        if (instrumentation == null) {
+            final VirtualMachine vm = getVM();
+            final String jar = createTempJar();
+            vm.loadAgent(jar);
+            LOGGER.info("Installing saving agent at vm {}", vm.id());
+            vm.detach();
+        }
+    }
+
+}


### PR DESCRIPTION
(test): 
-Deep Copy with ClassFileTransformer

(fix):
-givenJava22_whenUsingClassFileAPI_thenReturnUpdatedClass fails if compiled class is absent in src/main/java
-ForeignMemoryUnitTest does not match java filename and should not be public