### PR TITLE
Clarify usage and trade-offs of @Lazy annotation

### DIFF
--- a/spring-boot-modules/spring-boot-annotations/src/main/java/com/baeldung/lazy/City.java
+++ b/spring-boot-modules/spring-boot-annotations/src/main/java/com/baeldung/lazy/City.java
@@ -3,6 +3,13 @@ package com.baeldung.lazy;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
+/**
+ * Demonstrates the use of {@link Lazy} to defer bean initialization until
+ * it is first requested.
+ *
+ * Lazy initialization can reduce application startup time and memory usage,
+ * but it introduces a proxy layer that may delay error detection until runtime.
+ */
 @Lazy
 @Component
 public class City {


### PR DESCRIPTION
What was changed:
Added JavaDoc explaining the purpose, benefits, and trade-offs of using @Lazy.

Why:
The existing example demonstrated the annotation usage but did not explain when or why it should be applied.

How tested:
Documentation-only change.
