### PR TITLE
Fix ineffective assertion in OuterUnitTest

### DIFF
--- a/core-java-modules/core-java-11/src/test/java/com/baeldung/OuterUnitTest.java
+++ b/core-java-modules/core-java-11/src/test/java/com/baeldung/OuterUnitTest.java
@@ -1,6 +1,5 @@
 package com.baeldung;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
@@ -38,8 +37,7 @@ public class OuterUnitTest {
           .map(Class::getName)
           .collect(Collectors.toSet());
 
-        is(nestMembers.size()).equals(2);
-
+        assertEquals(2, nestMembers.size());
         assertTrue(nestMembers.contains("com.baeldung.Outer"));
         assertTrue(nestMembers.contains("com.baeldung.Outer$Inner"));
     }


### PR DESCRIPTION
Fixes #16237

The assertion `is(nestMembers.size()).equals(2)` was creating a Hamcrest 
matcher but never actually asserting anything. Replaced with 
`assertEquals(2, nestMembers.size())` and removed the unused import.