### PR TITLE
docs: update profile count from 9 to 13 and project list count from 4 to 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Profile-based segregation
 
 We use Maven build profiles to segregate the huge list of individual projects in our repository.
 
-The projects are broadly divided into 4 lists: default, default-jdk17, default-jdk8 and default-heavy. 
+The projects are broadly divided into 6 lists: default, default-jdk17, default-jdk22, default-jdk23, default-jdk8 and default-heavy. 
 
 Next, they are segregated further based on the tests that we want to execute.
 
 We also have a parents profile to build only parent modules.
 
-Therefore, we have a total of 9 profiles:
+Therefore, we have a total of 13 profiles:
 
 | Profile           | Includes                    | Type of test enabled |
 |-------------------|-----------------------------|----------------------|


### PR DESCRIPTION
## Summary
Updated the README documentation to reflect the current number of Maven profiles and project lists.

## Changes
- Updated profile count from 9 to 13 to include JDK22 and JDK23 profiles
- Updated project list count from 4 to 6 to include `default-jdk22` and `default-jdk23`
- This brings the documentation in sync with the actual profile table

## Motivation
The documentation was outdated after JDK22 and JDK23 support was added. The profile table showed 13 profiles but the text still mentioned 9 profiles, causing confusion for contributors.

## Type of Change
- [o] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change