### PR TITLE
Add JavaDoc explaining composite key usage in Book entity

### DIFF
--- a/persistence-modules/spring-data-jpa-annotations/src/main/java/com/baeldung/composite/entity/Book.java
+++ b/persistence-modules/spring-data-jpa-annotations/src/main/java/com/baeldung/composite/entity/Book.java
@@ -2,7 +2,11 @@ package com.baeldung.composite.entity;
 
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-
+/**
+ * JPA entity representing a Book with a composite primary key.
+ *
+ * Uses {@link BookId} as an embedded identifier.
+ */
 @Entity
 public class Book {
 


### PR DESCRIPTION
### What was changed
- Added JavaDoc to explain composite primary key usage in Book entity

### Why
- Improves clarity and readability of example code

### How tested
- Documentation-only change
