### PR TITLE
Enabling gcp-firebase module in correct profiles [BAEL-8475]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -678,7 +678,7 @@
                 <module>drools</module>
                 <module>dubbo</module>
                 <module>feign</module>
-                <!-- <module>gcp-firebase</module> --> <!-- BAEL-8475 -->
+                <module>gcp-firebase</module>
                 <module>geotools</module>
                 <module>google-auto-project</module>
                 <module>google-cloud</module>
@@ -989,7 +989,6 @@
                 <module>drools</module>
                 <module>dubbo</module>
                 <module>feign</module>
-                <module>gcp-firebase</module>
                 <module>geotools</module>
                 <module>google-auto-project</module>
                 <module>google-cloud</module>
@@ -1203,7 +1202,7 @@
                 <module>apache-libraries</module>
                 <module>apache-spark</module> <!-- failing after upgrading to jdk17 -->
                 <module>atomix</module>
-                <!-- <module>gcp-firebase</module> --> <!-- BAEL-8475 -->
+                <module>gcp-firebase</module>
                 <module>libraries-data-io</module>
                 <module>persistence-modules/spring-data-jpa-enterprise</module>
                 <module>persistence-modules/spring-data-jpa-query-2</module>

--- a/pom.xml
+++ b/pom.xml
@@ -989,6 +989,7 @@
                 <module>drools</module>
                 <module>dubbo</module>
                 <module>feign</module>
+                <module>gcp-firebase</module>
                 <module>geotools</module>
                 <module>google-auto-project</module>
                 <module>google-cloud</module>


### PR DESCRIPTION
PR enables the `gcp-firebase` module in the `default` and `live-all` profile.