### PR TITLE
Fix feign-okhttp version to 13.2.1 to support PATCH requests

### DIFF
--- a/spring-cloud-modules/spring-cloud-openfeign-2/pom.xml
+++ b/spring-cloud-modules/spring-cloud-openfeign-2/pom.xml
@@ -50,6 +50,7 @@
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-okhttp</artifactId>
+            <version>13.2.1</version>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign.form</groupId>


### PR DESCRIPTION
Fixes #17792

## Problem
The `feign-okhttp` dependency in `spring-cloud-openfeign-2` had no explicit
version, so it resolved transitively to `13.3`. This version throws
`Invalid HTTP method: PATCH` when executing PATCH requests through Feign +
OkHttp.

## Fix
Pinned `feign-okhttp` to version `13.2.1` explicitly, which does not have
this issue.

## Verification
- Ran `mvn compile` on the module — build succeeds.
- Confirmed the reported PATCH failure no longer occurs with 13.2.1.