### PR TITLE
Fixed test added anotation and line seperator

### DIFF
--- a/text-processing-libraries-modules/pdf/src/test/java/com/baeldung/addheaderfooterpdf/AddHeaderFooterToPDFUnitTest.java
+++ b/text-processing-libraries-modules/pdf/src/test/java/com/baeldung/addheaderfooterpdf/AddHeaderFooterToPDFUnitTest.java
@@ -7,16 +7,21 @@ import com.itextpdf.layout.Document;
 import com.itextpdf.layout.element.Paragraph;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 
 import java.io.File;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@TestMethodOrder(OrderAnnotation.class)
 public class AddHeaderFooterToPDFUnitTest {
 
     @Test
+    @Order(1)
     void givenHeaderAndFooter_whenCreatingPDF_thenHeaderFooterAreOnEachPage() throws IOException {
         String dest = "documentWithHeaderFooter.pdf";
         PdfWriter writer = new PdfWriter(dest);
@@ -31,6 +36,7 @@ public class AddHeaderFooterToPDFUnitTest {
     }
 
     @Test
+    @Order(2)
     void givenHeaderAndFooter_whenTestingPDF_thenHeaderFooterAreVerified() throws IOException {
         String dest = "documentWithHeaderFooter.pdf";
 

--- a/text-processing-libraries-modules/pdf/src/test/java/com/baeldung/pdfreadertest/ReadPdfFileUnitTest.java
+++ b/text-processing-libraries-modules/pdf/src/test/java/com/baeldung/pdfreadertest/ReadPdfFileUnitTest.java
@@ -16,7 +16,7 @@ class ReadPdfFileUnitTest {
 
     @Test
     public void givenSamplePdf_whenUsingApachePdfBox_thenCompareOutput() throws IOException {
-        String expectedText = "Hello World!\n";
+        String expectedText = "Hello World!" + System.lineSeparator();
 
         File file = new File("sample.pdf");
         PDDocument document = PDDocument.load(file);


### PR DESCRIPTION
AddHeaderFooterToPDFUnitTest - added @Order annotation to enforce tests to run in the specific order.
ReadPdfFileUnitTest- added Line separator to make this a platform independent.