### PR TITLE
Fix weak email validation in Vaadin custom validator example

### DIFF
--- a/vaadin/src/main/java/com/baeldung/introduction/FormView.java
+++ b/vaadin/src/main/java/com/baeldung/introduction/FormView.java
@@ -62,7 +62,7 @@ public class FormView extends HorizontalLayout {
                 .asRequired()
                 .bind(Contact::getName, Contact::setName);
         binder.forField(emailField)
-                .withValidator(email -> email.contains("@"), "Not a valid email address")
+                .withValidator(email -> email.matches("^[\\w.+-]+@[\\w-]+\\.[a-zA-Z]{2,}$"), "Not a valid email address")
                 .bind(Contact::getEmail, Contact::setEmail);
         binder.forField(phoneField)
                 .withValidator(phone -> phone.matches("\\d{3}-\\d{3}-\\d{4}"), "Not a valid phone number")


### PR DESCRIPTION
Fixes #16682

The custom email validator in `FormView.java`'s `addCustomValidationExample()` only checked `email.contains("@")`, which incorrectly passes invalid strings like `"@"` or `"abc@"` as valid emails.

This PR replaces it with a proper regex-based check, consistent with the phone number validator already used in the same method.