### PR TITLE
Fix ListIterator test assertions for clarity

### DIFF
--- a/core-java-modules/core-java-collections-list-7/src/test/java/com/baeldung/iteratorandlistiterator/IteratorVsListIteratorUnitTest.java
+++ b/core-java-modules/core-java-collections-list-7/src/test/java/com/baeldung/iteratorandlistiterator/IteratorVsListIteratorUnitTest.java
@@ -71,10 +71,10 @@ public class IteratorVsListIteratorUnitTest {
     @Test
     void whenUsingSetElement_thenGetExpectedResult() {
         List<String> inputList = Lists.newArrayList("1", "2", "3", "4", "5");
-        ListIterator<String> lit = inputList.listIterator(1); // ^ 1 2 3 4 5
-        lit.next(); // 1 ^ 2 3 4 5
+        ListIterator<String> lit = inputList.listIterator(1); // 1 ^ 2 3 4 5
+        lit.next(); // 1 2 ^ 3 4 5
 
-        assertEquals("3", lit.next()); // 1 2 ^ 3 4 5
+        assertEquals("3", lit.next()); // 1 2 3 ^ 4 5
         lit.set("X");
         assertEquals(Lists.newArrayList("1", "2", "X", "4", "5"), inputList);
 


### PR DESCRIPTION
Based on email feedback:

> In section 3.2 of the following page:
> https://www.baeldung.com/java-iterator-vs-listiterator
> 
> I believe there's a mistake in the comments.
> 
> List<String> inputList = Lists.newArrayList("1", "2", "3", "4", "5");
> ListIterator<String> lit = inputList.listIterator(1); // ^ 1 2 3 4 5
> lit.next(); // 1 ^ 2 3 4 5
> assertEquals("3", lit.next()); // 1 2 ^ 3 4 5
> 
> Because of inputList.listIterator(1), shouldn't it be // 1 ^ 2 3 4 5
> And then
> lit.next(); // 1 2 ^ 3 4 5
> assertEquals("3", lit.next()); // 1 2 3 ^ 4 5
> 