### PR TITLE
Fix actuator health probe paths for kubernetes-spring module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ persistence-modules/neo4j/data/**
 logging-modules/log4j/app-dynamic-log.log
 logging-modules/logback/conditional.log
 logging-modules/logback/filtered.log
+"*.exe" 
+"prometheus-3.7.3.windows-amd64/" 

--- a/kubernetes-modules/kubernetes-spring/serviceDeployment.yaml
+++ b/kubernetes-modules/kubernetes-spring/serviceDeployment.yaml
@@ -16,11 +16,23 @@ spec:
       creationTimestamp: null
       labels:
         app: demo
-    spec:
-      containers:
-      - image: docker.io/library/demo:0.0.1-SNAPSHOT
-        name: demo
-        resources: {}
-        imagePullPolicy: Never
+		spec:
+	      containers:
+	      - image: docker.io/library/demo:0.0.1-SNAPSHOT
+	        name: demo
+	        resources: {}
+	        imagePullPolicy: Never
+	        livenessProbe:
+	          httpGet:
+	            path: /actuator/health/liveness
+	            port: 8080
+	          initialDelaySeconds: 10
+	          periodSeconds: 10
+	        readinessProbe:
+	          httpGet:
+	            path: /actuator/health/readiness
+	            port: 8080
+	          initialDelaySeconds: 10
+	          periodSeconds: 10
 
 status: {}

--- a/kubernetes-modules/kubernetes-spring/src/main/resources/application.properties
+++ b/kubernetes-modules/kubernetes-spring/src/main/resources/application.properties
@@ -1,1 +1,3 @@
-
+management.endpoint.health.probes.enabled=true
+management.health.livenessState.enabled=true
+management.health.readinessState.enabled=true


### PR DESCRIPTION
## What does this PR do?
Fixes missing actuator health probe configuration in the 
kubernetes-spring module.

## Problem
- application.properties was empty with no actuator configuration
- serviceDeployment.yaml had no liveness or readiness probes

## Fix
- Added actuator health probe properties to application.properties
- Added correct liveness (/actuator/health/liveness) and readiness
  (/actuator/health/readiness) probes to serviceDeployment.yaml

## Related Issue
Fixes #17969