### PR TITLE
BAEL-8160-Fix: Use in-memory HSQLDB to avoid file creation issues in CI/CD

### DIFF
--- a/parent-boot-2/pom.xml
+++ b/parent-boot-2/pom.xml
@@ -109,7 +109,7 @@
         <mysql-connector-java.version>8.2.0</mysql-connector-java.version>
         <org.slf4j.version>1.7.32</org.slf4j.version>
         <logback.version>1.2.7</logback.version>
-        <hsqldb.version>2.7.1</hsqldb.version>
+        <hsqldb.version>2.5.1</hsqldb.version>
     </properties>
 
 </project>

--- a/testing-modules/spring-testing-2/src/test/resources/application-hsql.properties
+++ b/testing-modules/spring-testing-2/src/test/resources/application-hsql.properties
@@ -1,4 +1,4 @@
 spring.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
-spring.datasource.url=jdbc:hsqldb:hsql/testdb
+spring.datasource.url=jdbc:hsqldb:mem:testdb
 spring.jpa.database-platform=org.hibernate.dialect.HSQLDialect
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
* Switched the database configuration to use an in-memory HSQLDB instance instead of creating a file-based database. This change addresses permission issues encountered during CI/CD, where file creation rights were not permitted.