### PR TITLE
BAEL-8470: @MapsId Annotation in Hibernate

### DIFF
--- a/persistence-modules/hibernate-annotations-2/src/main/java/com/baeldung/hibernate/mapsid/Address.java
+++ b/persistence-modules/hibernate-annotations-2/src/main/java/com/baeldung/hibernate/mapsid/Address.java
@@ -1,0 +1,63 @@
+package com.baeldung.hibernate.mapsid;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+
+@Entity
+public class Address {
+
+    @Id
+    private int id;
+    private String street;
+    private String city;
+    private int zipode;
+
+    @OneToOne
+    @JoinColumn(name = "id")
+    @MapsId
+    private Person person;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public int getZipode() {
+        return zipode;
+    }
+
+    public void setZipode(int zipode) {
+        this.zipode = zipode;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public Person getPerson() {
+        return person;
+    }
+
+    public void setPerson(Person person) {
+        this.person = person;
+    }
+
+}

--- a/persistence-modules/hibernate-annotations-2/src/main/java/com/baeldung/hibernate/mapsid/HibernateConfigUtils.java
+++ b/persistence-modules/hibernate-annotations-2/src/main/java/com/baeldung/hibernate/mapsid/HibernateConfigUtils.java
@@ -1,0 +1,41 @@
+package com.baeldung.hibernate.mapsid;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.Environment;
+import org.hibernate.service.ServiceRegistry;
+
+public class HibernateConfigUtils {
+
+    public static SessionFactory sessionFactory() {
+        ServiceRegistry serviceRegistry = new StandardServiceRegistryBuilder().applySettings(getProperties())
+            .build();
+
+        MetadataSources metadataSources = new MetadataSources(serviceRegistry);
+        Metadata metadata = metadataSources.addAnnotatedClass(Person.class)
+            .addAnnotatedClass(Address.class)
+            .getMetadataBuilder()
+            .build();
+
+        return metadata.buildSessionFactory();
+    }
+
+    private static Map<String, Object> getProperties() {
+        Map<String, Object> dbSettings = new HashMap<>();
+        dbSettings.put(Environment.JAKARTA_JDBC_URL, "jdbc:h2:mem:mydbJoinColumn;DB_CLOSE_DELAY=-1");
+        dbSettings.put(Environment.JAKARTA_JDBC_DRIVER, "org.h2.Driver");
+        dbSettings.put(Environment.JAKARTA_JDBC_USER, "sa");
+        dbSettings.put(Environment.JAKARTA_JDBC_PASSWORD, "");
+        dbSettings.put(Environment.CURRENT_SESSION_CONTEXT_CLASS, "thread");
+        dbSettings.put(Environment.SHOW_SQL, "true");
+        dbSettings.put(Environment.HBM2DDL_AUTO, "create");
+
+        return dbSettings;
+    }
+
+}

--- a/persistence-modules/hibernate-annotations-2/src/main/java/com/baeldung/hibernate/mapsid/Person.java
+++ b/persistence-modules/hibernate-annotations-2/src/main/java/com/baeldung/hibernate/mapsid/Person.java
@@ -1,0 +1,49 @@
+package com.baeldung.hibernate.mapsid;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+@Entity
+public class Person {
+
+    @Id
+    private int id;
+    private String firstName;
+    private String lastName;
+    @OneToOne(mappedBy = "person")
+    private Address address;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+}

--- a/persistence-modules/hibernate-annotations-2/src/test/java/com/baeldung/hibernate/mapsid/MapsIdAnnotationIntegrationTest.java
+++ b/persistence-modules/hibernate-annotations-2/src/test/java/com/baeldung/hibernate/mapsid/MapsIdAnnotationIntegrationTest.java
@@ -1,0 +1,50 @@
+package com.baeldung.hibernate.mapsid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MapsIdAnnotationIntegrationTest {
+
+    private Session session;
+    private Transaction transaction;
+
+    @BeforeEach
+    void setUp() {
+        session = HibernateConfigUtils.sessionFactory()
+            .openSession();
+        transaction = session.beginTransaction();
+    }
+
+    @AfterEach
+    void tearDown() {
+        transaction.rollback();
+        session.close();
+    }
+
+    @Test
+    void givenPersonEntityWithIdentifier_whenAddingAddress_thenPersistWithSameIdentifier() {
+        int personId = 3;
+        Person person = new Person();
+        person.setId(personId);
+        person.setFirstName("Azhrioun");
+        person.setLastName("Abderrahim");
+        session.persist(person);
+
+        Address address = new Address();
+        address.setStreet("7 avenue berlin");
+        address.setCity("Tamassint");
+        address.setZipode(13000);
+        address.setPerson(person);
+
+        session.persist(address);
+        Address persistedAddress = session.find(Address.class, personId);
+
+        assertThat(persistedAddress.getId()).isEqualTo(personId);
+    }
+
+}


### PR DESCRIPTION
+ Add two Hibernate entities: _Person_ and _Address_
+ Add a test case to showcase how _@MapsId_ helps to implement shared primary key mapping