### PR TITLE
JAVA-48968: Fix NullPointerException in RSocket test after reactor up…

### DIFF
--- a/spring-reactive-modules/rsocket/src/main/java/com/baeldung/rsocket/ReqStreamClient.java
+++ b/spring-reactive-modules/rsocket/src/main/java/com/baeldung/rsocket/ReqStreamClient.java
@@ -24,7 +24,7 @@ public class ReqStreamClient {
           .requestStream(DefaultPayload.create(DATA_STREAM_NAME))
           .map(Payload::getData)
           .map(buf -> buf.getFloat())
-          .onErrorReturn(null);
+          .onErrorResume(err -> Flux.empty());
     }
 
     public void dispose() {


### PR DESCRIPTION
…grade.

Replace onErrorReturn(null) with onErrorResume in ReqStreamClient. The newer reactor version from Spring Boot 3.3.2 no longer allows null values in onErrorReturn().