### PR TITLE
[BAEL-9430] Fix Integration Test

### DIFF
--- a/saas-modules/temporal/src/test/java/com/baeldung/temporal/Hello2WorkerLiveTest.java
+++ b/saas-modules/temporal/src/test/java/com/baeldung/temporal/Hello2WorkerLiveTest.java
@@ -16,9 +16,9 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class Hello2WorkerIntegrationTest {
+class Hello2WorkerLiveTest {
     private static final String QUEUE_NAME = "say-hello-queue";
-    private static final Logger log = LoggerFactory.getLogger(Hello2WorkerIntegrationTest.class);
+    private static final Logger log = LoggerFactory.getLogger(Hello2WorkerLiveTest.class);
 
     private WorkerFactory factory;
 

--- a/saas-modules/temporal/src/test/java/com/baeldung/temporal/HelloWorkflowLiveTest.java
+++ b/saas-modules/temporal/src/test/java/com/baeldung/temporal/HelloWorkflowLiveTest.java
@@ -18,9 +18,9 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class HelloWorkflowIntegrationTest {
+class HelloWorkflowLiveTest {
     private static final String QUEUE_NAME = "say-hello-queue";
-    private static final Logger log = LoggerFactory.getLogger(HelloWorkflowIntegrationTest.class);
+    private static final Logger log = LoggerFactory.getLogger(HelloWorkflowLiveTest.class);
 
     private WorkerFactory factory;
 


### PR DESCRIPTION
Rename IntegrationTest classes to LiveTest as they assume a running Temporal server