### PR TITLE
fix: replace ineffective assertion in OuterUnitTest (#16237)

### DIFF
--- a/core-java-modules/core-java-11/src/test/java/com/baeldung/OuterUnitTest.java
+++ b/core-java-modules/core-java-11/src/test/java/com/baeldung/OuterUnitTest.java
@@ -1,6 +1,5 @@
 package com.baeldung;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
@@ -38,7 +37,7 @@ public class OuterUnitTest {
           .map(Class::getName)
           .collect(Collectors.toSet());
 
-        is(nestMembers.size()).equals(2);
+        assertEquals(2, nestMembers.size());
 
         assertTrue(nestMembers.contains("com.baeldung.Outer"));
         assertTrue(nestMembers.contains("com.baeldung.Outer$Inner"));


### PR DESCRIPTION
## Problem
The assertion `is(nestMembers.size()).equals(2)` was ineffective — 
it creates a Hamcrest matcher but never passes it to assertThat(), 
so the test always passed regardless of the actual value.

## Fix
Replaced with `assertEquals(2, nestMembers.size())` which actually 
validates the size.

Fixes #16237