### PR TITLE
BAEL-9249 Code and Unit Tests for Extracting Keys from a JSONObject Using keySet()

### DIFF
--- a/json-modules/json-2/src/main/java/com/baeldung/jsongetvaluewithkeyset/JSONGetValueWithKeySet.java
+++ b/json-modules/json-2/src/main/java/com/baeldung/jsongetvaluewithkeyset/JSONGetValueWithKeySet.java
@@ -1,0 +1,23 @@
+package com.baeldung.jsongetvaluewithkeyset;
+
+import org.json.JSONObject;
+import java.util.Set;
+import java.util.HashSet;
+
+public class JSONGetValueWithKeySet {
+    public static Set<String> extractKeys(String jsonString) {
+        JSONObject jsonObject = new JSONObject(jsonString);
+        return jsonObject.keySet();
+    }
+
+    public static void extractNestedKeys(JSONObject jsonObject, String parentKey, Set<String> result) {
+        for (String key : jsonObject.keySet()) {
+            String fullKey = parentKey.isEmpty() ? key : parentKey + "." + key;
+            Object value = jsonObject.get(key);
+            result.add(fullKey);
+            if (value instanceof JSONObject) {
+                extractNestedKeys((JSONObject) value, fullKey, result);
+            }
+        }
+    }
+}

--- a/json-modules/json-2/src/test/java/com/baeldung/jsongetvaluewithkeyset/JSONGetValueWithKeySetUnitTest.java
+++ b/json-modules/json-2/src/test/java/com/baeldung/jsongetvaluewithkeyset/JSONGetValueWithKeySetUnitTest.java
@@ -1,0 +1,46 @@
+package com.baeldung.jsongetvaluewithkeyset;
+
+import org.json.JSONObject;
+
+import org.junit.Test;
+import java.util.Set;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JSONGetValueWithKeySetUnitTest {
+
+    @Test
+    public void givenFlatJson_whenExtractKeys_thenReturnAllTopLevelKeys() {
+        String json = "{\"name\":\"Jane\", \"name_id\":12345, \"city\":\"Vancouver\"}";
+        Set<String> keys = JSONGetValueWithKeySet.extractKeys(json);
+        assertTrue(keys.contains("name"));
+        assertTrue(keys.contains("name_id"));
+        assertTrue(keys.contains("city"));
+        assertEquals(3, keys.size());
+    }
+
+    @Test
+    public void givenNestedJson_whenExtractNestedKeys_thenReturnAllKeysWithHierarchy() {
+        String json = "{"
+            + "\"user\": {"
+            +     "\"id\": 101,"
+            +     "\"name\": \"Gregory\""
+            + "},"
+            + "\"city\": {"
+            +     "\"id\": 121,"
+            +     "\"name\": \"Calgary\""
+            + "},"
+            + "\"region\": \"CA\""
+        + "}";
+
+        JSONObject jsonObject = new JSONObject(json);
+        Set<String> actualKeys = new HashSet<>();
+        JSONGetValueWithKeySet.extractNestedKeys(jsonObject, "", actualKeys);
+
+        Set<String> expectedKeys = Set.of("user", "user.id", "user.name", "city",
+          "city.id", "city.name", "region");
+        assertEquals(expectedKeys, actualKeys);
+    }
+}


### PR DESCRIPTION
BAEL-9249 Code and Unit Tests for Extracting Keys from a JSONObject Using keySet()

- Implements the solution showcasing two scenarios: 
extracting keys from a flat json and from a nested json object.
- Provides unit tests for each of the implemented scenarios.