### PR TITLE
Clarify evaluation timing of conditional configuration

### DIFF
--- a/spring-boot-modules/spring-boot-annotations/src/main/java/com/baeldung/annotations/HibernateCondition.java
+++ b/spring-boot-modules/spring-boot-annotations/src/main/java/com/baeldung/annotations/HibernateCondition.java
@@ -3,7 +3,13 @@ package com.baeldung.annotations;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
-
+/**
+ * Custom condition evaluated during application startup to determine whether
+ * a bean definition should be included in the application context.
+ *
+ * Conditional checks are performed early in the bootstrap phase, and their
+ * outcome affects bean registration rather than runtime behavior.
+ */
 public class HibernateCondition implements Condition {
 
     @Override


### PR DESCRIPTION
What was changed:
Added JavaDoc explaining when and how conditional configuration is evaluated.

Why:
The example demonstrated conditional usage but did not explain evaluation timing during application startup.

How tested:
Documentation-only change.
