### PR TITLE
bael-8622 getAndIncrement - fix based on email feedback

### DIFF
--- a/core-java-modules/core-java-concurrency-advanced-6/src/main/java/com/baeldung/atomic/AtomicLoadBalancer.java
+++ b/core-java-modules/core-java-concurrency-advanced-6/src/main/java/com/baeldung/atomic/AtomicLoadBalancer.java
@@ -12,8 +12,7 @@ public class AtomicLoadBalancer {
     }
 
     public String getServer() {
-        int index = counter.get() % serverList.size();
-        counter.incrementAndGet();
+        int index = counter.getAndIncrement() % serverList.size();
         return serverList.get(index);
     }
 


### PR DESCRIPTION
Quote:
```
I believe there is a mistake in the code in Section 6 of the article https://www.baeldung.com/java-atomicinteger-load-balancer

Specifically, the current code is:
public String getServer() {
    int index = counter.get() % serverList.size();
    counter.incrementAndGet();
    return serverList.get(index);
}

But I believe the correct code should be:
public String getServer() {
    int index = counter.getAndIncrement() % serverList.size();
    return serverList.get(index);
}

In the current code of the article, several threads could be calling getServer() at the same time, execute counter.get() in sequence, all get the same server number (index), before each incrementing the counter. This would mean one server gets more uses, and other servers are skipped, breaking a fair round-robin strategy.
```