### PR TITLE
upgrade/spring-ai-version/module/spring-ai-2 [BAEL-9132]

### DIFF
--- a/spring-ai-2/pom.xml
+++ b/spring-ai-2/pom.xml
@@ -121,7 +121,7 @@
 
    <properties>
        <spring-boot.version>3.4.1</spring-boot.version>
-       <spring-ai.version>1.0.0-M5</spring-ai.version>
+       <spring-ai.version>1.0.0-M6</spring-ai.version>
        <junit-jupiter.version>5.9.0</junit-jupiter.version>
    </properties>
 

--- a/spring-ai-2/src/main/java/com/baeldung/spring/ai/om/OrderManagementAIAssistant.java
+++ b/spring-ai-2/src/main/java/com/baeldung/spring/ai/om/OrderManagementAIAssistant.java
@@ -16,7 +16,7 @@ public class OrderManagementAIAssistant {
     public ChatResponse callChatClient(Set<String> functionNames, String promptString) {
         Prompt prompt  = new Prompt(promptString, OpenAiChatOptions
             .builder()
-            .withFunctions(functionNames)
+            .functions(functionNames)
             .build()
         );
         return chatClient.call(prompt);

--- a/spring-ai-2/src/main/java/com/baeldung/spring/ai/om/OrderManagementApplication.java
+++ b/spring-ai-2/src/main/java/com/baeldung/spring/ai/om/OrderManagementApplication.java
@@ -1,9 +1,25 @@
 package com.baeldung.spring.ai.om;
 
+import org.springframework.ai.autoconfigure.anthropic.AnthropicAutoConfiguration;
+import org.springframework.ai.autoconfigure.bedrock.converse.BedrockConverseProxyChatAutoConfiguration;
+import org.springframework.ai.autoconfigure.ollama.OllamaAutoConfiguration;
+import org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.PropertySource;
 
-@SpringBootApplication
+/**
+ * Excluding the below auto-configurations to avoid start up
+ * failure. Their corresponding starters are present on the classpath but are
+ * only needed by other articles in the shared codebase.
+ */
+@SpringBootApplication(exclude = {
+	OllamaAutoConfiguration.class,
+	AnthropicAutoConfiguration.class,
+	ChromaVectorStoreAutoConfiguration.class,
+	BedrockConverseProxyChatAutoConfiguration.class
+})
+@PropertySource("classpath:application-aiassistant.properties")
 public class OrderManagementApplication {
 
 	public static void main(String[] args) {

--- a/spring-ai-2/src/main/java/com/baeldung/spring/ai/om/OrderManagementApplication.java
+++ b/spring-ai-2/src/main/java/com/baeldung/spring/ai/om/OrderManagementApplication.java
@@ -14,10 +14,10 @@ import org.springframework.context.annotation.PropertySource;
  * only needed by other articles in the shared codebase.
  */
 @SpringBootApplication(exclude = {
-	OllamaAutoConfiguration.class,
-	AnthropicAutoConfiguration.class,
-	ChromaVectorStoreAutoConfiguration.class,
-	BedrockConverseProxyChatAutoConfiguration.class
+    OllamaAutoConfiguration.class,
+    AnthropicAutoConfiguration.class,
+    ChromaVectorStoreAutoConfiguration.class,
+    BedrockConverseProxyChatAutoConfiguration.class
 })
 @PropertySource("classpath:application-aiassistant.properties")
 public class OrderManagementApplication {

--- a/spring-ai-2/src/main/java/com/baeldung/springai/chromadb/Application.java
+++ b/spring-ai-2/src/main/java/com/baeldung/springai/chromadb/Application.java
@@ -1,10 +1,18 @@
 package com.baeldung.springai.chromadb;
 
+import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
 
-@SpringBootApplication
+/**
+ * Excluding the below auto-configurations to avoid start up
+ * failure. Their corresponding starters are present on the classpath but are
+ * only needed by other articles in the shared codebase.
+ */
+@SpringBootApplication(exclude = {
+    OpenAiAutoConfiguration.class
+})
 @PropertySource("classpath:application-chromadb.properties")
 public class Application {
 

--- a/spring-ai-2/src/main/java/com/baeldung/springai/huggingface/Application.java
+++ b/spring-ai-2/src/main/java/com/baeldung/springai/huggingface/Application.java
@@ -1,5 +1,7 @@
 package com.baeldung.springai.huggingface;
 
+import org.springframework.ai.autoconfigure.anthropic.AnthropicAutoConfiguration;
+import org.springframework.ai.autoconfigure.bedrock.converse.BedrockConverseProxyChatAutoConfiguration;
 import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;
 import org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration;
 import org.springframework.boot.SpringApplication;
@@ -13,7 +15,9 @@ import org.springframework.context.annotation.PropertySource;
  */
 @SpringBootApplication(exclude = {
     OpenAiAutoConfiguration.class,
-    ChromaVectorStoreAutoConfiguration.class
+    AnthropicAutoConfiguration.class,
+    ChromaVectorStoreAutoConfiguration.class,
+    BedrockConverseProxyChatAutoConfiguration.class
 })
 @PropertySource("classpath:application-huggingface.properties")
 public class Application {

--- a/spring-ai-2/src/main/resources/application-aiassistant.properties
+++ b/spring-ai-2/src/main/resources/application-aiassistant.properties
@@ -8,4 +8,3 @@ spring.jpa.hibernate.ddl-auto=none
 
 spring.ai.openai.chat.options.model=gpt-4o-mini
 spring.ai.openai.api-key=xxxxxxx
-spring.autoconfigure.exclude=org.springframework.ai.autoconfigure.ollama.OllamaAutoConfiguration,org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration

--- a/spring-ai-2/src/test/java/com/baeldung/spring/ai/om/AiOrderManagementLiveTest.java
+++ b/spring-ai-2/src/test/java/com/baeldung/spring/ai/om/AiOrderManagementLiveTest.java
@@ -16,7 +16,6 @@ import org.springframework.test.context.jdbc.Sql;
 
 @SpringBootTest
 @ActiveProfiles("aiassistant")
-
 @Sql(scripts = "classpath:/order_mgmt.sql", executionPhase = BEFORE_TEST_CLASS)
 public class AiOrderManagementLiveTest {
 
@@ -34,7 +33,7 @@ public class AiOrderManagementLiveTest {
     void whenOrderInfoProvided_thenSaveInDB(String promptString) {
        ChatResponse response = this.orderManagementAIAssistant
            .callChatClient(Set.of("createOrderFn"), promptString);
-        String resultContent = response.getResult().getOutput().getContent();
+        String resultContent = response.getResult().getOutput().getText();
         logger.info("The response from the LLM service: {}", resultContent);
     }
 
@@ -46,7 +45,7 @@ public class AiOrderManagementLiveTest {
             .callChatClient(Set.of("getUserOrdersFn"), promptString);
         String resultContent = response.getResult()
             .getOutput()
-            .getContent();
+            .getText();
         logger.info("The response from the LLM service: {}", resultContent);
     }
 
@@ -64,7 +63,7 @@ public class AiOrderManagementLiveTest {
             .callChatClient(Set.of("getUserOrdersFn", "createOrderFn"), promptString);
         String resultContent = response.getResult()
             .getOutput()
-            .getContent();
+            .getText();
         logger.info("The response from the LLM service: {}", resultContent);
     }
 
@@ -75,7 +74,7 @@ public class AiOrderManagementLiveTest {
             .callChatClient(Set.of("createOrderFn"), promptString);
         String resultContent = response.getResult()
             .getOutput()
-            .getContent();
+            .getText();
         logger.info("The response from the LLM service: {}", resultContent);
     }
 }

--- a/spring-ai-2/src/test/java/com/baeldung/springai/chromadb/SemanticSearchLiveTest.java
+++ b/spring-ai-2/src/test/java/com/baeldung/springai/chromadb/SemanticSearchLiveTest.java
@@ -26,8 +26,10 @@ class SemanticSearchLiveTest {
     @ValueSource(strings = {"Love and Romance", "Time and Mortality", "Jealousy and Betrayal"})
     void whenSearchingShakespeareTheme_thenRelevantPoemsReturned(String theme) {
         SearchRequest searchRequest = SearchRequest
+            .builder()
             .query(theme)
-            .withTopK(MAX_RESULTS);
+            .topK(MAX_RESULTS)
+            .build();
         List<Document> documents = vectorStore.similaritySearch(searchRequest);
 
         assertThat(documents)

--- a/spring-ai-2/src/test/java/com/baeldung/springai/evaluator/LLMResponseEvaluatorLiveTest.java
+++ b/spring-ai-2/src/test/java/com/baeldung/springai/evaluator/LLMResponseEvaluatorLiveTest.java
@@ -38,7 +38,7 @@ class LLMResponseEvaluatorLiveTest {
             .call()
             .chatResponse();
 
-        String answer = chatResponse.getResult().getOutput().getContent();
+        String answer = chatResponse.getResult().getOutput().getText();
         List<Document> documents = chatResponse.getMetadata().get(QuestionAnswerAdvisor.RETRIEVED_DOCUMENTS);
         EvaluationRequest evaluationRequest = new EvaluationRequest(question, documents, answer);
 
@@ -86,7 +86,7 @@ class LLMResponseEvaluatorLiveTest {
             .call()
             .chatResponse();
 
-        String answer = chatResponse.getResult().getOutput().getContent();
+        String answer = chatResponse.getResult().getOutput().getText();
         List<Document> documents = chatResponse.getMetadata().get(QuestionAnswerAdvisor.RETRIEVED_DOCUMENTS);
         EvaluationRequest evaluationRequest = new EvaluationRequest(question, documents, answer);
 


### PR DESCRIPTION
This PR upgrades `spring-ai` to the latest `1.0.0-M6` version in the `spring-ai-2` module.

It fixes the compilation and startup failures.

Only the methods removed in the latest version are replaced by their counterparts, the methods/classes that are deprecated but are still present in the library have not been replaced.