### PR TITLE
Remove redundant springdoc-openapi-starter-common dependency (#17157)

### DIFF
--- a/spring-boot-modules/spring-boot-springdoc-2/pom.xml
+++ b/spring-boot-modules/spring-boot-springdoc-2/pom.xml
@@ -59,11 +59,6 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${springdoc.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-common</artifactId>
-            <version>${springdoc.version}</version>
-        </dependency>
          <dependency>
             <groupId>org.springframework.restdocs</groupId>
             <artifactId>spring-restdocs-mockmvc</artifactId>


### PR DESCRIPTION
Fixes #17157

Removed the redundant explicit `springdoc-openapi-starter-common` 
dependency from `spring-boot-springdoc-2/pom.xml`, since it's already 
brought in transitively by `springdoc-openapi-starter-webmvc-ui`. This 
was causing a version conflict that broke Swagger UI.

Verified with `mvn clean install` — build succeeds.