### PR TITLE
fix: remove invalid ConditionalOnBean usage from samples

### DIFF
--- a/spring-boot-modules/spring-boot-annotations/src/main/java/com/baeldung/annotations/MySQLAutoconfiguration.java
+++ b/spring-boot-modules/spring-boot-annotations/src/main/java/com/baeldung/annotations/MySQLAutoconfiguration.java
@@ -11,14 +11,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnResource;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.orm.jpa.JpaVendorAdapter;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnClass(DataSource.class)
 public class MySQLAutoconfiguration {
 

--- a/spring-boot-modules/spring-boot-mvc-5/src/main/java/com/baeldung/dynamicendpoints/controller/AppController.java
+++ b/spring-boot-modules/spring-boot-mvc-5/src/main/java/com/baeldung/dynamicendpoints/controller/AppController.java
@@ -1,7 +1,7 @@
 package com.baeldung.dynamicendpoints.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.ResponseEntity;
@@ -48,7 +48,7 @@ public class AppController {
     }
 
     @Bean
-    @ConditionalOnBean(EnvironmentConfigBean.class)
+    
     public FilterRegistrationBean<DynamicEndpointFilter> dynamicEndpointFilterFilterRegistrationBean(EnvironmentConfigBean environmentConfigBean) {
         FilterRegistrationBean<DynamicEndpointFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(new DynamicEndpointFilter(environmentConfigBean.getEnvironment()));

--- a/spring-boot-modules/spring-boot-mvc/src/main/java/com/baeldung/springbootannotations/MySQLAutoconfiguration.java
+++ b/spring-boot-modules/spring-boot-mvc/src/main/java/com/baeldung/springbootannotations/MySQLAutoconfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.Environment;
@@ -31,7 +31,7 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.util.ClassUtils;
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnClass(DataSource.class)
 @AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
 @PropertySource("classpath:mysql.properties")

--- a/spring-boot-modules/spring-boot-simple/src/main/java/com/baeldung/annotations/MySQLAutoconfiguration.java
+++ b/spring-boot-modules/spring-boot-simple/src/main/java/com/baeldung/annotations/MySQLAutoconfiguration.java
@@ -11,14 +11,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnResource;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.orm.jpa.JpaVendorAdapter;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnClass(DataSource.class)
 public class MySQLAutoconfiguration {
 


### PR DESCRIPTION
Fixes #15906

## Summary
- Removed invalid usage of `@ConditionalOnBean` from user configuration samples.
- Updated sample auto-configuration to use the appropriate annotation where applicable.
- Aligned examples with the Spring Boot recommendation that `@ConditionalOnBean` should be used on auto-configuration classes.