### PR TITLE
How to append a newline to stringbuilder

### DIFF
--- a/core-java-modules/core-java-string-operations-10/README.md
+++ b/core-java-modules/core-java-string-operations-10/README.md
@@ -6,4 +6,7 @@
 - [How to Insert an Emoji in a Java String](https://www.baeldung.com/java-string-insert-emoji)
 - [Java Strip Methods](https://www.baeldung.com/java-string-strip-methods)
 - [Find the Substring After the Last Pattern in Java](https://www.baeldung.com/java-string-etract-after-last-occurence-match)
+- [Java StringBuilder and StringBuffer](https://www.baeldung.com/java-string-builder-string-buffer)
+- [Linux Line Break Types](https://www.baeldung.com/linux/line-breaks-types)
+- [String.format() in Java](https://www.baeldung.com/string/format)
 - More articles: [[<-- prev]](../core-java-string-operations-9)

--- a/core-java-modules/core-java-string-operations-10/src/main/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingFormat.java
+++ b/core-java-modules/core-java-string-operations-10/src/main/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingFormat.java
@@ -1,0 +1,11 @@
+package com.baeldung.insertnewlineinstringbuilder;
+
+public class NewlineUsingFormat {
+    public static String getFormattedString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("First Line");
+        sb.append(String.format("%n"));
+        sb.append("Second Line");
+        return sb.toString();
+    }
+}

--- a/core-java-modules/core-java-string-operations-10/src/main/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingLineSeparator.java
+++ b/core-java-modules/core-java-string-operations-10/src/main/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingLineSeparator.java
@@ -1,0 +1,11 @@
+package com.baeldung.insertnewlineinstringbuilder;
+
+public class NewlineUsingLineSeparator {
+    public static String getFormattedString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("First Line");
+        sb.append(System.lineSeparator());
+        sb.append("Second Line");
+        return sb.toString();
+    }
+}

--- a/core-java-modules/core-java-string-operations-10/src/main/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingN.java
+++ b/core-java-modules/core-java-string-operations-10/src/main/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingN.java
@@ -1,0 +1,12 @@
+package com.baeldung.insertnewlineinstringbuilder;
+
+public class NewlineUsingN {
+    public static String getFormattedString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Line 1");
+        sb.append("\n");
+        sb.append("Line 2");
+        return sb.toString();
+    }
+}
+

--- a/core-java-modules/core-java-string-operations-10/src/main/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingProperty.java
+++ b/core-java-modules/core-java-string-operations-10/src/main/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingProperty.java
@@ -1,0 +1,11 @@
+package com.baeldung.insertnewlineinstringbuilder;
+
+public class NewlineUsingProperty {
+    public static String getFormattedString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("First Line");
+        sb.append(System.getProperty("line.separator"));
+        sb.append("Second Line");
+        return sb.toString();
+    }
+}

--- a/core-java-modules/core-java-string-operations-10/src/main/java/com/baeldung/insertnewlineinstringbuilder/StringBuilderHelper.java
+++ b/core-java-modules/core-java-string-operations-10/src/main/java/com/baeldung/insertnewlineinstringbuilder/StringBuilderHelper.java
@@ -1,0 +1,25 @@
+package com.baeldung.insertnewlineinstringbuilder;
+
+public class StringBuilderHelper {
+
+    private StringBuilder sb;
+
+    public StringBuilderHelper() {
+        sb = new StringBuilder();
+    }
+
+    public StringBuilderHelper append(Object obj) {
+        sb.append(obj != null ? obj.toString() : "");
+        return this;
+    }
+
+    public StringBuilderHelper appendLineSeparator() {
+        sb.append(System.lineSeparator());
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return sb.toString();
+    }
+}

--- a/core-java-modules/core-java-string-operations-10/src/test/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingFormatTest.java
+++ b/core-java-modules/core-java-string-operations-10/src/test/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingFormatTest.java
@@ -1,0 +1,14 @@
+package com.baeldung.insertnewlineinstringbuilder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NewlineUsingFormatTest {
+    @Test
+    public void whenUsingLineSeparator_thenCorrectNewlineIsApplied() {
+        String result = NewlineUsingFormat.getFormattedString();
+        String expected = "First Line" + System.lineSeparator() + "Second Line";
+        assertEquals(expected, result);
+    }
+}

--- a/core-java-modules/core-java-string-operations-10/src/test/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingLineSeparatorTest.java
+++ b/core-java-modules/core-java-string-operations-10/src/test/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingLineSeparatorTest.java
@@ -1,0 +1,21 @@
+package com.baeldung.insertnewlineinstringbuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class NewlineUsingLineSeparatorTest {
+
+    @Test
+    public void whenUsingLineSeparator_thenCorrectNewlineIsApplied() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("First Line");
+        sb.append(System.lineSeparator());
+        sb.append("Second Line");
+
+        String expected = "First Line" + System.lineSeparator() + "Second Line";
+        assertEquals(expected, sb.toString());
+    }
+}

--- a/core-java-modules/core-java-string-operations-10/src/test/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingNTest.java
+++ b/core-java-modules/core-java-string-operations-10/src/test/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingNTest.java
@@ -1,0 +1,15 @@
+package com.baeldung.insertnewlineinstringbuilder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class NewlineUsingNTest {
+
+    @Test
+    public void whenUsingN_thenCorrectNewlineIsApplied() {
+        String result = NewlineUsingN.getFormattedString();
+        String expected = "Line 1" + "\n" + "Line 2";
+        assertEquals(expected, result);
+    }
+}

--- a/core-java-modules/core-java-string-operations-10/src/test/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingPropertyTest.java
+++ b/core-java-modules/core-java-string-operations-10/src/test/java/com/baeldung/insertnewlineinstringbuilder/NewlineUsingPropertyTest.java
@@ -1,0 +1,15 @@
+package com.baeldung.insertnewlineinstringbuilder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class NewlineUsingPropertyTest {
+
+    @Test
+    public void whenUsingProperty_thenCorrectNewlineIsApplied() {
+        String result = NewlineUsingProperty.getFormattedString();
+        String expected = "First Line" + System.getProperty("line.separator") + "Second Line";
+        assertEquals(expected, result);
+    }
+}

--- a/core-java-modules/core-java-string-operations-10/src/test/java/com/baeldung/insertnewlineinstringbuilder/StringBuilderHelperTest.java
+++ b/core-java-modules/core-java-string-operations-10/src/test/java/com/baeldung/insertnewlineinstringbuilder/StringBuilderHelperTest.java
@@ -1,0 +1,29 @@
+package com.baeldung.insertnewlineinstringbuilder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StringBuilderHelperTest {
+
+    @Test
+    public void whenAppendingString_thenCorrectStringIsBuilt() {
+        StringBuilderHelper gsBuilder = new StringBuilderHelper();
+        gsBuilder.append("Hello")
+                .appendLineSeparator()
+                .append("World");
+
+        assertEquals("Hello" + System.lineSeparator() + "World", gsBuilder.toString());
+    }
+
+    @Test
+    public void whenAppendingInteger_thenCorrectStringIsBuilt() {
+        StringBuilderHelper gsBuilder = new StringBuilderHelper();
+        gsBuilder.append(123)
+                .appendLineSeparator()
+                .append(456);
+
+        assertEquals("123" + System.lineSeparator() + "456", gsBuilder.toString());
+    }
+
+}


### PR DESCRIPTION
**Key Updates:**

- **Handling Platform-Dependent Newlines:** Explored various methods to manage newlines across different operating systems.
- **Platform-Independent Solutions:** Demonstrated using System.lineSeparator(), System.getProperty("line.separator"), and String.format("%n").
- **Helper Class:** Introduced StringBuilderHelper for simplified newline management and method chaining.
- **Testing:** Verified newline handling and functionality with relevant test cases.