### PR TITLE
Fix thread safety in DataQueue using synchronized add() and poll()

### DIFF
--- a/core-java-modules/core-java-concurrency-advanced-7/src/main/java/com/baeldung/producerconsumer/DataQueue.java
+++ b/core-java-modules/core-java-concurrency-advanced-7/src/main/java/com/baeldung/producerconsumer/DataQueue.java
@@ -33,16 +33,16 @@ public class DataQueue {
         }
     }
 
-    public void add(Message message) {
-        queue.add(message);
-        notifyIsNotEmpty();
-    }
+    public synchronized void add(Message message) {
+    queue.add(message);
+    notifyIsNotEmpty();
+}
 
-    public Message poll() {
-        Message mess = queue.poll();
-        notifyIsNotFull();
-        return mess;
-    }
+    public synchronized Message poll() {
+    Message mess = queue.poll();
+    notifyIsNotFull();
+    return mess;
+}
 
     public Integer getSize() {
         return queue.size();


### PR DESCRIPTION
Fixes #16156

## Problem
The add() and poll() methods in DataQueue were not synchronized, 
causing potential race conditions when multiple threads accessed 
the queue concurrently.

## Fix
Added `synchronized` keyword to both add() and poll() methods 
to ensure thread-safe access to the underlying LinkedList queue.