### PR TITLE
Deep shallow copy trushil patel

### DIFF
--- a/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/shallowdeepcopy/AddressDeepCopy.java
+++ b/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/shallowdeepcopy/AddressDeepCopy.java
@@ -1,0 +1,13 @@
+package com.baeldung.shallowdeepcopy;
+
+class AddressDeepCopy {
+    String city;
+
+    AddressDeepCopy(String city) {
+        this.city = city;
+    }
+
+    protected AddressDeepCopy clone() {
+        return new AddressDeepCopy(this.city);
+    }
+}

--- a/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/shallowdeepcopy/AddressShallowCopy.java
+++ b/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/shallowdeepcopy/AddressShallowCopy.java
@@ -1,0 +1,9 @@
+package com.baeldung.shallowdeepcopy;
+
+class AddressShallowCopy {
+    String city;
+
+    AddressShallowCopy(String city) {
+        this.city = city;
+    }
+}

--- a/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/shallowdeepcopy/PersonDeepCopy.java
+++ b/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/shallowdeepcopy/PersonDeepCopy.java
@@ -1,18 +1,5 @@
 package com.baeldung.shallowdeepcopy;
 
-class AddressDeepCopy {
-    String city;
-
-    AddressDeepCopy(String city) {
-        this.city = city;
-    }
-
-    protected AddressDeepCopy clone() {
-        // Strings are immutable in Java, so copying them (deep or shallow) results in new objects
-        return new AddressDeepCopy(this.city);
-    }
-}
-
 class PersonDeepCopy implements Cloneable {
     String name;
     AddressDeepCopy address;
@@ -22,7 +9,6 @@ class PersonDeepCopy implements Cloneable {
         this.address = address;
     }
 
-    // Creates a deep copy of the Person object
     @Override
     protected PersonDeepCopy clone() {
         return new PersonDeepCopy(this.name, this.address.clone());

--- a/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/shallowdeepcopy/PersonDeepCopy.java
+++ b/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/shallowdeepcopy/PersonDeepCopy.java
@@ -1,0 +1,30 @@
+package com.baeldung.shallowdeepcopy;
+
+class AddressDeepCopy {
+    String city;
+
+    AddressDeepCopy(String city) {
+        this.city = city;
+    }
+
+    protected AddressDeepCopy clone() {
+        // Strings are immutable in Java, so copying them (deep or shallow) results in new objects
+        return new AddressDeepCopy(this.city);
+    }
+}
+
+class PersonDeepCopy implements Cloneable {
+    String name;
+    AddressDeepCopy address;
+
+    PersonDeepCopy(String name, AddressDeepCopy address) {
+        this.name = name;
+        this.address = address;
+    }
+
+    // Creates a deep copy of the Person object
+    @Override
+    protected PersonDeepCopy clone() {
+        return new PersonDeepCopy(this.name, this.address.clone());
+    }
+}

--- a/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/shallowdeepcopy/PersonShallowCopy.java
+++ b/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/shallowdeepcopy/PersonShallowCopy.java
@@ -1,13 +1,5 @@
 package com.baeldung.shallowdeepcopy;
 
-class AddressShallowCopy {
-    String city;
-
-    AddressShallowCopy(String city) {
-        this.city = city;
-    }
-}
-
 class PersonShallowCopy implements Cloneable {
     String name;
     AddressShallowCopy address;
@@ -17,10 +9,8 @@ class PersonShallowCopy implements Cloneable {
         this.address = address;
     }
 
-    // Creates a shallow copy of the Person object
     @Override
     protected Object clone() throws CloneNotSupportedException {
-        return super.clone(); // Shallow copy
+        return super.clone();
     }
 }
-

--- a/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/shallowdeepcopy/PersonShallowCopy.java
+++ b/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/shallowdeepcopy/PersonShallowCopy.java
@@ -1,0 +1,26 @@
+package com.baeldung.shallowdeepcopy;
+
+class AddressShallowCopy {
+    String city;
+
+    AddressShallowCopy(String city) {
+        this.city = city;
+    }
+}
+
+class PersonShallowCopy implements Cloneable {
+    String name;
+    AddressShallowCopy address;
+
+    PersonShallowCopy(String name, AddressShallowCopy address) {
+        this.name = name;
+        this.address = address;
+    }
+
+    // Creates a shallow copy of the Person object
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        return super.clone(); // Shallow copy
+    }
+}
+

--- a/core-java-modules/core-java-lang-5/src/test/java/com/baeldung/shallowdeepcopy/PersonDeepCopyTest.java
+++ b/core-java-modules/core-java-lang-5/src/test/java/com/baeldung/shallowdeepcopy/PersonDeepCopyTest.java
@@ -1,0 +1,19 @@
+package com.baeldung.shallowdeepcopy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PersonDeepCopyTest {
+
+    @Test
+    public void testDeepCopy() {
+        AddressDeepCopy address = new AddressDeepCopy("New York");
+        PersonDeepCopy person1 = new PersonDeepCopy("John", address);
+        PersonDeepCopy person2 = person1.clone();
+
+        person2.address.city = "San Francisco";
+
+        assertEquals("New York", person1.address.city);
+    }
+}

--- a/core-java-modules/core-java-lang-5/src/test/java/com/baeldung/shallowdeepcopy/PersonDeepCopyTest.java
+++ b/core-java-modules/core-java-lang-5/src/test/java/com/baeldung/shallowdeepcopy/PersonDeepCopyTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class PersonDeepCopyTest {
 
     @Test
-    public void testDeepCopy() {
+    public void whenDeepCopyingPerson_thenAddressIsDeepCopied() {
         AddressDeepCopy address = new AddressDeepCopy("New York");
         PersonDeepCopy person1 = new PersonDeepCopy("John", address);
         PersonDeepCopy person2 = person1.clone();

--- a/core-java-modules/core-java-lang-5/src/test/java/com/baeldung/shallowdeepcopy/PersonShallowCopyTest.java
+++ b/core-java-modules/core-java-lang-5/src/test/java/com/baeldung/shallowdeepcopy/PersonShallowCopyTest.java
@@ -1,0 +1,18 @@
+package com.baeldung.shallowdeepcopy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PersonShallowCopyTest {
+    @Test
+    public void testShallowCopy() throws CloneNotSupportedException {
+        AddressShallowCopy address = new AddressShallowCopy("New York");
+        PersonShallowCopy person1 = new PersonShallowCopy("John", address);
+        PersonShallowCopy person2 = (PersonShallowCopy) person1.clone();
+
+        person2.address.city = "San Francisco";
+
+        assertEquals("San Francisco", person1.address.city);
+    }
+}

--- a/core-java-modules/core-java-lang-5/src/test/java/com/baeldung/shallowdeepcopy/PersonShallowCopyTest.java
+++ b/core-java-modules/core-java-lang-5/src/test/java/com/baeldung/shallowdeepcopy/PersonShallowCopyTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class PersonShallowCopyTest {
     @Test
-    public void testShallowCopy() throws CloneNotSupportedException {
+    public void whenShallowCopyingPerson_thenAddressIsShallowCopied() throws CloneNotSupportedException {
         AddressShallowCopy address = new AddressShallowCopy("New York");
         PersonShallowCopy person1 = new PersonShallowCopy("John", address);
         PersonShallowCopy person2 = (PersonShallowCopy) person1.clone();


### PR DESCRIPTION
Adds functionality for both shallow and deep copying with examples and test cases.

Key Changes:

Shallow Copy: Implemented PersonShallowCopy and AddressShallowCopy classes, with the clone() method for shallow copying.
Deep Copy: Introduced PersonDeepCopy and AddressDeepCopy classes, with deepCopy() methods for deep copying.

Testing:

- Includes test cases demonstrating shallow copy by verifying shared Address references.
- Includes test cases demonstrating deep copy by ensuring separate Address instances in the cloned objects.