### PR TITLE
Use IDENTITY strategy for JPA ID generation in Foo entity

### DIFF
--- a/spring-5/src/main/java/com/baeldung/web/Foo.java
+++ b/spring-5/src/main/java/com/baeldung/web/Foo.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Id;
 public class Foo {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
     private String name;


### PR DESCRIPTION
### What was changed
- Updated JPA ID generation strategy in Foo entity from AUTO to IDENTITY

### Why
- Makes the example explicit and provider-independent
- Aligns with common JPA usage patterns

### How tested
- Example-only change; no functional behavior impacted
