### PR TITLE
[DRAFT] Add Shallow and Deep Clone Examples 

### DIFF
--- a/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/deepshallowcopyv2/Address.java
+++ b/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/deepshallowcopyv2/Address.java
@@ -1,0 +1,32 @@
+package com.baeldung.deepshallowcopyv2;
+
+public class Address implements Cloneable {
+    private String city;
+    private String state;
+
+    public Address(String city, String state) {
+        this.city = city;
+        this.state = state;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        return super.clone(); // Shallow copy for Address
+    }
+}

--- a/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/deepshallowcopyv2/Person.java
+++ b/core-java-modules/core-java-lang-5/src/main/java/com/baeldung/deepshallowcopyv2/Person.java
@@ -1,0 +1,38 @@
+package com.baeldung.deepshallowcopyv2;
+
+public class Person implements Cloneable {
+    private String name;
+    private Address address;
+
+    public Person(String name, Address address) {
+        this.name = name;
+        this.address = address;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        return super.clone(); // Shallow copy for Person
+    }
+
+    public Person deepClone() throws CloneNotSupportedException {
+        Person clonedPerson = (Person) super.clone(); // Shallow copy of Person
+        clonedPerson.address = (Address) address.clone(); // Deep copy of Address
+        return clonedPerson;
+    }
+}

--- a/core-java-modules/core-java-lang-5/src/test/java/com/baeldung/deepshallowcopyv2/PersonDeepShallowTest.java
+++ b/core-java-modules/core-java-lang-5/src/test/java/com/baeldung/deepshallowcopyv2/PersonDeepShallowTest.java
@@ -1,0 +1,38 @@
+package com.baeldung.deepshallowcopyv2;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class PersonDeepShallowTest {
+
+    @Test
+    void givenPerson_whenShallowClone_thenAddressIsShared() throws CloneNotSupportedException {
+        Address address = new Address("New York", "NY");
+        Person person1 = new Person("John", address);
+
+        // Shallow Copy
+        Person person2 = (Person) person1.clone();
+
+        // Modify the address in person2
+        person2.getAddress().setCity("Los Angeles");
+
+        // person1 and person2 should share the same Address object
+        assertEquals(person1.getAddress().getCity(), person2.getAddress().getCity());
+    }
+
+    @Test
+    void givenPerson_whenDeepClone_thenAddressIsDifferent() throws CloneNotSupportedException {
+        Address address = new Address("New York", "NY");
+        Person person1 = new Person("John", address);
+
+        // Deep Copy
+        Person person3 = person1.deepClone();
+
+        // Modify the address in person3
+        person3.getAddress().setCity("Chicago");
+
+        // person1 and person3 should have different Address objects
+        assertNotEquals(person1.getAddress().getCity(), person3.getAddress().getCity());
+    }
+}


### PR DESCRIPTION
## *Draft Article:* https://drafts.baeldung.com/?p=212650&preview=true
**Description:**

This PR introduces a new package `com.baeldung.deepshallowcopyv2` with examples demonstrating shallow and deep cloning in Java. It includes:

1. **`Person` Class**:
   - Implements the `Cloneable` interface.
   - Provides methods for both shallow cloning (using `super.clone()`) and deep cloning (by manually cloning mutable objects).

2. **`Address` Class**:
   - Implements `Cloneable` and supports shallow cloning.

3. **Unit Tests**:
   - **`PersonDeepShallowTest.java`**: 
     - `givenPerson_whenShallowClone_thenAddressIsShared`: Verifies that a shallow clone shares the same `Address` object.
     - `givenPerson_whenDeepClone_thenAddressIsDifferent`: Ensures that a deep clone has a distinct `Address` object.

### Summary of Changes

- Added `Address` class with shallow cloning implementation.
- Added `Person` class with both shallow and deep cloning implementations.
- Created unit tests to validate the behavior of shallow and deep cloning.

### Code Overview

**`Address.java`**:
- Implements `Cloneable` interface.
- Provides shallow copy functionality.

**`Person.java`**:
- Implements `Cloneable` interface.
- Provides methods for shallow and deep copying, ensuring proper copying of mutable fields.

**`PersonDeepShallowTest.java`**:
- Contains JUnit 5 tests for verifying the cloning functionality.

### Testing

- Unit tests are written using JUnit 5.
- Tests cover both shallow and deep cloning scenarios to ensure correctness.
