### PR TITLE
BAEL-8039 - article code

### DIFF
--- a/persistence-modules/hibernate-exceptions-2/src/main/java/com/baeldung/hibernate/annotationexception/Comment.java
+++ b/persistence-modules/hibernate-exceptions-2/src/main/java/com/baeldung/hibernate/annotationexception/Comment.java
@@ -1,0 +1,24 @@
+package com.baeldung.hibernate.annotationexception;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class Comment {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String text;
+
+    public String getText() {
+        return text;
+    }
+
+    public Comment setText(String text) {
+        this.text = text;
+        return this;
+    }
+}

--- a/persistence-modules/hibernate-exceptions-2/src/main/java/com/baeldung/hibernate/annotationexception/Post.java
+++ b/persistence-modules/hibernate-exceptions-2/src/main/java/com/baeldung/hibernate/annotationexception/Post.java
@@ -1,0 +1,28 @@
+package com.baeldung.hibernate.annotationexception;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Post {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @OneToMany
+    private List<Comment> comments = new ArrayList<>();
+
+    public List<Comment> getComments() {
+        return comments;
+    }
+
+    public void setComments(ArrayList<Comment> comments) {
+        this.comments = comments;
+    }
+}


### PR DESCRIPTION
This pull request introduces two new entity classes, `Post` and `Comment`, to the `com.baeldung.hibernate.annotationexception` package. These classes are annotated for use with Jakarta Persistence (JPA) and establish a basic one-to-many relationship from `Post` to `Comment`.

**New Entity Definitions:**

* Added the `Comment` entity with fields for `id` and `text`, including getter and setter methods. (`Comment.java`)
* Added the `Post` entity with fields for `id` and a `List<Comment>` representing its comments, annotated with `@OneToMany`, and provided getter and setter methods. (`Post.java`)