### PR TITLE
BAEL-9176 Code and Unit Tests for Converting Nested Loops to Streams in Java

### DIFF
--- a/core-java-modules/core-java-streams-2/src/main/java/com/baeldung/streams/NestedLoopsToStreamsConverter.java
+++ b/core-java-modules/core-java-streams-2/src/main/java/com/baeldung/streams/NestedLoopsToStreamsConverter.java
@@ -1,0 +1,64 @@
+package com.baeldung.streams;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+
+import java.util.stream.Collectors;
+
+public class NestedLoopsToStreamsConverter {
+
+    public static List<int[]> getAllPairsImperative(List<Integer> list1, List<Integer> list2) {
+        List<int[]> pairs = new ArrayList<>();
+        for (Integer num1 : list1) {
+            for (Integer num2 : list2) {
+                pairs.add(new int[] { num1, num2 });
+            }
+        }
+        return pairs;
+    }
+
+    public static List<int[]> getAllPairsStream(List<Integer> list1, List<Integer> list2) {
+        return list1.stream()
+            .flatMap(num1 -> list2.stream().map(num2 -> new int[] { num1, num2 }))
+            .collect(Collectors.toList());
+    }
+
+    public static List<int[]> getFilteredPairsImperative(List<Integer> list1, List<Integer> list2) {
+        List<int[]> pairs = new ArrayList<>();
+        for (Integer num1 : list1) {
+            for (Integer num2 : list2) {
+                if (num1 + num2 > 7) {
+                    pairs.add(new int[] { num1, num2 });
+                }
+            }
+        }
+        return pairs;
+    }
+
+    public static List<int[]> getFilteredPairsStream(List<Integer> list1, List<Integer> list2) {
+        return list1.stream()
+            .flatMap(num1 -> list2.stream().map(num2 -> new int[] { num1, num2 }))
+            .filter(pair -> pair[0] + pair[1] > 7)
+            .collect(Collectors.toList());
+    }
+
+    public static Optional<int[]> getFirstMatchingPairImperative(List<Integer> list1, List<Integer> list2) {
+        for (Integer num1 : list1) {
+            for (Integer num2 : list2) {
+                if (num1 + num2 > 7) {
+                    return Optional.of(new int[] { num1, num2 });
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static Optional<int[]> getFirstMatchingPairStream(List<Integer> list1, List<Integer> list2) {
+        return list1.stream()
+            .flatMap(num1 -> list2.stream().map(num2 -> new int[] { num1, num2 }))
+            .filter(pair -> pair[0] + pair[1] > 7)
+            .findFirst();
+    }
+
+}

--- a/core-java-modules/core-java-streams-2/src/test/java/com/baeldung/streams/NestedLoopsToStreamsConverterUnitTest.java
+++ b/core-java-modules/core-java-streams-2/src/test/java/com/baeldung/streams/NestedLoopsToStreamsConverterUnitTest.java
@@ -1,0 +1,51 @@
+package com.baeldung.streams;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Test;
+
+public class NestedLoopsToStreamsConverterUnitTest {
+
+    @Test
+    public void givenTwoLists_whenGeneratingAllPairs_thenResultsShouldMatch() {
+        List<Integer> list1 = Arrays.asList(1, 2, 3);
+        List<Integer> list2 = Arrays.asList(4, 5, 6);
+
+        List<int[]> imperativeResult = NestedLoopsToStreamsConverter.getAllPairsImperative(list1, list2);
+        List<int[]> streamResult = NestedLoopsToStreamsConverter.getAllPairsStream(list1, list2);
+        assertEquals(imperativeResult.size(), streamResult.size());
+        for (int i = 0; i < imperativeResult.size(); i++) {
+            assertArrayEquals(imperativeResult.get(i), streamResult.get(i));
+        }
+    }
+
+    @Test
+    public void givenTwoLists_whenFilteringPairsBySum_thenResultsShouldMatch() {
+        List<Integer> list1 = Arrays.asList(1, 2, 3);
+        List<Integer> list2 = Arrays.asList(4, 5, 6);
+
+        List<int[]> imperativeResult = NestedLoopsToStreamsConverter.getFilteredPairsImperative(list1, list2);
+        List<int[]> streamResult = NestedLoopsToStreamsConverter.getFilteredPairsStream(list1, list2);
+        assertEquals(imperativeResult.size(), streamResult.size());
+        for (int i = 0; i < imperativeResult.size(); i++) {
+            assertArrayEquals(imperativeResult.get(i), streamResult.get(i));
+        }
+    }
+
+    @Test
+    public void givenTwoLists_whenFindingFirstMatchingPair_thenResultsShouldMatch() {
+        List<Integer> list1 = Arrays.asList(1, 2, 3);
+        List<Integer> list2 = Arrays.asList(4, 5, 6);
+
+        Optional<int[]> imperativeResult = NestedLoopsToStreamsConverter.getFirstMatchingPairImperative(list1, list2);
+        Optional<int[]> streamResult = NestedLoopsToStreamsConverter.getFirstMatchingPairStream(list1, list2);
+        assertEquals(imperativeResult.isPresent(), streamResult.isPresent());
+        imperativeResult.ifPresent(pair -> assertArrayEquals(pair, streamResult.get()));
+    }
+
+}


### PR DESCRIPTION
BAEL-9176 Code and Unit Tests for Converting Nested Loops to Streams in Java

- Implements the solution showcasing three use-cases: 
looping through all the elements, lopping through elements 
and using a filter, looping through elements and short-circuiting.
- Provides unit tests for each of the implemented use-cases.