### PR TITLE
[BAEL-9681] Introduction to Google GenAI Chat and Spring AI

### DIFF
--- a/spring-ai-modules/pom.xml
+++ b/spring-ai-modules/pom.xml
@@ -23,6 +23,7 @@
         <module>spring-ai-agent-skills</module>
         <module>spring-ai-agentic-patterns</module>
         <module>spring-ai-anthropic-agent-skills</module>
+        <module>spring-ai-chat</module>
         <module>spring-ai-chat-stream</module>
         <module>spring-ai-introduction</module>
         <module>spring-ai-llm-as-a-judge</module>

--- a/spring-ai-modules/spring-ai-chat/pom.xml
+++ b/spring-ai-modules/spring-ai-chat/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.baeldung</groupId>
+        <artifactId>spring-ai-modules</artifactId>
+        <version>0.0.1</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>com.baeldung</groupId>
+    <artifactId>spring-ai-chat</artifactId>
+    <version>0.0.1</version>
+    <name>spring-ai-chat</name>
+
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>${spring-ai.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-google-genai</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <java.version>21</java.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/spring-ai-modules/spring-ai-chat/pom.xml
+++ b/spring-ai-modules/spring-ai-chat/pom.xml
@@ -71,6 +71,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>

--- a/spring-ai-modules/spring-ai-chat/src/main/java/com/baeldung/springai/chat/Application.java
+++ b/spring-ai-modules/spring-ai-chat/src/main/java/com/baeldung/springai/chat/Application.java
@@ -1,0 +1,13 @@
+package com.baeldung.springai.chat;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/spring-ai-modules/spring-ai-chat/src/main/java/com/baeldung/springai/chat/ChatController.java
+++ b/spring-ai-modules/spring-ai-chat/src/main/java/com/baeldung/springai/chat/ChatController.java
@@ -1,0 +1,38 @@
+package com.baeldung.springai.chat;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ChatController {
+
+    private final ChatService chatService;
+
+    public ChatController(ChatService chatService) {
+        this.chatService = chatService;
+    }
+
+    @GetMapping("/v1/chat/simple")
+    public String simplifiedPrompt(@RequestParam(defaultValue = "Hello") String message) {
+        return chatService.simplifiedPrompt(message);
+    }
+
+    @GetMapping("/v1/chat/fluent")
+    public String fluentPrompt(@RequestParam String prompt) {
+        return chatService.fluentPrompt(prompt);
+    }
+
+    @PostMapping("/v1/chat/review")
+    public String reviewCode(@RequestParam(defaultValue = "Java") String language, @RequestBody String codeSnippet) {
+        return chatService.reviewCode(language, codeSnippet);
+    }
+
+    @GetMapping("/v1/chat/grounded")
+    public String searchGroundedPrompt(@RequestParam String currentEventQuery) {
+        return chatService.searchGroundedPrompt(currentEventQuery);
+    }
+
+}

--- a/spring-ai-modules/spring-ai-chat/src/main/java/com/baeldung/springai/chat/ChatService.java
+++ b/spring-ai-modules/spring-ai-chat/src/main/java/com/baeldung/springai/chat/ChatService.java
@@ -1,0 +1,66 @@
+package com.baeldung.springai.chat;
+
+import java.util.Map;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.google.genai.GoogleGenAiChatModel;
+import org.springframework.stereotype.Service;
+
+import reactor.core.publisher.Flux;
+
+@Service
+public class ChatService {
+
+    private final GoogleGenAiChatModel chatModel;
+    private final ChatClient defaultChatClient;
+    private final ChatClient fluentChatClient;
+
+    public ChatService(GoogleGenAiChatModel chatModel, ChatClient.Builder chatClientBuilder) {
+        this.chatModel = chatModel;
+        this.defaultChatClient = chatClientBuilder.build();
+        this.fluentChatClient = chatClientBuilder
+            .defaultSystem("You are a concise technical writer summarizing software concepts.")
+            .build();
+    }
+
+    public String simplifiedPrompt(String message) {
+        return chatModel.call(message);
+    }
+
+    public String fluentPrompt(String prompt) {
+        return this.fluentChatClient.prompt()
+            .user(prompt)
+            .call()
+            .content();
+    }
+
+    public String reviewCode(String language, String codeSnippet) {
+        String template = """
+            Analyze the following {language} code snippet for memory leaks or inefficiencies.
+            Provide an optimized version.
+
+            Code:
+            {code}
+            """;
+
+        return this.defaultChatClient.prompt()
+            .user(u -> u.text(template)
+                .params(Map.of("language", language, "code", codeSnippet)))
+            .call()
+            .content();
+    }
+
+    public String searchGroundedPrompt(String currentEventQuery) {
+        return this.defaultChatClient.prompt()
+            .user(currentEventQuery)
+            .call()
+            .content();
+    }
+
+    public Flux<String> streamChatTokens(String prompt) {
+        return this.defaultChatClient.prompt()
+            .user(prompt)
+            .stream()
+            .content();
+    }
+}

--- a/spring-ai-modules/spring-ai-chat/src/main/java/com/baeldung/springai/chat/ChatService.java
+++ b/spring-ai-modules/spring-ai-chat/src/main/java/com/baeldung/springai/chat/ChatService.java
@@ -19,8 +19,8 @@ public class ChatService {
         this.chatModel = chatModel;
         this.defaultChatClient = chatClientBuilder.build();
         this.fluentChatClient = chatClientBuilder
-            .defaultSystem("You are a concise technical writer summarizing software concepts.")
-            .build();
+                .defaultSystem("You are a concise technical writer summarizing software concepts.")
+                .build();
     }
 
     public String simplifiedPrompt(String message) {
@@ -29,38 +29,38 @@ public class ChatService {
 
     public String fluentPrompt(String prompt) {
         return this.fluentChatClient.prompt()
-            .user(prompt)
-            .call()
-            .content();
+                .user(prompt)
+                .call()
+                .content();
     }
 
     public String reviewCode(String language, String codeSnippet) {
         String template = """
-            Analyze the following {language} code snippet for memory leaks or inefficiencies.
-            Provide an optimized version.
+                Analyze the following {language} code snippet for memory leaks or inefficiencies.
+                Provide an optimized version.
 
-            Code:
-            {code}
-            """;
+                Code:
+                {code}
+                """;
 
-        return this.defaultChatClient.prompt()
-            .user(u -> u.text(template)
-                .params(Map.of("language", language, "code", codeSnippet)))
-            .call()
-            .content();
+                return this.defaultChatClient.prompt()
+                        .user(u -> u.text(template)
+                                .params(Map.of("language", language, "code", codeSnippet)))
+                        .call()
+                        .content();
     }
 
     public String searchGroundedPrompt(String currentEventQuery) {
         return this.defaultChatClient.prompt()
-            .user(currentEventQuery)
-            .call()
-            .content();
+                .user(currentEventQuery)
+                .call()
+                .content();
     }
 
     public Flux<String> streamChatTokens(String prompt) {
         return this.defaultChatClient.prompt()
-            .user(prompt)
-            .stream()
-            .content();
+                .user(prompt)
+                .stream()
+                .content();
     }
 }

--- a/spring-ai-modules/spring-ai-chat/src/main/java/com/baeldung/springai/chat/StreamingChatController.java
+++ b/spring-ai-modules/spring-ai-chat/src/main/java/com/baeldung/springai/chat/StreamingChatController.java
@@ -1,0 +1,24 @@
+package com.baeldung.springai.chat;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Flux;
+
+@RestController
+public class StreamingChatController {
+
+    private final ChatService chatService;
+
+    public StreamingChatController(ChatService chatService) {
+        this.chatService = chatService;
+    }
+
+    @GetMapping(value = "/v1/chat/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<String> streamChatTokens(@RequestParam String prompt) {
+        return chatService.streamChatTokens(prompt);
+    }
+
+}

--- a/spring-ai-modules/spring-ai-chat/src/main/resources/application.properties
+++ b/spring-ai-modules/spring-ai-chat/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.ai.model.chat=google-genai
+spring.ai.google.genai.chat.model=gemini-2.5-flash
+spring.ai.google.genai.api-key=${SPRING_AI_GOOGLE_GENAI_API_KEY}
+spring.ai.google.genai.chat.google-search-retrieval=true

--- a/spring-ai-modules/spring-ai-chat/src/test/java/com/baeldung/springai/chat/ChatControllerIntegrationTest.java
+++ b/spring-ai-modules/spring-ai-chat/src/test/java/com/baeldung/springai/chat/ChatControllerIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.baeldung.springai.chat;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import jakarta.annotation.Resource;
+
+@SpringBootTest(properties = {
+    "spring.ai.model.chat=google-genai",
+    "spring.ai.google.genai.chat.model=gemini-2.5-flash",
+    "spring.ai.google.genai.api-key=test-key"
+})
+@AutoConfigureMockMvc
+class ChatControllerIntegrationTest {
+
+    @Resource
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ChatService chatService;
+
+    @Test
+    void whenSimpleEndpointIsInvoked_thenReturnsMockedModelResponse() throws Exception {
+        when(chatService.simplifiedPrompt(anyString())).thenReturn("Mocked Gemini Response");
+
+        mockMvc.perform(get("/v1/chat/simple").param("message", "Hello"))
+            .andExpect(status().isOk())
+            .andExpect(content().string("Mocked Gemini Response"));
+
+        verify(chatService).simplifiedPrompt("Hello");
+    }
+
+    @Test
+    void whenFluentEndpointIsInvoked_thenReturnsModelContent() throws Exception {
+        when(chatService.fluentPrompt(anyString())).thenReturn("Fluent Response");
+
+        mockMvc.perform(get("/v1/chat/fluent").param("prompt", "Explain DI"))
+            .andExpect(status().isOk())
+            .andExpect(content().string("Fluent Response"));
+
+        verify(chatService).fluentPrompt("Explain DI");
+    }
+
+    @Test
+    void whenReviewEndpointIsInvoked_thenReturnsModelContent() throws Exception {
+        when(chatService.reviewCode(anyString(), anyString())).thenReturn("Optimized Code");
+
+        mockMvc.perform(post("/v1/chat/review")
+                .param("language", "Java")
+                .contentType(MediaType.TEXT_PLAIN)
+                .content("class A { }"))
+            .andExpect(status().isOk())
+            .andExpect(content().string("Optimized Code"));
+
+        verify(chatService).reviewCode("Java", "class A { }");
+    }
+
+    @Test
+    void whenGroundedEndpointIsInvoked_thenReturnsModelContent() throws Exception {
+        when(chatService.searchGroundedPrompt(anyString())).thenReturn("Grounded Response");
+
+        mockMvc.perform(get("/v1/chat/grounded").param("currentEventQuery", "latest match winner"))
+            .andExpect(status().isOk())
+            .andExpect(content().string("Grounded Response"));
+
+        verify(chatService).searchGroundedPrompt("latest match winner");
+    }
+
+    @Test
+    void whenStreamEndpointIsInvoked_thenReturnsEventStreamContent() throws Exception {
+        when(chatService.streamChatTokens(anyString())).thenReturn(reactor.core.publisher.Flux.just("token-1", "token-2"));
+
+        mockMvc.perform(get("/v1/chat/stream").param("prompt", "Stream tokens"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM))
+            .andExpect(content().string("data:token-1\n\ndata:token-2\n\n"));
+
+        verify(chatService).streamChatTokens("Stream tokens");
+    }
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/spring-ai-modules/spring-ai-chat/src/test/java/com/baeldung/springai/chat/ChatControllerIntegrationTest.java
+++ b/spring-ai-modules/spring-ai-chat/src/test/java/com/baeldung/springai/chat/ChatControllerIntegrationTest.java
@@ -10,13 +10,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-
-import jakarta.annotation.Resource;
 
 @SpringBootTest(properties = {
     "spring.ai.model.chat=google-genai",
@@ -26,10 +25,10 @@ import jakarta.annotation.Resource;
 @AutoConfigureMockMvc
 class ChatControllerIntegrationTest {
 
-    @Resource
+    @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @MockBean
     private ChatService chatService;
 
     @Test

--- a/spring-ai-modules/spring-ai-chat/src/test/java/com/baeldung/springai/chat/ChatControllerUnitTest.java
+++ b/spring-ai-modules/spring-ai-chat/src/test/java/com/baeldung/springai/chat/ChatControllerUnitTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
     "spring.ai.google.genai.api-key=test-key"
 })
 @AutoConfigureMockMvc
-class ChatControllerIntegrationTest {
+class ChatControllerUnitTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/spring-ai-modules/spring-ai-chat/src/test/java/com/baeldung/springai/chat/ChatControllerUnitTest.java
+++ b/spring-ai-modules/spring-ai-chat/src/test/java/com/baeldung/springai/chat/ChatControllerUnitTest.java
@@ -20,7 +20,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest(properties = {
     "spring.ai.model.chat=google-genai",
     "spring.ai.google.genai.chat.model=gemini-2.5-flash",
-    "spring.ai.google.genai.api-key=test-key"
+    "spring.ai.google.genai.api-key=test-key",
+    "spring.autoconfigure.exclude=org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration"
 })
 @AutoConfigureMockMvc
 class ChatControllerUnitTest {

--- a/spring-ai-modules/spring-ai-chat/src/test/java/com/baeldung/springai/chat/ChatControllerUnitTest.java
+++ b/spring-ai-modules/spring-ai-chat/src/test/java/com/baeldung/springai/chat/ChatControllerUnitTest.java
@@ -30,8 +30,8 @@ class ChatControllerUnitTest {
         when(chatService.simplifiedPrompt(anyString())).thenReturn("Mocked Gemini Response");
 
         mockMvc.perform(get("/v1/chat/simple").param("message", "Hello"))
-            .andExpect(status().isOk())
-            .andExpect(content().string("Mocked Gemini Response"));
+        .andExpect(status().isOk())
+        .andExpect(content().string("Mocked Gemini Response"));
 
         verify(chatService).simplifiedPrompt("Hello");
     }
@@ -41,8 +41,8 @@ class ChatControllerUnitTest {
         when(chatService.fluentPrompt(anyString())).thenReturn("Fluent Response");
 
         mockMvc.perform(get("/v1/chat/fluent").param("prompt", "Explain DI"))
-            .andExpect(status().isOk())
-            .andExpect(content().string("Fluent Response"));
+        .andExpect(status().isOk())
+        .andExpect(content().string("Fluent Response"));
 
         verify(chatService).fluentPrompt("Explain DI");
     }
@@ -55,8 +55,8 @@ class ChatControllerUnitTest {
                 .param("language", "Java")
                 .contentType(MediaType.TEXT_PLAIN)
                 .content("class A { }"))
-            .andExpect(status().isOk())
-            .andExpect(content().string("Optimized Code"));
+        .andExpect(status().isOk())
+        .andExpect(content().string("Optimized Code"));
 
         verify(chatService).reviewCode("Java", "class A { }");
     }
@@ -66,8 +66,8 @@ class ChatControllerUnitTest {
         when(chatService.searchGroundedPrompt(anyString())).thenReturn("Grounded Response");
 
         mockMvc.perform(get("/v1/chat/grounded").param("currentEventQuery", "latest match winner"))
-            .andExpect(status().isOk())
-            .andExpect(content().string("Grounded Response"));
+        .andExpect(status().isOk())
+        .andExpect(content().string("Grounded Response"));
 
         verify(chatService).searchGroundedPrompt("latest match winner");
     }
@@ -77,9 +77,9 @@ class ChatControllerUnitTest {
         when(chatService.streamChatTokens(anyString())).thenReturn(reactor.core.publisher.Flux.just("token-1", "token-2"));
 
         mockMvc.perform(get("/v1/chat/stream").param("prompt", "Stream tokens"))
-            .andExpect(status().isOk())
-            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM))
-            .andExpect(content().string("data:token-1\n\ndata:token-2\n\n"));
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM))
+        .andExpect(content().string("data:token-1\n\ndata:token-2\n\n"));
 
         verify(chatService).streamChatTokens("Stream tokens");
     }

--- a/spring-ai-modules/spring-ai-chat/src/test/java/com/baeldung/springai/chat/ChatControllerUnitTest.java
+++ b/spring-ai-modules/spring-ai-chat/src/test/java/com/baeldung/springai/chat/ChatControllerUnitTest.java
@@ -11,19 +11,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest(properties = {
-    "spring.ai.model.chat=google-genai",
-    "spring.ai.google.genai.chat.model=gemini-2.5-flash",
-    "spring.ai.google.genai.api-key=test-key",
-    "spring.autoconfigure.exclude=org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration"
-})
-@AutoConfigureMockMvc
+@WebMvcTest({ChatController.class, StreamingChatController.class})
 class ChatControllerUnitTest {
 
     @Autowired


### PR DESCRIPTION
Adds a new **spring-ai-chat** module with sample code for integrating Google Gemini via Spring AI.

Files changed
- `spring-ai-modules/pom.xml` - registers the new spring-ai-chat module
- `spring-ai-chat/pom.xml` - Maven config with spring-ai-starter-model-google-genai, WebFlux, and Web dependencies

**Application**
- `ChatService.java` - core chat logic (simple, fluent, template, grounded, and streaming)
- `ChatController.java` - REST endpoints for /v1/chat/simple, /fluent, /review, /grounded
- `StreamingChatController.java` - SSE streaming endpoint at /v1/chat/stream

**Tests**
- `ChatControllerUnitTest.java` — integration tests for all endpoints via MockMvc