### PR TITLE
bael-4384 - passing null instead of class

### DIFF
--- a/core-java-modules/core-java-reflection-2/src/test/java/com/baeldung/reflection/access/privatemethods/InvokePrivateMethodsUnitTest.java
+++ b/core-java-modules/core-java-reflection-2/src/test/java/com/baeldung/reflection/access/privatemethods/InvokePrivateMethodsUnitTest.java
@@ -16,7 +16,7 @@ class InvokePrivateMethodsUnitTest {
         Method indexOfMethod = LongArrayUtil.class.getDeclaredMethod("indexOf", long[].class, long.class, int.class, int.class);
         indexOfMethod.setAccessible(true);
 
-        assertEquals(2, indexOfMethod.invoke(LongArrayUtil.class, someLongArray, 1L, 1, someLongArray.length), "The index should be 2.");
+        assertEquals(2, indexOfMethod.invoke(null, someLongArray, 1L, 1, someLongArray.length), "The index should be 2.");
     }
 
     @Test


### PR DESCRIPTION
Based on email feedback:

Good evening,

I just noticed a discrepancy between two of your articles. In https://www.baeldung.com/java-call-private-method, section 3.3 states that to call a static method using reflection, one needs to pass the reference to the class object as the first parameter to the Method.invoke() method. In https://www.baeldung.com/java-invoke-static-method-reflection however, section 3 states that under the same circumstances one needs to pass a null to the same method. This likely means that the first parameter of this method call is ignored for static methods in the current JRE implementation.

However, according to a note in the article on Oracle web site https://docs.oracle.com/javase/tutorial/reflect/member/methodInvocation.html the first parameter should be null. Just wanted to bring this to your attention in case you would want to fix this inconsistency.
