### PR TITLE
fix: remove leading slash from logback resource path (#16132)

### DIFF
--- a/spring-boot-modules/spring-boot-testing-spock/src/test/resources/logback-test.xml
+++ b/spring-boot-modules/spring-boot-testing-spock/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <configuration>
-    <include resource="/org/springframework/boot/logging/logback/base.xml"/>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n


### PR DESCRIPTION
## Problem
The logback-test.xml file had a leading slash in the resource path:
`/org/springframework/boot/logging/logback/base.xml`

This can cause resource loading failures as the path should be 
relative, not absolute.

## Fix
Removed the leading slash so the path resolves correctly.

Fixes #16132