### PR TITLE
Add PDF Generation Unit Tests and Update Dependencies

### DIFF
--- a/testing-modules/selenium-2/pom.xml
+++ b/testing-modules/selenium-2/pom.xml
@@ -52,8 +52,8 @@
 
     <properties>
         <testng.version>7.10.2</testng.version>
-        <selenium-java.version>4.21.0</selenium-java.version>
-        <webdrivermanager.version>5.8.0</webdrivermanager.version>
+        <selenium-java.version>4.23.1</selenium-java.version>
+        <webdrivermanager.version>5.9.2</webdrivermanager.version>
     </properties>
 
 </project>

--- a/testing-modules/selenium-2/src/test/java/com/baeldung/selenium/generatePDF/GeneratePDFsUnitTests.java
+++ b/testing-modules/selenium-2/src/test/java/com/baeldung/selenium/generatePDF/GeneratePDFsUnitTests.java
@@ -1,0 +1,82 @@
+package com.baeldung.selenium.generatePDF;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Pdf;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.print.PageMargin;
+import org.openqa.selenium.print.PageSize;
+import org.openqa.selenium.print.PrintOptions;
+
+public class GeneratePDFsUnitTests {
+
+    @Test
+    public void whenNavigatingToBaeldung_thenPDFIsGenerated() throws IOException {
+        ChromeDriver driver = new ChromeDriver();
+        driver.get("https://www.baeldung.com/library/java-web-weekly");
+        Pdf pdf = driver.print(new PrintOptions());
+        byte[] pdfContent = Base64.getDecoder()
+            .decode(pdf.getContent());
+        Files.write(Paths.get("./Baeldung_Weekly.pdf"), pdfContent);
+        assertTrue(Files.exists(Paths.get("./Baeldung_Weekly.pdf")), "PDF file should be created");
+        driver.quit();
+    }
+
+    @Test
+    public void whenCustomizingPDFOutput_thenAdvancedCustomPDFIsGenerated() throws IOException {
+        ChromeDriver driver = new ChromeDriver();
+        driver.get("https://www.baeldung.com/library/java-web-weekly");
+
+        PrintOptions options = new PrintOptions();
+
+        options.setOrientation(PrintOptions.Orientation.LANDSCAPE);
+        options.setScale(1.5);
+        options.setPageSize(new PageSize(100, 100));
+        options.setPageMargin(new PageMargin(2, 2, 2, 2));
+
+        Pdf pdf = driver.print(options);
+
+        byte[] pdfContent = Base64.getDecoder().decode(pdf.getContent());
+        Files.write(Paths.get("./Custom_Baeldung_Weekly.pdf"), pdfContent);
+        assertTrue(Files.exists(Paths.get("./Custom_Baeldung_Weekly.pdf")), "Custom PDF file should be created");
+        driver.quit();
+    }
+
+    @Test
+    public void whenRunningInHeadlessMode_thenPDFIsGenerated() throws IOException {
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--headless");
+
+        ChromeDriver driver = new ChromeDriver(options);
+        driver.get("https://www.baeldung.com/library/java-web-weekly");
+        Pdf pdf = driver.print(new PrintOptions());
+        byte[] pdfContent = Base64.getDecoder()
+            .decode(pdf.getContent());
+        Files.write(Paths.get("./Headless_Baeldung_Weekly.pdf"), pdfContent);
+        assertTrue(Files.exists(Paths.get("./Headless_Baeldung_Weekly.pdf")), "Headless PDF file should be created");
+        driver.quit();
+    }
+
+    @Test
+    public void whenNavigatingToBaeldungWithFirefox_thenPDFIsGenerated() throws IOException {
+        FirefoxDriver driver = new FirefoxDriver(new FirefoxOptions());
+        driver.get("https://www.baeldung.com/library/java-web-weekly");
+        Pdf pdf = driver.print(new PrintOptions());
+        byte[] pdfContent = Base64.getDecoder()
+            .decode(pdf.getContent());
+        Files.write(Paths.get("./Firefox_Weekly.pdf"), pdfContent);
+        assertTrue(Files.exists(Paths.get("./Firefox_Weekly.pdf")), "PDF file should be created");
+        driver.quit();
+    }
+
+
+}

--- a/testing-modules/selenium-2/src/test/java/com/baeldung/selenium/generatepdf/GeneratePDFsUnitTests.java
+++ b/testing-modules/selenium-2/src/test/java/com/baeldung/selenium/generatepdf/GeneratePDFsUnitTests.java
@@ -1,4 +1,4 @@
-package com.baeldung.selenium.generatePDF;
+package com.baeldung.selenium.generatepdf;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 


### PR DESCRIPTION
1. Added `GeneratePDFsUnitTests.java` to demonstrate PDF generation using the` print()` method in Selenium, including customization options with PrintOptions.
2. Updated` pom.xml` to include the necessary dependencies for Selenium and WebDriverManager.

Draft:  [How to Generate PDF With Selenium](https://drafts.baeldung.com/?p=211550&preview=true)
