### PR TITLE
JAVA-50477: Remove Spring milestone/snapshot repos from spring-ai-4 a…

### DIFF
--- a/spring-ai-modules/spring-ai-4/pom.xml
+++ b/spring-ai-modules/spring-ai-4/pom.xml
@@ -15,31 +15,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-   <repositories>
-       <repository>
-           <id>spring-milestones</id>
-           <name>Spring Milestones</name>
-           <url>https://repo.spring.io/milestone</url>
-           <snapshots>
-               <enabled>false</enabled>
-           </snapshots>
-           <releases>
-               <enabled>true</enabled>
-           </releases>
-       </repository>
-       <repository>
-           <id>spring-snapshots</id>
-           <name>Spring Snapshots</name>
-           <url>https://repo.spring.io/snapshot</url>
-           <snapshots>
-               <enabled>true</enabled>
-           </snapshots>
-           <releases>
-               <enabled>false</enabled>
-           </releases>
-       </repository>
-   </repositories>
-
    <dependencyManagement>
        <dependencies>
            <dependency>

--- a/spring-ai-modules/spring-ai-chat-stream/pom.xml
+++ b/spring-ai-modules/spring-ai-chat-stream/pom.xml
@@ -14,31 +14,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <repositories>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-        </repository>
-        <repository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
…nd spring-ai-chat-stream

Both modules already use Spring AI 1.0.1 GA available in Maven Central.