### PR TITLE
fix/module/spring-ai-2

### DIFF
--- a/spring-ai-2/pom.xml
+++ b/spring-ai-2/pom.xml
@@ -117,13 +117,79 @@
        </dependency>
    </dependencies>
 
+    <profiles>
+        <profile>
+            <id>chromadb</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <spring.boot.mainclass>com.baeldung.springai.chromadb.Application</spring.boot.mainclass>
+            </properties>
+        </profile>
+        <profile>
+            <id>assistant</id>
+            <properties>
+                <spring.boot.mainclass>com.baeldung.spring.ai.om.OrderManagementApplication</spring.boot.mainclass>
+            </properties>
+        </profile>
+        <profile>
+            <id>anthropic</id>
+            <properties>
+                <spring.boot.mainclass>com.baeldung.springai.anthropic.Application</spring.boot.mainclass>
+            </properties>
+        </profile>
+        <profile>
+            <id>deepseek</id>
+            <properties>
+                <spring.boot.mainclass>com.baeldung.springai.deepseek.Application</spring.boot.mainclass>
+            </properties>
+        </profile>
+        <profile>
+            <id>evaluator</id>
+            <properties>
+                <spring.boot.mainclass>com.baeldung.springai.evaluator.Application</spring.boot.mainclass>
+            </properties>
+        </profile>
+        <profile>
+            <id>hugging-face</id>
+            <properties>
+                <spring.boot.mainclass>com.baeldung.springai.huggingface.Application</spring.boot.mainclass>
+            </properties>
+        </profile>
+        <profile>
+            <id>mcp-server</id>
+            <properties>
+                <spring.boot.mainclass>com.baeldung.springai.mcp.server.ServerApplication</spring.boot.mainclass>
+            </properties>
+        </profile>
+        <profile>
+            <id>mcp-client</id>
+            <properties>
+                <spring.boot.mainclass>com.baeldung.springai.mcp.client.ClientApplication</spring.boot.mainclass>
+            </properties>
+        </profile>
+        <profile>
+            <id>amazon-nova</id>
+            <properties>
+                <spring.boot.mainclass>com.baeldung.springai.nova.Application</spring.boot.mainclass>
+            </properties>
+        </profile>
+        <profile>
+            <id>pgvector</id>
+            <properties>
+                <spring.boot.mainclass>com.baeldung.springai.semanticsearch.Application</spring.boot.mainclass>
+            </properties>
+        </profile>
+    </profiles>
+
    <build>
        <plugins>
            <plugin>
                <groupId>org.springframework.boot</groupId>
                <artifactId>spring-boot-maven-plugin</artifactId>
                <configuration>
-                   <mainClass>com.baeldung.springai.chromadb.Application</mainClass>
+                   <mainClass>${spring.boot.mainclass}</mainClass>
                </configuration>
            </plugin>
            <plugin>

--- a/spring-ai-2/src/main/java/com/baeldung/spring/ai/om/OrderManagementApplication.java
+++ b/spring-ai-2/src/main/java/com/baeldung/spring/ai/om/OrderManagementApplication.java
@@ -17,7 +17,7 @@ import org.springframework.context.annotation.PropertySource;
 @SpringBootApplication(exclude = {
     OllamaAutoConfiguration.class,
     AnthropicAutoConfiguration.class,
-	PgVectorStoreAutoConfiguration.class,
+    PgVectorStoreAutoConfiguration.class,
     ChromaVectorStoreAutoConfiguration.class,
     BedrockConverseProxyChatAutoConfiguration.class
 })

--- a/spring-ai-2/src/main/java/com/baeldung/spring/ai/om/OrderManagementApplication.java
+++ b/spring-ai-2/src/main/java/com/baeldung/spring/ai/om/OrderManagementApplication.java
@@ -4,6 +4,7 @@ import org.springframework.ai.autoconfigure.anthropic.AnthropicAutoConfiguration
 import org.springframework.ai.autoconfigure.bedrock.converse.BedrockConverseProxyChatAutoConfiguration;
 import org.springframework.ai.autoconfigure.ollama.OllamaAutoConfiguration;
 import org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration;
+import org.springframework.ai.autoconfigure.vectorstore.pgvector.PgVectorStoreAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
@@ -16,6 +17,7 @@ import org.springframework.context.annotation.PropertySource;
 @SpringBootApplication(exclude = {
     OllamaAutoConfiguration.class,
     AnthropicAutoConfiguration.class,
+	PgVectorStoreAutoConfiguration.class,
     ChromaVectorStoreAutoConfiguration.class,
     BedrockConverseProxyChatAutoConfiguration.class
 })

--- a/spring-ai-2/src/main/java/com/baeldung/springai/anthropic/Application.java
+++ b/spring-ai-2/src/main/java/com/baeldung/springai/anthropic/Application.java
@@ -2,6 +2,7 @@ package com.baeldung.springai.anthropic;
 
 import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;
 import org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration;
+import org.springframework.ai.autoconfigure.vectorstore.pgvector.PgVectorStoreAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.PropertySource;
  */
 @SpringBootApplication(exclude = {
     OpenAiAutoConfiguration.class,
+    PgVectorStoreAutoConfiguration.class,
     ChromaVectorStoreAutoConfiguration.class
 })
 @PropertySource("classpath:application-anthropic.properties")

--- a/spring-ai-2/src/main/java/com/baeldung/springai/chromadb/Application.java
+++ b/spring-ai-2/src/main/java/com/baeldung/springai/chromadb/Application.java
@@ -1,6 +1,7 @@
 package com.baeldung.springai.chromadb;
 
 import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;
+import org.springframework.ai.autoconfigure.vectorstore.pgvector.PgVectorStoreAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
@@ -11,7 +12,8 @@ import org.springframework.context.annotation.PropertySource;
  * only needed by other articles in the shared codebase.
  */
 @SpringBootApplication(exclude = {
-    OpenAiAutoConfiguration.class
+    OpenAiAutoConfiguration.class,
+    PgVectorStoreAutoConfiguration.class
 })
 @PropertySource("classpath:application-chromadb.properties")
 public class Application {

--- a/spring-ai-2/src/main/java/com/baeldung/springai/deepseek/Application.java
+++ b/spring-ai-2/src/main/java/com/baeldung/springai/deepseek/Application.java
@@ -2,6 +2,7 @@ package com.baeldung.springai.deepseek;
 
 import org.springframework.ai.autoconfigure.anthropic.AnthropicAutoConfiguration;
 import org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration;
+import org.springframework.ai.autoconfigure.vectorstore.pgvector.PgVectorStoreAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.PropertySource;
  */
 @SpringBootApplication(exclude = {
     AnthropicAutoConfiguration.class,
+    PgVectorStoreAutoConfiguration.class,
     ChromaVectorStoreAutoConfiguration.class
 })
 @PropertySource("classpath:application-deepseek.properties")

--- a/spring-ai-2/src/main/java/com/baeldung/springai/evaluator/Application.java
+++ b/spring-ai-2/src/main/java/com/baeldung/springai/evaluator/Application.java
@@ -4,6 +4,7 @@ import org.springframework.ai.autoconfigure.anthropic.AnthropicAutoConfiguration
 import org.springframework.ai.autoconfigure.bedrock.converse.BedrockConverseProxyChatAutoConfiguration;
 import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;
 import org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration;
+import org.springframework.ai.autoconfigure.vectorstore.pgvector.PgVectorStoreAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
@@ -16,6 +17,7 @@ import org.springframework.context.annotation.PropertySource;
 @SpringBootApplication(exclude = {
     OpenAiAutoConfiguration.class,
     AnthropicAutoConfiguration.class,
+    PgVectorStoreAutoConfiguration.class,
     ChromaVectorStoreAutoConfiguration.class,
     BedrockConverseProxyChatAutoConfiguration.class
 })

--- a/spring-ai-2/src/main/java/com/baeldung/springai/huggingface/Application.java
+++ b/spring-ai-2/src/main/java/com/baeldung/springai/huggingface/Application.java
@@ -4,6 +4,7 @@ import org.springframework.ai.autoconfigure.anthropic.AnthropicAutoConfiguration
 import org.springframework.ai.autoconfigure.bedrock.converse.BedrockConverseProxyChatAutoConfiguration;
 import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;
 import org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration;
+import org.springframework.ai.autoconfigure.vectorstore.pgvector.PgVectorStoreAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
@@ -16,6 +17,7 @@ import org.springframework.context.annotation.PropertySource;
 @SpringBootApplication(exclude = {
     OpenAiAutoConfiguration.class,
     AnthropicAutoConfiguration.class,
+    PgVectorStoreAutoConfiguration.class,
     ChromaVectorStoreAutoConfiguration.class,
     BedrockConverseProxyChatAutoConfiguration.class
 })

--- a/spring-ai-2/src/main/java/com/baeldung/springai/mcp/client/ClientApplication.java
+++ b/spring-ai-2/src/main/java/com/baeldung/springai/mcp/client/ClientApplication.java
@@ -4,6 +4,7 @@ import org.springframework.ai.autoconfigure.bedrock.converse.BedrockConverseProx
 import org.springframework.ai.autoconfigure.ollama.OllamaAutoConfiguration;
 import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;
 import org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration;
+import org.springframework.ai.autoconfigure.vectorstore.pgvector.PgVectorStoreAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
@@ -16,6 +17,7 @@ import org.springframework.context.annotation.PropertySource;
 @SpringBootApplication(exclude = {
     OllamaAutoConfiguration.class,
     OpenAiAutoConfiguration.class,
+    PgVectorStoreAutoConfiguration.class,
     ChromaVectorStoreAutoConfiguration.class,
     BedrockConverseProxyChatAutoConfiguration.class
 })

--- a/spring-ai-2/src/main/java/com/baeldung/springai/mcp/server/ServerApplication.java
+++ b/spring-ai-2/src/main/java/com/baeldung/springai/mcp/server/ServerApplication.java
@@ -2,6 +2,7 @@ package com.baeldung.springai.mcp.server;
 
 import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;
 import org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration;
+import org.springframework.ai.autoconfigure.vectorstore.pgvector.PgVectorStoreAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.PropertySource;
  */
 @SpringBootApplication(exclude = {
     OpenAiAutoConfiguration.class,
+    PgVectorStoreAutoConfiguration.class,
     ChromaVectorStoreAutoConfiguration.class
 })
 @PropertySource("classpath:application-mcp-server.properties")

--- a/spring-ai-2/src/main/java/com/baeldung/springai/nova/Application.java
+++ b/spring-ai-2/src/main/java/com/baeldung/springai/nova/Application.java
@@ -4,6 +4,7 @@ import org.springframework.ai.autoconfigure.anthropic.AnthropicAutoConfiguration
 import org.springframework.ai.autoconfigure.ollama.OllamaAutoConfiguration;
 import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;
 import org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration;
+import org.springframework.ai.autoconfigure.vectorstore.pgvector.PgVectorStoreAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
@@ -17,6 +18,7 @@ import org.springframework.context.annotation.PropertySource;
     OpenAiAutoConfiguration.class,
     OllamaAutoConfiguration.class,
     AnthropicAutoConfiguration.class,
+    PgVectorStoreAutoConfiguration.class,
     ChromaVectorStoreAutoConfiguration.class
 })
 @PropertySource("classpath:application-nova.properties")


### PR DESCRIPTION
#18251 broke all the existing main classes in the `spring-ai-2` module. This PR fixes it.

Also, this PR introduces `<profiles>` in `pom.xml` to allow overriding main Spring Boot class when running via terminal. 