### PR TITLE
Clarify retry and transaction interaction for @Retryable

### DIFF
--- a/spring-boot-modules/spring-boot-annotations/src/main/java/com/baeldung/retryable/transactional/Blog.java
+++ b/spring-boot-modules/spring-boot-annotations/src/main/java/com/baeldung/retryable/transactional/Blog.java
@@ -29,6 +29,14 @@ public class Blog {
 
     @Transactional
     @Retryable(maxAttempts = 3)
+    /**
+     * Publishes an article using a transactional operation that is automatically retried
+     * in case of transient failures.
+     *
+     * When {@link Retryable} is used together with {@link Transactional}, each retry
+     * triggers a new transaction. Therefore, the operation should be idempotent to
+     * avoid unintended side effects such as duplicate updates.
+     */
     public Article publishArticle(Long draftId) {
         Article article = articles.findById(draftId)
             .orElseThrow();


### PR DESCRIPTION
What was changed:
Added JavaDoc explaining retry behavior when @Retryable is used together with @Transactional.

Why:
The example demonstrated the annotations but did not explain transaction boundaries and idempotency considerations.

How tested:
Documentation-only change.
