### PR TITLE
Fix broken sliding window logic in SlidingWindowGatherer

### DIFF
--- a/core-java-modules/core-java-streams-7/src/main/java/com/baeldung/streams/gatherer/SlidingWindowGatherer.java
+++ b/core-java-modules/core-java-streams-7/src/main/java/com/baeldung/streams/gatherer/SlidingWindowGatherer.java
@@ -1,7 +1,6 @@
 package com.baeldung.streams.gatherer;
 
 import java.util.*;
-import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Gatherer;
 
@@ -18,15 +17,12 @@ public class SlidingWindowGatherer implements Gatherer<Integer, Deque<Integer>, 
             @Override
             public boolean integrate(Deque<Integer> state, Integer element, Downstream<? super List<Integer>> downstream) {
                 state.addLast(element);
-                downstream.push(new ArrayList<>(state));
-                state.removeFirst();
+                if (state.size() == 3) {
+                    downstream.push(new ArrayList<>(state));
+                    state.removeFirst();
+                }
                 return true;
             }
         };
-    }
-
-    @Override
-    public BiConsumer<Deque<Integer>, Downstream<? super List<Integer>>> finisher() {
-        return (state, downstream) -> {};
     }
 }


### PR DESCRIPTION
`SlidingWindowGatherer` currently emits one single-element list per input element
instead of overlapping windows of three, which makes its own unit test fail.

### Cause

The `state.size() == 3` guard was dropped from the integrator in aae2714723.
Without the guard, each element is pushed downstream
and then immediately removed from the state,
so the window never grows past one.

For the stream `1..5`:

| | Result |
|---|---|
| `SlidingWindowGathererUnitTest` expects | `[[1, 2, 3], [2, 3, 4], [3, 4, 5]]` |
| Current code produces | `[[1], [2], [3], [4], [5]]` |

The test asserts a window count of 3, so it fails with 5.

### Changes

- Restore the `state.size() == 3` guard in `integrator()`.
- Remove the `finisher()` override.
  It returned an empty `BiConsumer`, which is exactly what `Gatherer`'s default finisher already does.
  This addresses the remaining point of #18683.

### Why this went unnoticed

`core-java-streams-7` requires JDK 24, so it is commented out in `core-java-modules/pom.xml`
and only listed under the `default-jdk24` and `integration-jdk24` profiles.
The module is not part of an ordinary build.

Refs #18683