### PR TITLE
Have authenticationConverter use the interface AuthoritiesConverter

### DIFF
--- a/spring-boot-modules/spring-boot-keycloak/README.md
+++ b/spring-boot-modules/spring-boot-keycloak/README.md
@@ -247,7 +247,7 @@ The <em>AuthoritiesConverter</em> interface is a tip for the bean factory becaus
 As we configured Keycloak as an OpenID Provider by providing just its <em>issuer-uri</em>, what we get as input in the <em>GrantedAuthoritiesMapper</em> are <em>OidcUserAuthority</em> instances:
 <pre><code class="language-java">@Bean
 GrantedAuthoritiesMapper authenticationConverter(
-        Converter&lt;Map&lt;String, Object&gt;, Collection&lt;GrantedAuthority&gt;&gt; realmRolesAuthoritiesConverter) {
+        AuthoritiesConverter realmRolesAuthoritiesConverter) {
     return (authorities) -&gt; authorities.stream().filter(authority -&gt; authority instanceof OidcUserAuthority)
             .map(OidcUserAuthority.class::cast).map(OidcUserAuthority::getIdToken).map(OidcIdToken::getClaims)
             .map(realmRolesAuthoritiesConverter::convert)

--- a/spring-boot-modules/spring-boot-keycloak/spring-boot-resource-server/src/main/java/com/baeldung/boot/keycloak/resourceserver/SecurityConfig.java
+++ b/spring-boot-modules/spring-boot-keycloak/spring-boot-resource-server/src/main/java/com/baeldung/boot/keycloak/resourceserver/SecurityConfig.java
@@ -42,8 +42,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    JwtAuthenticationConverter authenticationConverter(
-            Converter<Map<String, Object>, Collection<GrantedAuthority>> authoritiesConverter) {
+    JwtAuthenticationConverter authenticationConverter(AuthoritiesConverter authoritiesConverter) {
         JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
         jwtAuthenticationConverter
                 .setJwtGrantedAuthoritiesConverter(jwt -> authoritiesConverter.convert(jwt.getClaims()));


### PR DESCRIPTION
The article says this:
```
Because of generics type erasure in the JVM and because there could be many Converter beans with different inputs and outputs in an application context, this AuthoritiesConverter interface can be a useful tip for the bean factory when it searches for a Converter<Map<String, Object>, Collection<GrantedAuthority>> bean.
```
Then it never uses the interface for the authenticationConverter.